### PR TITLE
Always construct DocumentSnapshot for event.data.previous for Firestore functions

### DIFF
--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -145,7 +145,10 @@ describe('Firestore Functions', () => {
       let testFunction = firestore.document('path').onCreate((event) => {
         expect(event.data.data()).to.deep.equal({key1: true, key2: 123});
         expect(event.data.get('key1')).to.equal(true);
-        expect(event.data.previous).to.equal(null);
+        expect(event.data.previous).to.not.equal(null);
+        expect(event.data.previous.exists).to.be.false;
+        expect(event.data.previous.data).to.throw(Error);
+        expect(() => {return event.data.previous.get('key1');}).to.throw(Error);
       });
       let data = constructEvent({}, createValue());
       return testFunction(data);

--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -333,7 +333,7 @@ describe('Firestore Functions', () => {
         let snapshot = firestore.dataConstructor({
           data: { value: raw },
         });
-        expect(snapshot.data()).to.deep.equal({'binaryVal': 'Zm9vYmFy'});
+        expect(snapshot.data()).to.deep.equal({'binaryVal': new Buffer('foobar')});
       });
     });
 

--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -147,8 +147,6 @@ describe('Firestore Functions', () => {
         expect(event.data.get('key1')).to.equal(true);
         expect(event.data.previous).to.not.equal(null);
         expect(event.data.previous.exists).to.be.false;
-        expect(event.data.previous.data).to.throw(Error);
-        expect(() => {return event.data.previous.get('key1');}).to.throw(Error);
       });
       let data = constructEvent({}, createValue());
       return testFunction(data);
@@ -167,8 +165,7 @@ describe('Firestore Functions', () => {
 
     it('constructs appropriate fields and getters for event.data on "document.delete" events', () => {
       let testFunction = firestore.document('path').onDelete((event) => {
-        expect(event.data.data).to.throw(Error);
-        expect(() => {return event.data.get('key1');}).to.throw(Error);
+        expect(event.data.exists).to.equal(false);
         expect(event.data.previous.data()).to.deep.equal({key1: false, key2: 111});
         expect(event.data.previous.get('key1')).to.equal(false);
       });
@@ -390,8 +387,6 @@ describe('Firestore Functions', () => {
         });
         expect(snapshot.exists).to.be.false;
         expect(snapshot.ref.path).to.equal('collection/123');
-        expect(snapshot.data).to.throw(Error);
-        expect(() => {return snapshot.get('key1');}).to.throw(Error);
       });
 
       it('constructs existent DocumentSnapshot with empty data when all fields of document deleted', () => {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Code sample

This changes what event.data.previous is when there's no previous data (i.e. the Firestore document was just created)

```
// Before this PR:
event.data.previous // null
event.data.previous.exists // would throw

// After this PR
event.data.previous // is a firestore.DocumentSnapshot
event.data.previous.exists // false
```
IMPORTANT: need to make sure docs/sample code isn't suggesting the wrong thing before we merge this PR (tracking bug 69812710)
