### PR TITLE
Change order of parameters for DeltaSnapshot constructor

### DIFF
--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -185,10 +185,10 @@ describe('DeltaSnapshot', () => {
     subject = new database.DeltaSnapshot(
       apps.admin,
       apps.admin,
-      instance,
       old,
       change,
-      path
+      path,
+      instance
     );
   };
 
@@ -424,10 +424,10 @@ describe('DeltaSnapshot', () => {
       const snapshot = new database.DeltaSnapshot(
         apps.admin,
         apps.admin,
-        instance,
         null,
         null,
-        path
+        path,
+        instance
       );
       expect(snapshot.key).to.be.null;
     });
@@ -437,10 +437,10 @@ describe('DeltaSnapshot', () => {
       expect(new database.DeltaSnapshot(
         apps.admin,
         apps.admin,
-        instance,
         null,
         {},
-        path
+        path,
+        instance
       ).key).to.be.null;
     });
 

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -125,10 +125,10 @@ export class RefBuilder {
       return new DeltaSnapshot(
         this.apps.forMode(raw.auth),
         this.apps.admin,
-        dbInstance,
         raw.data.data,
         raw.data.delta,
         path,
+        dbInstance
       );
     };
     return makeCloudFunction({
@@ -173,10 +173,10 @@ export class DeltaSnapshot {
   constructor(
     private app: firebase.app.App,
     private adminApp: firebase.app.App,
-    private instance: string,
     data: any,
     delta: any,
-    path?: string // path will be undefined for the database root
+    path?: string, // path will be undefined for the database root
+    public instance?: string,
   ) {
     if (delta !== undefined) {
       this._path = path;
@@ -311,7 +311,7 @@ export class DeltaSnapshot {
   }
 
   private _dup(previous: boolean, childPath?: string): DeltaSnapshot {
-    let dup = new DeltaSnapshot(this.app, this.adminApp, this.instance, undefined, undefined);
+    let dup = new DeltaSnapshot(this.app, this.adminApp, undefined, undefined, undefined, this.instance);
     [dup._path, dup._data, dup._delta, dup._childPath, dup._newData] =
       [this._path, this._data, this._delta, this._childPath, this._newData];
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Fixes https://github.com/firebase/firebase-functions/issues/137, so users doing uni testing can still construct DeltaSnapshots in the same way as before multi-DB was introduced.

Also made instance both a public and an optional field. This is ok since the admin SDK will initialize the database for the default instance if no parameter is supplied.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->