### PR TITLE
Allow "npm run build:pack" to work even in a cleanly-cloned directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "scripts": {
     "build": "node_modules/.bin/tsc -p tsconfig.release.json",
-    "build:pack": "npm prune --production && rm -rf lib && npm install typescript firebase-admin && node_modules/.bin/tsc -p tsconfig.release.json && npm pack && npm install",
+    "build:pack": "npm prune --production && rm -rf lib && npm install && npm install firebase-admin && node_modules/.bin/tsc -p tsconfig.release.json && npm pack && npm install",
     "build:release": "npm install --production && npm install typescript firebase-admin && node_modules/.bin/tsc -p tsconfig.release.json",
     "lint": "node_modules/.bin/tslint src/{**/*,*}.ts spec/{**/*,*}.ts integration_test/functions/src/{**/*,*}.ts",
     "pretest": "node_modules/.bin/tsc && cp -r spec/fixtures .tmp/spec",


### PR DESCRIPTION
### Description
Allow "npm run build:pack" to work even in a cleanly-cloned directory; previously the lack of an "npm install" command in that directive caused it to fail with errors like "Cannot find module 'lodash'" if the developer hadn't run "npm install" manually before.

We no longer need to "npm install typescript", because it's a dev-dependency. We still need to install firebase-admin, since it's a peer dependency.