### PR TITLE
Correct the argument types of the forEach function

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -223,10 +223,10 @@ describe('DeltaSnapshot', () => {
       let count = 0;
       let counter = snap => count++;
 
-      subject.forEach(counter);
+      expect(subject.forEach(counter)).to.equal(false);
       populate(23, null);
 
-      subject.forEach(counter);
+      expect(subject.forEach(counter)).to.equal(false);
       expect(count).to.eq(0);
     });
 
@@ -243,13 +243,21 @@ describe('DeltaSnapshot', () => {
       expect(ret).to.equal(true);
     });
 
-    it('should not cancel further enumeration if callback does not return true', () => {
+    it('should not cancel further enumeration if callback returns a truthy value', () => {
       populate(null, { a: 'b', c: 'd', e: 'f', g: 'h' });
       let out = '';
       const ret = subject.forEach(snap => {
-        if (snap.val() === 'a') {
-          return true;
-        }
+        out += snap.val();
+        return 1;
+      });
+      expect(out).to.equal('bdfh');
+      expect(ret).to.equal(false);
+    });
+
+    it('should not cancel further enumeration if callback does not return', () => {
+      populate(null, { a: 'b', c: 'd', e: 'f', g: 'h' });
+      let out = '';
+      const ret = subject.forEach(snap => {
         out += snap.val();
       });
       expect(out).to.equal('bdfh');

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -208,7 +208,7 @@ describe('DeltaSnapshot', () => {
     });
   });
 
-  describe('#forEach(childAction: Function)', () => {
+  describe('#forEach(action: (a: DeltaSnapshot) => boolean): boolean', () => {
     it('should iterate through child snapshots', () => {
       populate({ a: 'b' }, { c: 'd' });
       let out = '';
@@ -228,6 +228,32 @@ describe('DeltaSnapshot', () => {
 
       subject.forEach(counter);
       expect(count).to.eq(0);
+    });
+
+    it('should cancel further enumeration if callback returns true', () => {
+      populate(null, { a: 'b', c: 'd', e: 'f', g: 'h' });
+      let out = '';
+      const ret = subject.forEach(snap => {
+        if (snap.val() === 'f') {
+          return true;
+        }
+        out += snap.val();
+      });
+      expect(out).to.equal('bd');
+      expect(ret).to.equal(true);
+    });
+
+    it('should not cancel further enumeration if callback does not return true', () => {
+      populate(null, { a: 'b', c: 'd', e: 'f', g: 'h' });
+      let out = '';
+      const ret = subject.forEach(snap => {
+        if (snap.val() === 'a') {
+          return true;
+        }
+        out += snap.val();
+      });
+      expect(out).to.equal('bdfh');
+      expect(ret).to.equal(false);
     });
   });
 

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -206,11 +206,10 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
     return valAt(this._delta, this._childPath) !== undefined;
   }
 
-  // TODO(inlined) what is this boolean for?
-  forEach(action: (a: DeltaSnapshot) => void): boolean {
+  forEach(action: (a: DeltaSnapshot) => boolean): boolean {
     let val = this.val();
     if (_.isPlainObject(val)) {
-      _.keys(val).forEach(key => action(this.child(key)));
+      return _.keys(val).some(key => action(this.child(key)));
     }
     return false;
   }

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -209,7 +209,7 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
   forEach(action: (a: DeltaSnapshot) => boolean): boolean {
     let val = this.val();
     if (_.isPlainObject(val)) {
-      return _.keys(val).some(key => action(this.child(key)));
+      return _.keys(val).some(key => action(this.child(key)) === true);
     }
     return false;
   }

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -209,7 +209,7 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
   forEach(action: (a: DeltaSnapshot) => boolean): boolean {
     let val = this.val();
     if (_.isPlainObject(val)) {
-      return _.keys(val).some(key => action(this.child(key)) === true);
+      return _.some(val, (value, key: string) => action(this.child(key)) === true);
     }
     return false;
   }

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -207,7 +207,7 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
   }
 
   // TODO(inlined) what is this boolean for?
-  forEach(action: (a: DeltaSnapshot) => boolean): boolean {
+  forEach(action: (a: DeltaSnapshot) => void): boolean {
     let val = this.val();
     if (_.isPlainObject(val)) {
       _.keys(val).forEach(key => action(this.child(key)));


### PR DESCRIPTION
According to the definition of `Array.prototype.forEach` function, `action` should return `void`.