### PR TITLE
Correct the type signature of DeltaDocumentSnapshot

### DIFF
--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -70,12 +70,12 @@ export class NamespaceBuilder {
 
 export interface DeltaDocumentSnapshot {
   exists: Boolean;
-  ref: any;
+  ref: firebase.firestore.DocumentReference;
   id: string;
-  createTime: string;
-  updateTime: string;
-  readTime: string;
-  previous: any;
+  createTime?: string;
+  updateTime?: string;
+  readTime?: string;
+  previous: DeltaDocumentSnapshot;
   data: () => any;
   get: (key: string) => any;
 };


### PR DESCRIPTION
### Description

Correct the type signature of `DeltaDocumentSnapshot` to make it correspond to the [reference documentation](https://firebase.google.com/docs/reference/functions/functions.firestore.DeltaDocumentSnapshot).

### Code sample