### PR TITLE
Warn users about breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "node_modules/.bin/tslint src/{**/*,*}.ts spec/{**/*,*}.ts integration_test/functions/src/{**/*,*}.ts",
     "pretest": "node_modules/.bin/tsc && cp -r spec/fixtures .tmp/spec",
     "test": "mocha .tmp/spec/index.spec.js",
-    "posttest": "npm run lint && rm -rf .tmp"
+    "posttest": "npm run lint && rm -rf .tmp",
+    "postinstall": "node ./upgrade-warning"
   },
   "repository": {
     "type": "git",

--- a/upgrade-warning
+++ b/upgrade-warning
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const message = `
+Congratulations! You have just updated to firebase-functions 1.0.
+
+This means you've installed some breaking changes. To see a complete
+list of these breaking changes, please go to
+
+https://firebase.google.com/docs/functions/early-access/beta-v1-diff
+`;
+
+console.log(message);


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

firebase-functions SDK will print out a message warning users about breaking changes when being upgraded. This postinstall script can be removed in later versions.

To test: run `npm install` inside a functions directory after upgrading the `package.json` version number to 1.0 for firebase-functions. 

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->