### PR TITLE
Added `resourceState` to the `ObjectMetadata` type

### DIFF
--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -79,6 +79,7 @@ export class ObjectBuilder {
 export interface ObjectMetadata {
   kind: string;
   id: string;
+  resourceState: string;
   selfLink?: string;
   name?: string;
   bucket: string;


### PR DESCRIPTION
The `resourceState` property is in the payload, just not in the type information.

@katfang - Can you confirm that the type should be `string` (meaning it will always be there) and not `string?` (meaning it is optional)?