### PR TITLE
Correct a broken integration test

### DIFF
--- a/integration_test/functions/src/firestore-tests.ts
+++ b/integration_test/functions/src/firestore-tests.ts
@@ -25,7 +25,7 @@ export const firestoreTests: any = functions.firestore.document('tests/{document
 
     .it('should have the correct data', event => expectDeepEq(event.data.data(), {test: event.params.documentId}))
 
-    .it('previous should be null', event => expectEq(event.data.previous, null))
+    .it('previous.exists should be false', event => expectEq(event.data.previous.exists, false))
 
     .run(receivedEvent.params[testIdFieldName], receivedEvent);
 });


### PR DESCRIPTION
### Description
Correct a broken integration test.

Nowadays, Firestore snapshots with no previous value have `data.previous.exists` set to false instead of `data.previous` being null.