### PR TITLE
Remove the Auth UID reformatting shim

### DIFF
--- a/spec/providers/auth.spec.ts
+++ b/spec/providers/auth.spec.ts
@@ -146,33 +146,5 @@ describe('AuthBuilder', () => {
 
       return expect(cloudFunction(event)).to.eventually.deep.equal(event.data);
     });
-
-    it('should reformat a url-formatted UID', () => {
-      const cloudFunction = auth.user().onCreate((ev: Event<firebase.auth.UserRecord>) => ev.data);
-      let event: Event<firebase.auth.UserRecord> = {
-        data: {
-          uid: 'http://github.com/abcde12345',
-        },
-      } as any;
-      return expect(cloudFunction(event)).to.eventually.deep.equal(
-        {
-          uid: 'abcde12345',
-        },
-      );
-    });
-
-    it('should not reformat legally-formatted UIDs', () => {
-      const cloudFunction = auth.user().onCreate((ev: Event<firebase.auth.UserRecord>) => ev.data);
-      let event: Event<firebase.auth.UserRecord> = {
-        data: {
-          uid: 'abcde12345',
-        },
-      } as any;
-      return expect(cloudFunction(event)).to.eventually.deep.equal(
-        {
-          uid: 'abcde12345',
-        },
-      );
-    });
   });
 });

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -51,18 +51,6 @@ export class UserBuilder {
       }
     }
 
-    // It is possible that the incoming UID is formatted as a URL, for example: "http://github.com/12345".
-    // That format would break our spec, since...
-    // - The Admin SDK would return a UserRecord with a UID of just "12345".
-    // - The UserRecord UID is supposed to be usable as a key in the Firebase Realtime Database, which is
-    //   impossible with this slash-based format.
-    // Hence, we'll re-format the UID here, if it was indeed supplied as a URL.
-    // We won't use string.split(), since it's not available on older versions of node.
-    // BUG(36486645)
-    if (raw.data.uid) {
-      raw.data.uid = raw.data.uid.substring(raw.data.uid.lastIndexOf('/') + 1);
-    }
-
     return raw.data;
   }
 


### PR DESCRIPTION
### Description
The SDK contained a small shim that reformatted some Auth UIDs to match the spec; previously, some UIDs were sent in a URL-formatted way, which was not the intention. The Auth server now sends correctly-formatted UIDs, allowing the shim to be removed.

### Code sample
N/A