### PR TITLE
Fix database event.data.val() bug

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -137,6 +137,12 @@ describe('DeltaSnapshot', () => {
       populate({ myKey: 'foo', myOtherKey: 'bar' }, { myKey: null });
       expect(subject.val()).to.deep.equal({ myOtherKey: 'bar' });
     });
+
+    // Regression test: .val() was returning array of nulls when there's a property called length
+    it('should return correct values when data has "length" property', () => {
+      populate(null, { length: 3,  foo: 'bar' });
+      expect(subject.val()).to.deep.equal({ length: 3, foo: 'bar'});
+    });
   });
 
   describe('#child(): DeltaSnapshot', () => {

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -138,7 +138,7 @@ describe('DeltaSnapshot', () => {
       expect(subject.val()).to.deep.equal({ myOtherKey: 'bar' });
     });
 
-    // Regression test: .val() was returning array of nulls when there's a property called length
+    // Regression test: .val() was returning array of nulls when there's a property called length (BUG#37683995)
     it('should return correct values when data has "length" property', () => {
       populate(null, { length: 3,  foo: 'bar' });
       expect(subject.val()).to.deep.equal({ length: 3, foo: 'bar'});

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -248,16 +248,19 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
     let numKeys = 0;
     let maxKey = 0;
     let allIntegerKeys = true;
-    _.forEach(node, (childNode, key) => {
-      obj[key] = this._checkAndConvertToArray(childNode);
-      numKeys++;
-      const integerRegExp = /^(0|[1-9]\d*)$/;
-      if (allIntegerKeys && integerRegExp.test(key)) {
-        maxKey = Math.max(maxKey, Number(key));
-      } else {
-        allIntegerKeys = false;
+    for (let key in node) {
+      if (node.hasOwnProperty(key)) {
+        let childNode = node[key];
+        obj[key] = this._checkAndConvertToArray(childNode);
+        numKeys++;
+        const integerRegExp = /^(0|[1-9]\d*)$/;
+        if (allIntegerKeys && integerRegExp.test(key)) {
+          maxKey = Math.max(maxKey, Number(key));
+        } else {
+          allIntegerKeys = false;
+        }
       }
-    });
+    }
 
     if (allIntegerKeys && maxKey < 2 * numKeys) {
       // convert to array.

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -249,16 +249,15 @@ export class DeltaSnapshot implements firebase.database.DataSnapshot {
     let maxKey = 0;
     let allIntegerKeys = true;
     for (let key in node) {
-      if (node.hasOwnProperty(key)) {
-        let childNode = node[key];
-        obj[key] = this._checkAndConvertToArray(childNode);
-        numKeys++;
-        const integerRegExp = /^(0|[1-9]\d*)$/;
-        if (allIntegerKeys && integerRegExp.test(key)) {
-          maxKey = Math.max(maxKey, Number(key));
-        } else {
-          allIntegerKeys = false;
-        }
+      if (!node.hasOwnProperty(key)) { continue; }
+      let childNode = node[key];
+      obj[key] = this._checkAndConvertToArray(childNode);
+      numKeys++;
+      const integerRegExp = /^(0|[1-9]\d*)$/;
+      if (allIntegerKeys && integerRegExp.test(key)) {
+        maxKey = Math.max(maxKey, Number(key));
+      } else {
+        allIntegerKeys = false;
       }
     }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Fix bug where event.data.val() was returning array of nulls when database payload had a length property.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Code sample

If new database node looks like:
{ length: "something", foo: "bar"}

Previously, calling event.data.val() would return array of nulls (since lodash's _.forEach method thought that the data was actually an array due to the presence of the length property, and tried to iterate over teh nonexistent array elements). Now, event.data.val() will return the expected value of { length: "something", foo: "bar"}
<!-- Proposing an API change? Provide code samples showing how the API will be used. -->