### PR TITLE
Add support for create/update/delete event types for database functions

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -62,23 +62,6 @@ describe('DatabaseBuilder', () => {
         resource: 'projects/_/instances/subdomains/refs/users',
       } as any);
     });
-
-    it('should interpolate params until the server does it', () => {
-      let handler = database.ref('/users/{id}').onWrite(event => {
-        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
-      });
-
-      return handler({
-        data: {
-          data: null,
-          delta: 'hello',
-        },
-        resource: 'projects/_/instances/subdomain/refs/users/{id}',
-        params: {
-          id: 'aUserId',
-        },
-      });
-    });
   });
 
   describe('#onCreate()', () => {
@@ -104,23 +87,6 @@ describe('DatabaseBuilder', () => {
         },
         resource: 'projects/_/instances/subdomains/refs/users',
       } as any);
-    });
-
-    it('should interpolate params until the server does it', () => {
-      let handler = database.ref('/users/{id}').onCreate(event => {
-        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
-      });
-
-      return handler({
-        data: {
-          data: null,
-          delta: 'hello',
-        },
-        resource: 'projects/_/instances/subdomain/refs/users/{id}',
-        params: {
-          id: 'aUserId',
-        },
-      });
     });
   });
 
@@ -148,23 +114,6 @@ describe('DatabaseBuilder', () => {
         resource: 'projects/_/instances/subdomains/refs/users',
       } as any);
     });
-
-    it('should interpolate params until the server does it', () => {
-      let handler = database.ref('/users/{id}').onUpdate(event => {
-        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
-      });
-
-      return handler({
-        data: {
-          data: null,
-          delta: 'hello',
-        },
-        resource: 'projects/_/instances/subdomain/refs/users/{id}',
-        params: {
-          id: 'aUserId',
-        },
-      });
-    });
   });
 
   describe('#onDelete()', () => {
@@ -190,23 +139,6 @@ describe('DatabaseBuilder', () => {
         },
         resource: 'projects/_/instances/subdomains/refs/users',
       } as any);
-    });
-
-    it('should interpolate params until the server does it', () => {
-      let handler = database.ref('/users/{id}').onDelete(event => {
-        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
-      });
-
-      return handler({
-        data: {
-          data: null,
-          delta: 'hello',
-        },
-        resource: 'projects/_/instances/subdomain/refs/users/{id}',
-        params: {
-          id: 'aUserId',
-        },
-      });
     });
   });
 

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -80,6 +80,136 @@ describe('DatabaseBuilder', () => {
       });
     });
   });
+
+  describe('#onCreate()', () => {
+    it('should return "ref.create" as the event type', () => {
+      let eventType = database.ref('foo').onCreate(() => null).__trigger.eventTrigger.eventType;
+      expect(eventType).to.eq('providers/google.firebase.database/eventTypes/ref.create');
+    });
+
+    it('should construct a proper resource path', () => {
+      let resource = database.ref('foo').onCreate(() => null).__trigger.eventTrigger.resource;
+      expect(resource).to.eq('projects/_/instances/subdomain/refs/foo');
+    });
+
+    it('should return a handler that emits events with a proper DeltaSnapshot', () => {
+      let handler = database.ref('/users/{id}').onCreate(event => {
+        expect(event.data.val()).to.deep.equal({ foo: 'bar' });
+      });
+
+      return handler({
+        data: {
+          data: null,
+          delta: { foo: 'bar' },
+        },
+        resource: 'projects/_/instances/subdomains/refs/users',
+      } as any);
+    });
+
+    it('should interpolate params until the server does it', () => {
+      let handler = database.ref('/users/{id}').onCreate(event => {
+        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
+      });
+
+      return handler({
+        data: {
+          data: null,
+          delta: 'hello',
+        },
+        resource: 'projects/_/instances/subdomain/refs/users/{id}',
+        params: {
+          id: 'aUserId',
+        },
+      });
+    });
+  });
+
+  describe('#onUpdate()', () => {
+    it('should return "ref.update" as the event type', () => {
+      let eventType = database.ref('foo').onUpdate(() => null).__trigger.eventTrigger.eventType;
+      expect(eventType).to.eq('providers/google.firebase.database/eventTypes/ref.update');
+    });
+
+    it('should construct a proper resource path', () => {
+      let resource = database.ref('foo').onUpdate(() => null).__trigger.eventTrigger.resource;
+      expect(resource).to.eq('projects/_/instances/subdomain/refs/foo');
+    });
+
+    it('should return a handler that emits events with a proper DeltaSnapshot', () => {
+      let handler = database.ref('/users/{id}').onUpdate(event => {
+        expect(event.data.val()).to.deep.equal({ foo: 'bar' });
+      });
+
+      return handler({
+        data: {
+          data: null,
+          delta: { foo: 'bar' },
+        },
+        resource: 'projects/_/instances/subdomains/refs/users',
+      } as any);
+    });
+
+    it('should interpolate params until the server does it', () => {
+      let handler = database.ref('/users/{id}').onUpdate(event => {
+        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
+      });
+
+      return handler({
+        data: {
+          data: null,
+          delta: 'hello',
+        },
+        resource: 'projects/_/instances/subdomain/refs/users/{id}',
+        params: {
+          id: 'aUserId',
+        },
+      });
+    });
+  });
+
+  describe('#onDelete()', () => {
+    it('should return "ref.delete" as the event type', () => {
+      let eventType = database.ref('foo').onDelete(() => null).__trigger.eventTrigger.eventType;
+      expect(eventType).to.eq('providers/google.firebase.database/eventTypes/ref.delete');
+    });
+
+    it('should construct a proper resource path', () => {
+      let resource = database.ref('foo').onDelete(() => null).__trigger.eventTrigger.resource;
+      expect(resource).to.eq('projects/_/instances/subdomain/refs/foo');
+    });
+
+    it('should return a handler that emits events with a proper DeltaSnapshot', () => {
+      let handler = database.ref('/users/{id}').onDelete(event => {
+        expect(event.data.val()).to.deep.equal({ foo: 'bar' });
+      });
+
+      return handler({
+        data: {
+          data: null,
+          delta: { foo: 'bar' },
+        },
+        resource: 'projects/_/instances/subdomains/refs/users',
+      } as any);
+    });
+
+    it('should interpolate params until the server does it', () => {
+      let handler = database.ref('/users/{id}').onDelete(event => {
+        expect(event.resource).to.equal('projects/_/instances/subdomain/refs/users/aUserId');
+      });
+
+      return handler({
+        data: {
+          data: null,
+          delta: 'hello',
+        },
+        resource: 'projects/_/instances/subdomain/refs/users/{id}',
+        params: {
+          id: 'aUserId',
+        },
+      });
+    });
+  });
+
 });
 
 describe('DeltaSnapshot', () => {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -118,13 +118,7 @@ export class RefBuilder {
       eventType: eventType,
       resource: this.resource,
       dataConstructor,
-      before: (event) => {
-        // BUG(36000428) Remove when no longer necessary
-        _.forEach(event.params, (val, key) => {
-          event.resource = _.replace(event.resource, `{${key}}`, val);
-        });
-        this.apps.retain(event);
-      },
+      before: (event) => this.apps.retain(event),
       after: (event) => this.apps.release(event),
     });
   }

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -79,6 +79,28 @@ export class RefBuilder {
 
   /** Respond to any write that affects a ref. */
   onWrite(handler: (event: Event<DeltaSnapshot>) => PromiseLike<any> | any): CloudFunction<DeltaSnapshot> {
+    return this.onOperation(handler, 'ref.write');
+  }
+
+  /** Respond to new data on a ref. */
+  onCreate(handler: (event: Event<DeltaSnapshot>) => PromiseLike<any> | any): CloudFunction<DeltaSnapshot> {
+    return this.onOperation(handler, 'ref.create');
+  }
+
+  /** Respond to update on a ref. */
+  onUpdate(handler: (event: Event<DeltaSnapshot>) => PromiseLike<any> | any): CloudFunction<DeltaSnapshot> {
+    return this.onOperation(handler, 'ref.update');
+  }
+
+  /** Respond to all data being deleted from a ref. */
+  onDelete(handler: (event: Event<DeltaSnapshot>) => PromiseLike<any> | any): CloudFunction<DeltaSnapshot> {
+    return this.onOperation(handler, 'ref.delete');
+  }
+
+  private onOperation(
+    handler: (event: Event<DeltaSnapshot>) => PromiseLike<any> | any,
+    eventType: string): CloudFunction<DeltaSnapshot> {
+
     const dataConstructor = (raw: Event<any>) => {
       if (raw.data instanceof DeltaSnapshot) {
         return raw.data;
@@ -93,7 +115,7 @@ export class RefBuilder {
     };
     return makeCloudFunction({
       provider, handler,
-      eventType: 'ref.write',
+      eventType: eventType,
       resource: this.resource,
       dataConstructor,
       before: (event) => {


### PR DESCRIPTION
Repeat of https://github.com/firebase/firebase-functions/pull/57, which was reverted since backend wasn't ready.

### Description

Add support for create/update/delete event types for database functions.

### Code sample

```
const functions = require('firebase-functions');
 
exports.createEvent = functions.database.ref('/path').onCreate(event => {
        console.log('Data created.');
});
 
exports.updateEvent = functions.database.ref('/path').onUpdate(event => {
        console.log('Data updated.');
});
 
exports.deleteEvent = functions.database.ref('/path').onDelete(event => {
        console.log('Data at path is deleted or its only child is deleted.');
});
 
// onWrite currently exists and will be kept:
exports.writeEvent = functions.database.ref('/path').onWrite(event => {
        console.log('Data created, updated, or deleted');
});
```
