### PR TITLE
Refactor Integration Test Script

### DIFF
--- a/integration_test/README.md
+++ b/integration_test/README.md
@@ -6,8 +6,7 @@ How to Use
 Run the integration test as follows:
 
 ```bash
-firebase init # Don't choose to use any features, select your project.
-./run_tests.sh
+./run_tests.sh <project_id>
 ```
 
 The tests run fully automatically, and will print the result on standard out. The integration test for HTTPS is that it properly kicks off other integration tests and returns a result. From there the other integration test suites will write their results back to the database, where you can check the detailed results if you'd like.

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -1,47 +1,76 @@
-#!/bin/bash
-(
-  echo "##### Building SDK..." &&
-  (
-    cd ../ &&
-    rm -f firebase-functions-*.tgz &&
-    npm run build:pack &&
-    mv firebase-functions-*.tgz integration_test/functions/firebase-functions.tgz
-  ) &&
-  echo "##### Installing dependencies..." &&
-  (
-    cd functions &&
-    npm install
-  ) &&
-  echo "##### Deploying empty index.js to project..." &&
-  ./functions/node_modules/.bin/tsc -p functions/ &&  # Make sure the functions/lib directory actually exists.
-  echo "" > functions/lib/index.js &&
-  firebase deploy --debug 2> /dev/null &&
-  echo &&
-  echo "##### Project emptied. Deploying functions..." &&
-  ./functions/node_modules/.bin/tsc -p functions/ &&
-  firebase deploy --only functions --debug 2> /dev/null &&
-  echo &&
-  echo "##### Running the integration tests..." &&
-  funcURL=$(tail -n 1 firebase-debug.log | awk '{ print $5 }') &&  # URL is printed on last line of log.
-  wget --content-on-error -qO- $funcURL &&
-  echo &&
-  echo "##### Integration test run passed!" &&
-  echo "##### Re-deploying the same functions, to make sure updates work..." &&
-  firebase deploy --only functions --debug 2> /dev/null &&
-  echo &&
-  echo "##### Running the integration tests..." &&
-  wget --content-on-error -qO- $funcURL &&
-  echo &&
-  echo "##### Integration test run passed!" &&
-  echo "##### Removing all functions" &&
-  echo "" > functions/lib/index.js &&
-  firebase deploy --only functions --debug 2> /dev/null &&
-  rm functions/firebase-functions.tgz &&
-  rm -f functions/firebase-debug.log &&
-  echo &&
-  echo "##### All tests pass!"
-) || (
-  echo &&
-  echo "XXXXX Something failed XXXXX" &&
-  false  # Finish with an error code.
-)
+#!/usr/bin/env bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+function usage {
+  echo "Usage: $0 <project_id>"
+  exit 1
+}
+
+# The first parameter is required and is the Firebase project id.
+if [[ $1 == "" ]]; then
+  usage
+fi
+PROJECT_ID=$1
+
+# Directory where this script lives.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+function announce {
+  echo -e "\n##### $1"
+}
+
+function build_sdk {
+  announce "Building SDK..."
+  cd $DIR/..
+  rm -f firebase-functions-*.tgz
+  npm run build:pack
+  mv firebase-functions-*.tgz integration_test/functions/firebase-functions.tgz
+}
+
+function install_deps {
+  announce "Installing dependencies..."
+  cd $DIR/functions
+  npm install
+}
+
+function delete_all_functions {
+  announce "Deploying empty index.js to project..."
+  cd $DIR
+  ./functions/node_modules/.bin/tsc -p functions/ # Make sure the functions/lib directory actually exists.
+  echo "" > functions/lib/index.js
+  firebase deploy --project=$PROJECT_ID --only functions
+  announce "Project emptied."
+}
+
+function deploy {
+  announce "Deploying functions..."
+  cd $DIR
+  ./functions/node_modules/.bin/tsc -p functions/
+  firebase deploy --project=$PROJECT_ID --only functions
+}
+
+function run_tests {
+  announce "Running the integration tests..."
+  funcURL=$(tail -n 1 $DIR/firebase-debug.log | awk '{ print $5 }') # URL is printed on last line of log.
+  curl -s --fail $funcURL
+}
+
+function cleanup {
+  announce "Performing cleanup..."
+  delete_all_functions
+  rm $DIR/functions/firebase-functions.tgz
+  rm -f $DIR/functions/firebase-debug.log
+}
+
+build_sdk
+install_deps
+delete_all_functions
+deploy
+run_tests
+announce "Re-deploying the same functions to make sure updates work..."
+deploy
+run_tests
+cleanup
+announce "All tests pass!"

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -18,7 +18,7 @@ PROJECT_ID=$1
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 function announce {
-  echo -e "\n##### $1"
+  echo -e "\n\n##### $1"
 }
 
 function build_sdk {
@@ -53,8 +53,14 @@ function deploy {
 
 function run_tests {
   announce "Running the integration tests..."
-  funcURL=$(tail -n 1 $DIR/firebase-debug.log | awk '{ print $5 }') # URL is printed on last line of log.
-  curl -s --fail $funcURL
+
+  # Construct the URL for the test function. This may change in the future,
+  # causing this script to start failing, but currently we don't have a very
+  # reliable way of determining the URL dynamically.
+  TEST_URL=https://us-central1-$PROJECT_ID.cloudfunctions.net/integrationTests
+  echo $TEST_URL
+
+  curl --fail $TEST_URL
 }
 
 function cleanup {


### PR DESCRIPTION
This PR refactors the integration test script:
1. Require a command line parameter for specifying project_id.
2. Use `set -e` instead of `&&` chaining.
3. Modularize into reusable functions.
4. Use curl instead of wget as it's available on OS X by default.
5. Use absolute paths so the script can be run from outside the `integration_test` directory, and to make the `cd` statements independent of each other.
6. Don't suppress stderr during `firebase deploy`.