### PR TITLE
Change release function to only decrement counter after waiting 2 min

### DIFF
--- a/spec/apps.spec.ts
+++ b/spec/apps.spec.ts
@@ -64,102 +64,101 @@ describe('apps', () => {
     expect(userApp).to.equal(userAppAgain);
   });
 
-  it('should retain/release ref counters appropriately without auth', function() {
-    apps.retain({});
-    expect(apps['_refCounter']).to.deep.equal({
-      __admin__: 1,
-      __noauth__: 1,
-    });
-    apps.release({});
-    expect(apps['_refCounter']).to.deep.equal({
-      __admin__: 0,
-      __noauth__: 0,
-    });
-  });
-
-  it('should retain/release ref counters appropriately with admin auth', function() {
-    apps.retain({auth: {admin: true}});
-    expect(apps['_refCounter']).to.deep.equal({
-      __admin__: 2,
-    });
-    apps.release({auth: {admin: true}});
-    expect(apps['_refCounter']).to.deep.equal({
-      __admin__: 0,
-    });
-  });
-
-  it('should retain/release ref counters appropriately with user auth', function() {
-    const payload = {auth: {admin: false, variable: claims}};
-    const userAppName = apps._appName(payload.auth);
-    apps.retain(payload);
-    expect(apps['_refCounter']).to.deep.equal({
-      __admin__: 1,
-      [userAppName]: 1,
-    });
-    apps.release(payload);
-    expect(apps['_refCounter']).to.deep.equal({
-      __admin__: 0,
-      [userAppName]: 0,
-    });
-  });
-
-  describe('#_waitToDestroyApp', () => {
+  describe('retain/release', () => {
     let clock;
-    let noauthApp;
-    let deleteNoauth;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers();
-      noauthApp = apps.forMode({ admin: false });
-      deleteNoauth = noauthApp.delete.bind(noauthApp);
-      sinon.spy(noauthApp, 'delete');
     });
 
     afterEach(() => {
       clock.restore();
-      noauthApp.delete.restore();
     });
 
-    it('should delete app after 2 minutes and not earlier', function() {
-      apps['_refCounter'] = { '__noauth__': 0 };
-      apps._waitToDestroyApp('__noauth__');
-      clock.tick(appsNamespace.garbageCollectionInterval - 1);
-      expect(noauthApp.delete.called).to.be.false;
-      clock.tick(1);
-
-      // Technically the delete happens on the next tick *after* 2 min
+    it('should retain/release ref counters appropriately without auth', function() {
+      apps.retain({});
+      expect(apps['_refCounter']).to.deep.equal({
+        __admin__: 1,
+        __noauth__: 1,
+      });
+      apps.release({});
+      clock.tick(appsNamespace.garbageCollectionInterval);
       return Promise.resolve().then(() => {
-        expect(noauthApp.delete.called).to.be.true;
+        expect(apps['_refCounter']).to.deep.equal({
+          __admin__: 0,
+          __noauth__: 0,
+        });
       });
     });
 
-    it('should exit right away if app was already deleted', function() {
-      return deleteNoauth().then(() => {
-        let spy = sinon.spy(appsNamespace, 'delay');
-        apps._waitToDestroyApp('__noauth__');
-        spy.restore();
+    it('should retain/release ref counters appropriately with admin auth', function() {
+      apps.retain({auth: {admin: true}});
+      expect(apps['_refCounter']).to.deep.equal({
+        __admin__: 2,
+      });
+      apps.release({auth: {admin: true}});
+      clock.tick(appsNamespace.garbageCollectionInterval);
+      return Promise.resolve().then(() => {
+        expect(apps['_refCounter']).to.deep.equal({
+          __admin__: 0,
+        });
+      });
+    });
+
+    it('should retain/release ref counters appropriately with user auth', function() {
+      const payload = {auth: {admin: false, variable: claims}};
+      const userAppName = apps._appName(payload.auth);
+      apps.retain(payload);
+      expect(apps['_refCounter']).to.deep.equal({
+        __admin__: 1,
+        [userAppName]: 1,
+      });
+      apps.release(payload);
+      clock.tick(appsNamespace.garbageCollectionInterval);
+      return Promise.resolve().then(() => {
+        expect(apps['_refCounter']).to.deep.equal({
+          __admin__: 0,
+          [userAppName]: 0,
+        });
+      });
+    });
+
+    it('should only decrement counter after garbageCollectionInterval is up', function() {
+      apps.retain({});
+      apps.release({});
+      clock.tick(appsNamespace.garbageCollectionInterval / 2);
+      expect(apps['_refCounter']).to.deep.equal({
+        __admin__: 1,
+        __noauth__: 1,
+      });
+      clock.tick(appsNamespace.garbageCollectionInterval / 2);
+      return Promise.resolve().then(() => {
+        expect(apps['_refCounter']).to.deep.equal({
+          __admin__: 0,
+          __noauth__: 0,
+        });
+      });
+    });
+
+    it('should call _destroyApp if app no longer used', function() {
+      let spy = sinon.spy(apps, '_destroyApp');
+      apps.retain({});
+      apps.release({});
+      clock.tick(appsNamespace.garbageCollectionInterval);
+      return Promise.resolve().then(() => {
+        expect(spy.called).to.be.true;
+      });
+    });
+
+    it('should not call _destroyApp if app used again while waiting for release', function() {
+      let spy = sinon.spy(apps, '_destroyApp');
+      apps.retain({});
+      apps.release({});
+      clock.tick(appsNamespace.garbageCollectionInterval / 2);
+      apps.retain({});
+      clock.tick(appsNamespace.garbageCollectionInterval / 2);
+      return Promise.resolve().then(() => {
         expect(spy.called).to.be.false;
-      });
-    });
-
-    it('should not delete app if it gets deleted while function is waiting', function() {
-      apps._waitToDestroyApp('__noauth__');
-      deleteNoauth();
-      clock.tick(appsNamespace.garbageCollectionInterval);
-      return Promise.resolve().then(() => {
-        expect(noauthApp.delete.called).to.be.false;
-      });
-    });
-
-    it('should not delete app if ref count rises above 0', function() {
-      apps['_refCounter'] = {
-        '__admin__': 0,
-        '__noauth__': 1,
-      };
-      apps._waitToDestroyApp('__noauth__');
-      clock.tick(appsNamespace.garbageCollectionInterval);
-      return Promise.resolve().then(() => {
-        expect(noauthApp.delete.called).to.be.false;
       });
     });
   });

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -105,7 +105,7 @@ export namespace apps {
       };
       // Increment counter for admin because function might use event.data.adminRef
       _.update(this._refCounter, '__admin__', increment);
-      // Increment counter for according to auth type because function might use event.data.ref
+      // Increment counter according to auth type because function might use event.data.ref
       _.update(this._refCounter, this._appName(auth), increment);
     }
 
@@ -118,7 +118,7 @@ export namespace apps {
         _.update(this._refCounter, '__admin__', decrement);
         _.update(this._refCounter, this._appName(auth), decrement);
         _.forEach(this._refCounter, (count, key) => {
-          if (count === 0) {
+          if (count <= 0) {
             this._destroyApp(key);
           }
         });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Fixing a bug where database connections were being closed even if a function was invoked recently. I changed the model for ref counting, to only decrement the counter after waiting 2 minutes. Whereas the old model decremented the counter right away, and then waited 2 minutes to destroy the app. With the new changes, an app will only be destroyed if there's 2 minutes of no invocations.

### Code sample

N/A