### PR TITLE
Remove outdated storage shim.

### DIFF
--- a/spec/providers/storage.spec.ts
+++ b/spec/providers/storage.spec.ts
@@ -70,40 +70,6 @@ describe('storage.FunctionBuilder', () => {
       expect(() => storage.bucket('bad/bucket/format')).to.throw(Error);
     });
 
-    it('should correct nested media links using a single literal slash', () => {
-      let cloudFunction = storage.object().onChange((event) => {
-        return event.data.mediaLink;
-      });
-      let badMediaLinkEvent = {
-        data: {
-          mediaLink: 'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com'
-          + '/o/nestedfolder/myobject.file?generation=12345&alt=media',
-        },
-      };
-      return cloudFunction(badMediaLinkEvent).then(result => {
-        expect(result).equals(
-          'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com'
-          + '/o/nestedfolder%2Fmyobject.file?generation=12345&alt=media');
-      });
-    });
-
-    it('should correct nested media links using multiple literal slashes', () => {
-      let cloudFunction = storage.object().onChange((event) => {
-        return event.data.mediaLink;
-      });
-      let badMediaLinkEvent = {
-        data: {
-          mediaLink: 'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com'
-          + '/o/nestedfolder/anotherfolder/myobject.file?generation=12345&alt=media',
-        },
-      };
-      return cloudFunction(badMediaLinkEvent).then(result => {
-        expect(result).equals(
-          'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com'
-          + '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media');
-      });
-    });
-
     it('should not mess with media links using non-literal slashes', () => {
       let cloudFunction = storage.object().onChange((event) => {
         return event.data.mediaLink;

--- a/src/providers/analytics.ts
+++ b/src/providers/analytics.ts
@@ -63,6 +63,9 @@ export class AnalyticsEventBuilder {
     handler: (event: Event<AnalyticsEvent>) => PromiseLike<any> | any
   ): CloudFunction<AnalyticsEvent> {
     const dataConstructor = (raw: Event<any>) => {
+      if (raw.data instanceof AnalyticsEvent) {
+        return raw.data;
+      }
       return new AnalyticsEvent(raw.data);
     };
     return makeCloudFunction({

--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -52,9 +52,6 @@ export class BucketBuilder {
   }
 }
 
-// A RegExp that matches on a GCS media link that points at a _nested_ object (one that uses a path/with/slashes).
-const nestedMediaLinkRE = new RegExp('https://www.googleapis.com/storage/v1/b/([^/]+)/o/(.*)');
-
 export class ObjectBuilder {
   /** @internal */
   constructor(private resource) { }
@@ -63,21 +60,8 @@ export class ObjectBuilder {
    * Handle any change to any object.
    */
   onChange(handler: (event: Event<ObjectMetadata>) => PromiseLike<any> | any): CloudFunction<ObjectMetadata> {
-    // This is a temporary shim to fix the 'mediaLink' for nested objects.
-    // BUG(37962789): clean this up when backend fix for bug is deployed.
-    let correctMediaLink = (event: Event<ObjectMetadata>) => {
-      let deconstructedNestedLink = event.data.mediaLink.match(nestedMediaLinkRE);
-      if (deconstructedNestedLink != null) {
-        // The media link for a nested object uses an illegal URL (using literal slashes instead of "%2F".
-        // Fix up the URL.
-        let bucketName = deconstructedNestedLink[1];
-        let fixedTail = deconstructedNestedLink[2].replace(/\//g, '%2F');  // "/\//g" means "all forward slashes".
-        event.data.mediaLink = 'https://www.googleapis.com/storage/v1/b/' + bucketName + '/o/' + fixedTail;
-      }
-      return handler(event);
-    };
     return makeCloudFunction(
-      { provider, handler: correctMediaLink, resource: this.resource, eventType: 'object.change' });
+      { provider, handler: handler, resource: this.resource, eventType: 'object.change' });
   }
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

This PR:
- Removes outdated shim since underlying bug has been fixed
- Does not construct AnalyticsEvent if the event.data is already an AnalyticsEvent (e.g. unit testing)

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->