### PR TITLE
 Change https callables to use apps.admin.auth instead of firebase.auth.

### DIFF
--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -21,15 +21,12 @@
 // SOFTWARE.
 
 import * as express from 'express';
-import * as firebase from 'firebase-admin';
 import * as https from '../../src/providers/https';
 import * as jwt from 'jsonwebtoken';
 import * as mocks from '../fixtures/credential/key.json';
 import * as nock from 'nock';
 import * as _ from 'lodash';
-import { config } from '../../src/index';
 import { expect } from 'chai';
-import { fakeConfig } from '../support/helpers';
 
 describe('CloudHttpsBuilder', () => {
   describe('#onRequest', () => {
@@ -202,15 +199,6 @@ export function generateIdToken(projectId: string): string {
 }
 
 describe('callable.FunctionBuilder', () => {
-  before(() => {
-    config.singleton = fakeConfig();
-    firebase.initializeApp(config.singleton.firebase);
-  });
-
-  after(() => {
-    delete config.singleton;
-  });
-
   describe('#onCall', () => {
     it('should return a Trigger with appropriate values', () => {
       const result = https.onCall((data) => {
@@ -361,7 +349,7 @@ describe('callable.FunctionBuilder', () => {
 
     it('should handle auth', async () => {
       const mock = mockFetchPublicKeys();
-      const projectId = config.singleton.firebase['projectId'];
+      const projectId = 'aProjectId';
       const idToken = generateIdToken(projectId);
       await runTest({
         httpRequest: request(null, 'application/json', {

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -21,11 +21,13 @@
 // SOFTWARE.
 
 import * as express from 'express';
+import * as firebase from 'firebase-admin';
 import * as https from '../../src/providers/https';
 import * as jwt from 'jsonwebtoken';
 import * as mocks from '../fixtures/credential/key.json';
 import * as nock from 'nock';
 import * as _ from 'lodash';
+import { apps } from '../../src/apps';
 import { expect } from 'chai';
 
 describe('CloudHttpsBuilder', () => {
@@ -199,6 +201,30 @@ export function generateIdToken(projectId: string): string {
 }
 
 describe('callable.FunctionBuilder', () => {
+  let oldCredential: firebase.credential.Credential = undefined;
+
+  before(() => {
+    let credential = {
+      getAccessToken: () => {
+        return Promise.resolve({
+          expires_in: 1000,
+          access_token: 'fake',
+        });
+      },
+      getCertificate: () => {
+        return {
+          projectId: 'aProjectId',
+        };
+      },
+    };
+    oldCredential = apps().admin.options.credential;
+    apps().admin.options.credential = credential;
+  });
+
+  after(() => {
+    apps().admin.options.credential = oldCredential;
+  });
+
   describe('#onCall', () => {
     it('should return a Trigger with appropriate values', () => {
       const result = https.onCall((data) => {

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -375,7 +375,7 @@ describe('callable.FunctionBuilder', () => {
 
     it('should handle auth', async () => {
       const mock = mockFetchPublicKeys();
-      const projectId = 'aProjectId';
+      const projectId = apps().admin.options.projectId;
       const idToken = generateIdToken(projectId);
       await runTest({
         httpRequest: request(null, 'application/json', {

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -23,6 +23,7 @@
 import { HttpsFunction } from '../cloud-functions';
 import * as express from 'express';
 import * as firebase from 'firebase-admin';
+import { apps } from '../apps';
 import * as _ from 'lodash';
 import * as cors from 'cors';
 
@@ -382,7 +383,7 @@ export function onCall(
         }
         const idToken = match[1];
         try {
-          const authToken = await firebase.auth().verifyIdToken(idToken);
+          const authToken = await apps().admin.auth().verifyIdToken(idToken);
           context.auth = {
             uid: authToken.uid,
             token: authToken,


### PR DESCRIPTION
This fixes the problem where an https callable function will reject all requests with an auth token if the function has not called firebase.initializeApp.

I have tested this with `npm test`, and with a function deployed to an app in production using this branch.