### PR TITLE
Handle Firestore timestamp values with precision to the second

### DIFF
--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -307,6 +307,19 @@ describe('Firestore Functions', () => {
         expect(snapshot.data()).to.deep.equal({'timestampVal': new Date('2017-06-13T00:58:40.349Z')});
       });
 
+      it('should parse timestamp values of with precision to the second', () => {
+        let raw = constructValue({
+          'timestampVal': {
+            'timestampValue': '2017-06-13T00:58:40Z',
+          },
+        });
+        let snapshot = firestore.dataConstructor({
+          data: { value: raw },
+        });
+        expect(snapshot.data()).to.deep.equal({'timestampVal': new Date('2017-06-13T00:58:40Z')});
+
+      });
+
       it('should parse binary values', () => {
         // Format defined in https://developers.google.com/discovery/v1/type-format
         let raw = constructValue({

--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -295,7 +295,7 @@ describe('Firestore Functions', () => {
         expect(snapshot.data()['referenceVal'].path).to.equal('doc1/id');
       });
 
-      it('should parse timestamp values', () => {
+      it('should parse timestamp values with precision to the millisecond', () => {
         let raw = constructValue({
           'timestampVal': {
             'timestampValue': '2017-06-13T00:58:40.349Z',
@@ -307,7 +307,7 @@ describe('Firestore Functions', () => {
         expect(snapshot.data()).to.deep.equal({'timestampVal': new Date('2017-06-13T00:58:40.349Z')});
       });
 
-      it('should parse timestamp values of with precision to the second', () => {
+      it('should parse timestamp values with precision to the second', () => {
         let raw = constructValue({
           'timestampVal': {
             'timestampValue': '2017-06-13T00:58:40Z',

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -32,9 +32,5 @@ export function dateToTimestampProto(timeString) {
     const trailingZeroes = 9 - nanoString.length;
     nanos = parseInt(nanoString, 10) * Math.pow(10, trailingZeroes);
   }
-
-  return {
-    seconds: seconds,
-    nanos: nanos,
-  };
+  return { seconds, nanos };
 };

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -20,18 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import * as _ from 'lodash';
+
 export function dateToTimestampProto(timeString) {
   if (typeof timeString === 'undefined') {
     return;
   }
   let date = new Date(timeString);
   let seconds = Math.floor(date.getTime() / 1000);
-  let nanoString = timeString.substring(20, timeString.length - 1);
-
-  if (nanoString.length === 3) {
-    nanoString = `${nanoString}000000`;
-  } else if (nanoString.length === 6)  {
-    nanoString = `${nanoString}000`;
+  let nanoString;
+  if (timeString.length <= 20) {
+    nanoString = '000000000';
+  } else {
+    nanoString = timeString.substring(20, timeString.length - 1);
+    nanoString += _.reduce(new Array(9 - nanoString.length), i => {return i + '0';}, '');
   }
   let proto = {
     seconds: seconds,

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -20,24 +20,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import * as _ from 'lodash';
-
 export function dateToTimestampProto(timeString) {
   if (typeof timeString === 'undefined') {
     return;
   }
   let date = new Date(timeString);
   let seconds = Math.floor(date.getTime() / 1000);
-  let nanoString;
-  if (timeString.length <= 20) {
-    nanoString = '000000000';
-  } else {
-    nanoString = timeString.substring(20, timeString.length - 1);
-    nanoString += _.reduce(new Array(9 - nanoString.length), i => {return i + '0';}, '');
+  let nanos = 0;
+  if (timeString.length > 20) {
+    const nanoString = timeString.substring(20, timeString.length - 1);
+    const trailingZeroes = 9 - nanoString.length;
+    nanos = parseInt(nanoString, 10) * Math.pow(10, trailingZeroes);
   }
-  let proto = {
+
+  return {
     seconds: seconds,
-    nanos: parseInt(nanoString, 10),
+    nanos: nanos,
   };
-  return proto;
 };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Fixes bug where timestamp values that didn't have millisecond or nanosecond precision resulted in "Invalid date" when event.data.data() is called.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->