### PR TITLE
Preserve params passed with the original event

### DIFF
--- a/spec/cloud-functions.spec.ts
+++ b/spec/cloud-functions.spec.ts
@@ -79,17 +79,38 @@ describe('makeParams', () => {
     handler: () => null,
   };
 
-  const testEvent: Event<string> = {
-    resource: 'projects/_/instances/pid/ref/a/nested/b',
-    data: 'data',
-  };
-
   it('should construct params from the event resource', () => {
     let args: any = _.assign({}, cloudFunctionArgs, {handler: (e) => e});
     let cf = makeCloudFunction(args);
 
+    const testEvent: Event<string> = {
+      resource: 'projects/_/instances/pid/ref/a/nested/b',
+      data: 'data',
+    };
+
     return expect(cf(testEvent)).to.eventually.deep.equal({
       resource: 'projects/_/instances/pid/ref/a/nested/b',
+      data: 'data',
+      params: {
+        foo: 'a',
+        bar: 'b',
+      },
+    });
+  });
+
+  it('should construct params from the event params', () => {
+    let args: any = _.assign({}, cloudFunctionArgs, {handler: (e) => e});
+    let cf = makeCloudFunction(args);
+
+    const testEvent: Event<string> = {
+      data: 'data',
+      params: {
+        foo: 'a',
+        bar: 'b',
+      },
+    };
+
+    return expect(cf(testEvent)).to.eventually.deep.equal({
       data: 'data',
       params: {
         foo: 'a',

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -74,7 +74,7 @@ export interface MakeCloudFunctionArgs<EventData> {
 }
 
 function _makeParams(event: Event<any>, triggerResource: string): { [option: string]: any } {  
-  if (!event.resource) {
+  if (!event.resource) { // In unit testing, "resource" may not be populated for a test event.
     return event.params || {};
   }
 

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -73,7 +73,7 @@ export interface MakeCloudFunctionArgs<EventData> {
   after?: (raw: Event<any>) => void;
 }
 
-function _makeParams (event: Event<any>, triggerResource: string): { [option: string]: any } {
+function _makeParams(event: Event<any>, triggerResource: string): { [option: string]: any } {
   let wildcards = triggerResource.match(WILDCARD_REGEX);
   let params = {};
   if (wildcards) {
@@ -86,6 +86,9 @@ function _makeParams (event: Event<any>, triggerResource: string): { [option: st
       params[wildcardNoBraces] = eventResourceParts[position];
     });
   }
+
+  Object.assign(params, event.params);
+
   return params;
 };
 

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -73,7 +73,11 @@ export interface MakeCloudFunctionArgs<EventData> {
   after?: (raw: Event<any>) => void;
 }
 
-function _makeParams(event: Event<any>, triggerResource: string): { [option: string]: any } {
+function _makeParams(event: Event<any>, triggerResource: string): { [option: string]: any } {  
+  if (!event.resource) {
+    return event.params || {};
+  }
+
   let wildcards = triggerResource.match(WILDCARD_REGEX);
   let params = {};
   if (wildcards) {
@@ -86,8 +90,6 @@ function _makeParams(event: Event<any>, triggerResource: string): { [option: str
       params[wildcardNoBraces] = eventResourceParts[position];
     });
   }
-
-  Object.assign(params, event.params);
 
   return params;
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Fixes #88. Parameters assigned to event.params take precedence over those from the resource string.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->