### PR TITLE
Further improve on config() type

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -56,11 +56,15 @@ function init (credential: firebase.credential.Credential) {
   }
   let merged= _.merge({}, loadedFromFile, firebaseEnv);
 
-  if (!_.has(merged, 'firebase')) {
+  if (!hasFirebase(merged)) {
     throw new Error('Firebase config variables are not available. ' +
     'Please use the latest version of the Firebase CLI to deploy this function.');
   }
 
   _.set(merged, 'firebase.credential', credential);
   config.singleton = merged;
+}
+
+function hasFirebase (merged: { [key: string]: any }): merged is { [key: string]: any, firebase: firebase.AppOptions } {
+  return _.has(merged, 'firebase');
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -65,6 +65,6 @@ function init (credential: firebase.credential.Credential) {
   config.singleton = merged;
 }
 
-function hasFirebase (merged: { [key: string]: any }): merged is { [key: string]: any, firebase: firebase.AppOptions } {
+function hasFirebase (merged: { [key: string]: any }): merged is config.Config {
   return _.has(merged, 'firebase');
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -35,7 +35,7 @@ export function config(): config.Config {
 export namespace config {
   // Config type is usable as a object (dot notation allowed), and firebase
   // property will also code complete.
-  export type Config = { [key: string]: any } & { firebase?: firebase.AppOptions };
+  export type Config = { [key: string]: any } & { firebase: firebase.AppOptions };
 
   /** @internal */
   export let singleton: config.Config;


### PR DESCRIPTION
### Description

Further addition to #127. Updates ```config().firebase``` to be strictly of type ```firebase.AppOptions``` instead of the union with ```undefined``` since ```config()``` will throw an error if ```merged.firebase``` is undefined. This keeps from unnecessarily having to check whether ```firebase``` exists or not.