### PR TITLE
Disallow implicit any typings (noImplicitAny: true)

### DIFF
--- a/spec/apps.spec.ts
+++ b/spec/apps.spec.ts
@@ -42,7 +42,7 @@ describe('apps', () => {
   });
 
   describe('retain/release', () => {
-    let clock;
+    let clock: sinon.SinonFakeTimers;
 
     beforeEach(() => {
       clock = sinon.useFakeTimers();

--- a/spec/cloud-functions.spec.ts
+++ b/spec/cloud-functions.spec.ts
@@ -22,7 +22,8 @@
 
 import * as _ from 'lodash';
 import { expect } from 'chai';
-import { Event, LegacyEvent, makeCloudFunction, MakeCloudFunctionArgs, Change } from '../src/cloud-functions';
+import { Event, EventContext, LegacyEvent,
+  makeCloudFunction, MakeCloudFunctionArgs, Change } from '../src/cloud-functions';
 
 describe('makeCloudFunction', () => {
   const cloudFunctionArgs: MakeCloudFunctionArgs<any> = {
@@ -45,7 +46,7 @@ describe('makeCloudFunction', () => {
   });
 
   it('should construct the right context for legacy event format', () => {
-    let args: any = _.assign({}, cloudFunctionArgs, {handler: (data, context) => context});
+    let args: any = _.assign({}, cloudFunctionArgs, {handler: (data: any, context: EventContext) => context});
     let cf = makeCloudFunction(args);
     let test: LegacyEvent = {
       eventId: '00000',
@@ -68,7 +69,7 @@ describe('makeCloudFunction', () => {
   });
 
   it('should construct the right context for new event format', () => {
-    let args: any = _.assign({}, cloudFunctionArgs, { handler: (data, context) => context });
+    let args: any = _.assign({}, cloudFunctionArgs, { handler: (data: any, context: EventContext) => context });
     let cf = makeCloudFunction(args);
     let test: Event = {
       context: {
@@ -277,9 +278,9 @@ describe('Change', () => {
     });
 
     it('should apply the customizer function to `before` and `after`', () => {
-      function customizer<T>(input) {
+      function customizer<T>(input: any) {
         _.set(input, 'another', 'value');
-        return input;
+        return input as T;
       }
       let created = Change.fromJSON<Object>(
         {

--- a/spec/providers/auth.spec.ts
+++ b/spec/providers/auth.spec.ts
@@ -23,6 +23,7 @@
 import * as auth from '../../src/providers/auth';
 import { expect } from 'chai';
 import * as firebase from 'firebase-admin';
+import { CloudFunction } from '../../src';
 
 describe('Auth Functions', () => {
   describe('AuthBuilder', () => {
@@ -63,9 +64,9 @@ describe('Auth Functions', () => {
     });
 
     describe('#_dataConstructor', () => {
-      let cloudFunctionCreate;
-      let cloudFunctionDelete;
-      let event;
+      let cloudFunctionCreate: CloudFunction<firebase.auth.UserRecord>;
+      let cloudFunctionDelete: CloudFunction<firebase.auth.UserRecord>;
+      let event: any;
 
       before(() => {
         cloudFunctionCreate = auth.user().onCreate((data: firebase.auth.UserRecord) => data);
@@ -82,11 +83,11 @@ describe('Auth Functions', () => {
 
       it('should transform wire format for UserRecord into v5.0.0 format', () => {
         return Promise.all([
-          cloudFunctionCreate(event).then(data => {
+          cloudFunctionCreate(event).then((data: any) => {
             expect(data.metadata.creationTime).to.equal('2016-12-15T19:37:37.059Z');
             expect(data.metadata.lastSignInTime).to.equal('2017-01-01T00:00:00.000Z');
           }),
-          cloudFunctionDelete(event).then(data => {
+          cloudFunctionDelete(event).then((data: any) => {
             expect(data.metadata.creationTime).to.equal('2016-12-15T19:37:37.059Z');
             expect(data.metadata.lastSignInTime).to.equal('2017-01-01T00:00:00.000Z');
           }),
@@ -104,11 +105,11 @@ describe('Auth Functions', () => {
         };
 
         return Promise.all([
-          cloudFunctionCreate(newEvent).then(data => {
+          cloudFunctionCreate(newEvent).then((data: any) => {
             expect(data.metadata.creationTime).to.equal('2016-12-15T19:37:37.059Z');
             expect(data.metadata.lastSignInTime).to.equal('2017-01-01T00:00:00.000Z');
           }),
-          cloudFunctionDelete(newEvent).then(data => {
+          cloudFunctionDelete(newEvent).then((data: any) => {
             expect(data.metadata.creationTime).to.equal('2016-12-15T19:37:37.059Z');
             expect(data.metadata.lastSignInTime).to.equal('2017-01-01T00:00:00.000Z');
           }),
@@ -141,7 +142,7 @@ describe('Auth Functions', () => {
     });
 
     it('will not interfere with fields that are in raw wire data', () => {
-      const raw = {
+      const raw: any = {
         uid: '123',
         email: 'email@gmail.com',
         emailVerified: true,

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -200,7 +200,7 @@ describe('Database Functions', () => {
   });
 
   describe('DataSnapshot', () => {
-    let subject;
+    let subject: any;
     const apps = new appsNamespace.Apps();
 
     let populate = (data: any) => {
@@ -300,7 +300,7 @@ describe('Database Functions', () => {
       it('should iterate through child snapshots', () => {
         populate({ a: 'b', c: 'd' });
         let out = '';
-        subject.forEach(snap => {
+        subject.forEach((snap: any) => {
           out += snap.val();
         });
         expect(out).to.equal('bd');
@@ -309,7 +309,7 @@ describe('Database Functions', () => {
       it('should have correct key values for child snapshots', () => {
         populate({ a: 'b', c: 'd' });
         let out = '';
-        subject.forEach(snap => {
+        subject.forEach((snap: any) => {
           out += snap.key;
         });
         expect(out).to.equal('ac');
@@ -318,7 +318,7 @@ describe('Database Functions', () => {
       it('should not execute for leaf or null nodes', () => {
         populate(23);
         let count = 0;
-        let counter = snap => count++;
+        let counter = (snap: any) => count++;
 
         expect(subject.forEach(counter)).to.equal(false);
         expect(count).to.eq(0);
@@ -327,7 +327,7 @@ describe('Database Functions', () => {
       it('should cancel further enumeration if callback returns true', () => {
         populate({ a: 'b', c: 'd', e: 'f', g: 'h' });
         let out = '';
-        const ret = subject.forEach(snap => {
+        const ret = subject.forEach((snap: any) => {
           if (snap.val() === 'f') {
             return true;
           }
@@ -340,7 +340,7 @@ describe('Database Functions', () => {
       it('should not cancel further enumeration if callback returns a truthy value', () => {
         populate({ a: 'b', c: 'd', e: 'f', g: 'h' });
         let out = '';
-        const ret = subject.forEach(snap => {
+        const ret = subject.forEach((snap: any) => {
           out += snap.val();
           return 1;
         });
@@ -351,7 +351,7 @@ describe('Database Functions', () => {
       it('should not cancel further enumeration if callback does not return', () => {
         populate({ a: 'b', c: 'd', e: 'f', g: 'h' });
         let out = '';
-        const ret = subject.forEach(snap => {
+        const ret = subject.forEach((snap: any) => {
           out += snap.val();
         });
         expect(out).to.equal('bdfh');

--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -24,7 +24,7 @@ import * as firestore from '../../src/providers/firestore';
 import { expect } from 'chai';
 
 describe('Firestore Functions', () => {
-  let constructValue = (fields) => {
+  let constructValue = (fields: any) => {
     return {
       'fields': fields,
       'name': 'projects/pid/databases/(default)/documents/collection/123',
@@ -349,7 +349,7 @@ describe('Firestore Functions', () => {
     });
 
     describe('Other DocumentSnapshot methods', () => {
-      let snapshot;
+      let snapshot: FirebaseFirestore.DocumentSnapshot;
 
       before(() => {
         snapshot = firestore.snapshotConstructor({

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -87,7 +87,7 @@ function runHandler(handler: express.Handler, request: express.Request): Promise
       }
 
       // Headers are only set by the cors handler.
-      public setHeader(name, value: string) {
+      public setHeader(name: string, value: string) {
         this.headers[name] = value;
       }
 
@@ -201,7 +201,7 @@ export function generateIdToken(projectId: string): string {
 }
 
 describe('callable.FunctionBuilder', () => {
-  let app;
+  let app: firebase.app.App;
 
   before(() => {
     let credential = {

--- a/spec/providers/storage.spec.ts
+++ b/spec/providers/storage.spec.ts
@@ -85,7 +85,7 @@ describe('Storage Functions', () => {
             + '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
         };
-        return cloudFunction(goodMediaLinkEvent).then(result => {
+        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -141,7 +141,7 @@ describe('Storage Functions', () => {
               + '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
         };
-        return cloudFunction(goodMediaLinkEvent).then(result => {
+        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -197,7 +197,7 @@ describe('Storage Functions', () => {
               + '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
         };
-        return cloudFunction(goodMediaLinkEvent).then(result => {
+        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -253,7 +253,7 @@ describe('Storage Functions', () => {
               + '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
         };
-        return cloudFunction(goodMediaLinkEvent).then(result => {
+        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -72,7 +72,7 @@ describe ('utils', () => {
 
     it('should return the merged value of two objects', () => {
       let from = {a: {b: 'foo', c: 23, d: 444}, d: {e: 42}};
-      let to = {a: {b: 'bar', c: null}, d: null, e: {f: 'g'}};
+      let to: any = {a: {b: 'bar', c: null}, d: null, e: {f: 'g'}};
       let result = {a: {b: 'bar', d: 444}, e: {f: 'g'}};
       expect(applyChange(from, to)).to.deep.equal(result);
     });

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -83,7 +83,7 @@ export namespace apps {
     }
 
     retain() {
-      let increment = n => {
+      let increment = (n?: number) => {
         return (n || 0) + 1;
       };
       // Increment counter for admin because function might use event.data.ref
@@ -91,7 +91,7 @@ export namespace apps {
     }
 
     release() {
-      let decrement = n => {
+      let decrement = (n: number) => {
         return n - 1;
       };
       return delay(garbageCollectionInterval).then(() => {

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -117,7 +117,7 @@ export namespace Change {
   /** Factory method for creating a Change from a JSON and an optional customizer function to be
    * applied to both the `before` and the `after` fields.
    */
-  export function fromJSON<T>(json: ChangeJson, customizer: (any) => T = reinterpretCast): Change<T> {
+  export function fromJSON<T>(json: ChangeJson, customizer: (x: any) => T = reinterpretCast): Change<T> {
     let before = _.assign({}, json.before);
     if (json.fieldMask) {
       before = applyFieldMask(before, json.after, json.fieldMask);
@@ -126,7 +126,7 @@ export namespace Change {
   }
 
   /** @internal */
-  export function applyFieldMask(sparseBefore, after, fieldMask) {
+  export function applyFieldMask(sparseBefore: any, after: any, fieldMask: string) {
     let before = _.assign({}, after);
     let masks = fieldMask.split(',');
     _.forEach(masks, mask => {
@@ -216,7 +216,7 @@ export function makeCloudFunction<EventData>({
       before(event);
 
       let dataOrChange = dataConstructor(event);
-      let context;
+      let context: any;
       if (isEvent(event)) { // new event format
         context = _.cloneDeep(event.context);
       } else { // legacy event format
@@ -276,7 +276,7 @@ function _makeParams(context: EventContext, triggerResourceGetter: () => string)
   }
   let triggerResource = triggerResourceGetter();
   let wildcards = triggerResource.match(WILDCARD_REGEX);
-  let params = {};
+  let params: { [option: string]: any } = {};
   if (wildcards) {
     let triggerResourceParts = _.split(triggerResource, '/');
     let eventResourceParts = _.split(context.resource.name, '/');

--- a/src/encoder.ts
+++ b/src/encoder.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-export function dateToTimestampProto(timeString) {
+export function dateToTimestampProto(timeString?: string) {
   if (typeof timeString === 'undefined') {
     return;
   }

--- a/src/providers/analytics.ts
+++ b/src/providers/analytics.ts
@@ -346,13 +346,13 @@ export class ExportBundleInfo {
 }
 
 function copyFieldTo<T, K extends keyof T>(
-  from: any, to: T, fromField: string, toField: K, transform: (any) => T[K] = _.identity): void {
+  from: any, to: T, fromField: string, toField: K, transform: (val: any) => T[K] = _.identity): void {
   if (from[fromField] !== undefined) {
     to[toField] = transform(from[fromField]);
   }
 }
 
-function copyField<T, K extends keyof T>(from: any, to: T, field: K, transform: (any) => T[K] = _.identity): void {
+function copyField<T, K extends keyof T>(from: any, to: T, field: K, transform: (val: any) => T[K] = _.identity): void {
   copyFieldTo(from, to, field, field, transform);
 }
 

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -95,7 +95,7 @@ export type UserRecord = firebase.auth.UserRecord;
 
 export function userRecordConstructor(wireData: Object): firebase.auth.UserRecord {
   // Falsey values from the wire format proto get lost when converted to JSON, this adds them back.
-  let falseyValues = {
+  let falseyValues: any = {
     email: null,
     emailVerified: false,
     displayName: null,

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -22,7 +22,7 @@
 
 import * as _ from 'lodash';
 import { apps } from '../apps';
-import { LegacyEvent, CloudFunction, makeCloudFunction, EventContext, Change } from '../cloud-functions';
+import { LegacyEvent, CloudFunction, makeCloudFunction, Event, EventContext, Change } from '../cloud-functions';
 import { normalizePath, applyChange, pathParts, joinPath } from '../utils';
 import * as firebase from 'firebase-admin';
 import { firebaseConfig } from '../config';
@@ -153,7 +153,7 @@ export class RefBuilder {
   private onOperation<T>(
     handler: (data: T, context?: EventContext) => PromiseLike<any> | any,
     eventType: string,
-    dataConstructor): CloudFunction<T> {
+    dataConstructor: (raw: Event | LegacyEvent) => any): CloudFunction<T> {
 
     return makeCloudFunction({
       handler,
@@ -191,7 +191,7 @@ export class RefBuilder {
 
 /* Utility function to extract database reference from resource string */
 /** @internal */
-export function resourceToInstanceAndPath(resource) {
+export function resourceToInstanceAndPath(resource: string) {
   let resourceRegex = `projects/([^/]+)/instances/([^/]+)/refs(/.+)?`;
   let match = resource.match(new RegExp(resourceRegex));
   if (!match) {
@@ -305,14 +305,14 @@ export class DataSnapshot {
   }
 
   /* Recursive function to check if keys are numeric & convert node object to array if they are */
-  private _checkAndConvertToArray(node): any {
+  private _checkAndConvertToArray(node: any): any {
     if (node === null || typeof node === 'undefined') {
       return null;
     }
     if (typeof node !== 'object') {
       return node;
     }
-    let obj = {};
+    let obj: any = {};
     let numKeys = 0;
     let maxKey = 0;
     let allIntegerKeys = true;
@@ -331,7 +331,7 @@ export class DataSnapshot {
 
     if (allIntegerKeys && maxKey < 2 * numKeys) {
       // convert to array.
-      let array = [];
+      let array: any = [];
       _.forOwn(obj, (val, key) => {
         array[key] = val;
       });

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -25,7 +25,7 @@ import * as _ from 'lodash';
 import * as firebase from 'firebase-admin';
 import { apps } from '../apps';
 import { makeCloudFunction, CloudFunction, LegacyEvent, Change,
-  EventContext } from '../cloud-functions';
+  Event, EventContext } from '../cloud-functions';
 import { dateToTimestampProto } from '../encoder';
 
 /** @internal */
@@ -36,7 +36,7 @@ export type DocumentSnapshot = firebase.firestore.DocumentSnapshot;
 
 /** @internal */
 export const defaultDatabase = '(default)';
-let firestoreInstance;
+let firestoreInstance: any;
 
 /** @internal */
 // Multiple databases are not yet supported by Firestore.
@@ -168,7 +168,7 @@ export class DocumentBuilder {
   private onOperation<T>(
     handler: (data: T, context?: EventContext) => PromiseLike<any> | any,
     eventType: string,
-    dataConstructor): CloudFunction<T> {
+    dataConstructor: (raw: Event | LegacyEvent) => any): CloudFunction<T> {
     return makeCloudFunction({
       handler,
       provider,

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -29,7 +29,7 @@ import * as cors from 'cors';
 
 export function onRequest(handler: (req: express.Request, resp: express.Response) => void): HttpsFunction {
   // lets us add __trigger without altering handler:
-  let cloudFunction: any = (req, res) => { handler(req, res); };
+  let cloudFunction: any = (req: express.Request, res: express.Response) => { handler(req, res); };
   cloudFunction.__trigger = {httpsTrigger: {}};
 
   return cloudFunction;
@@ -321,7 +321,7 @@ export function encode(data: any): any {
  * This is exposed only for testing.
  */
 /** @internal */
-export function decode(data: any) {
+export function decode(data: any): any {
   if (data === null) {
     return data;
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,7 +49,7 @@ export function applyChange(src: any, dest: any) {
   return pruneNulls(_.merge({}, src, dest));
 }
 
-export function pruneNulls(obj: Object) {
+export function pruneNulls(obj: any) {
   for (let key in obj) {
     if (obj[key] === null) {
       delete obj[key];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "lib": ["es6"],
     "module": "commonjs",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "outDir": ".tmp",
     "sourceMap": true,
     "target": "es6",


### PR DESCRIPTION
### Description

Activate the `noImplicitAny` flag in TypeScript configurations to be more strict and clear when using types. Add some missing types in the source and test files.

This resolves #213 so no one needs to workaround by disabling `noImplicitAny` or using `skipLibCheck` in their projects.