### PR TITLE
Fixed return type for getPriority()

### DIFF
--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -179,7 +179,7 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
   exportVal(): any { return this.val(); }
 
   // TODO(inlined): figure out what to do here
-  getPriority(): any {
+  getPriority(): string|number|null {
     return 0;
   }
 


### PR DESCRIPTION
### Description

Fixed the return type for `getPriority()`. I know technically this API is not implemented properly, but at least we can get the return updated to be correct.

Reference docs for [`DataSnapshot.getPriority()`](https://firebase.google.com/docs/reference/js/firebase.database.DataSnapshot#getPriority). Looks like I already updated the reference docs for [`DeltaSnapshot.getPriority()`](https://firebase.google.com/docs/reference/functions/functions.database.DeltaSnapshot#getPriority), so those won't need to be updated.

### Code sample

N/A