### PR TITLE
Add code coverage reports to unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.nyc_output/
 .idea
 .npm
 .tmp

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '0.12'
 - '6.11.1'
 - stable
 sudo: false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build:release": "npm install --production && npm install typescript firebase-admin && node_modules/.bin/tsc -p tsconfig.release.json",
     "lint": "node_modules/.bin/tslint src/{**/*,*}.ts spec/{**/*,*}.ts integration_test/functions/src/{**/*,*}.ts",
     "pretest": "node_modules/.bin/tsc && cp -r spec/fixtures .tmp/spec",
-    "test": "mocha .tmp/spec/index.spec.js",
+    "test": "nyc -x .tmp/spec --reporter=text mocha .tmp/spec/index.spec.js",
     "posttest": "npm run lint && rm -rf .tmp"
   },
   "repository": {
@@ -43,6 +43,7 @@
     "mocha": "^2.4.5",
     "mock-require": "^2.0.1",
     "nock": "^8.0.0",
+    "nyc": "^11.1.0",
     "sinon": "^1.17.4",
     "tslint": "^3.15.1",
     "typescript": "^2.0.3"


### PR DESCRIPTION
### Description

Adds automatic test coverage reports to `npm test` via the `nyc` commandline tool for `istanbul`. Future changes may cause a test failure if code coverage drops too low.

### Code sample

N/A