### PR TITLE
Use process.env.FIREBASE_PROJECT for Firebase config values if available

### DIFF
--- a/spec/config.spec.ts
+++ b/spec/config.spec.ts
@@ -58,6 +58,6 @@ describe('config()', () => {
 
   it('throws an error if Firebase configs not present', () => {
     mockRequire('../../../.runtimeconfig.json', {});
-    expect(config).to.throw('Firebase config variables are missing.');
+    expect(config).to.throw('Firebase config variables are not available.');
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,23 +42,30 @@ export namespace config {
 }
 
 function init (credential: firebase.credential.Credential) {
-  let loaded: any;
-  try {
-    loaded = require('../../../.runtimeconfig.json');
-  } catch (e) {
-    try {
-      loaded = require('../../../config.json');
-    } catch (e) {
-      throw new Error(
-        'functions.config() is not available. ' +
-        'Please use the latest version of the Firebase CLI to deploy this function.'
-      );
-    }
-  }
-  if (!_.has(loaded, 'firebase')) {
-    throw new Error('Firebase config variables are missing.');
+  let loadedFromFile = {};
+  let firebaseEnv = {};
+  if (process.env.FIREBASE_PROJECT) {
+    firebaseEnv = { firebase: JSON.parse(process.env.FIREBASE_PROJECT) };
   }
 
-  _.set(loaded, 'firebase.credential', credential);
-  config.singleton = loaded;
+  try {
+    let path = process.env.CLOUD_RUNTIME_CONFIG || '../../../.runtimeconfig.json';
+    loadedFromFile = require(path);
+  } catch (e) {
+    try {
+      loadedFromFile = require('../../../config.json');
+    } catch (e) {
+      // Do nothing
+    }
+  }
+  let merged= _.merge({}, loadedFromFile, firebaseEnv);
+
+  if (!_.has(merged, 'firebase')) {
+    throw new Error('Firebase config variables are not available. ' +
+    'Please use the latest version of the Firebase CLI to deploy this function.'
+    + 'process.pid' + process.pid + 'process.env.PATH' + process.env.PATH);
+  }
+
+  _.set(merged, 'firebase.credential', credential);
+  config.singleton = merged;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,18 +52,13 @@ function init (credential: firebase.credential.Credential) {
     let path = process.env.CLOUD_RUNTIME_CONFIG || '../../../.runtimeconfig.json';
     loadedFromFile = require(path);
   } catch (e) {
-    try {
-      loadedFromFile = require('../../../config.json');
-    } catch (e) {
-      // Do nothing
-    }
+    // Do nothing
   }
   let merged= _.merge({}, loadedFromFile, firebaseEnv);
 
   if (!_.has(merged, 'firebase')) {
     throw new Error('Firebase config variables are not available. ' +
-    'Please use the latest version of the Firebase CLI to deploy this function.'
-    + 'process.pid' + process.pid + 'process.env.PATH' + process.env.PATH);
+    'Please use the latest version of the Firebase CLI to deploy this function.');
   }
 
   _.set(merged, 'firebase.credential', credential);

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -60,7 +60,8 @@ export function ref(path: string): RefBuilder {
   const normalized = normalizePath(path);
   const databaseURL = config().firebase.databaseURL;
   if (!databaseURL) {
-    throw new Error('Missing expected config value firebase.databaseURL');
+    throw new Error('Missing expected config value firebase.databaseURL, ' +
+    'config is actually' + JSON.stringify(config()));
   }
   const match = databaseURL.match(databaseURLRegex);
   if (!match) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Use FIREBASE_PROJECT and CLOUD_RUNTIME_CONFIG during population of function.config(), in anticipating of these env variables being available in the runtime in the future. 

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->