### PR TITLE
Update firebase-admin in integration tests to v5.12.0

### DIFF
--- a/integration_test/functions/package.json
+++ b/integration_test/functions/package.json
@@ -8,7 +8,7 @@
     "@google-cloud/pubsub": "^0.6.0",
     "@types/lodash": "^4.14.41",
     "firebase": "^4.9.1",
-    "firebase-admin": "~5.10.0",
+    "firebase-admin": "~5.12.0",
     "firebase-functions": "./firebase-functions.tgz",
     "lodash": "^4.17.2"
   },


### PR DESCRIPTION
Updating firebase-admin version in the integration test dependencies to v5.12.0 so that it matches the peer dependency requirement of firebase-functions. This fixes the integration tests.

/cc @laurenzlong for review