### PR TITLE
`context` parameter is no longer optional

### DIFF
--- a/integration_test/functions/src/testing.ts
+++ b/integration_test/functions/src/testing.ts
@@ -2,7 +2,7 @@ import * as firebase from 'firebase-admin';
 import * as _ from 'lodash';
 import { EventContext } from 'firebase-functions';
 
-export type TestCase<T> = (data: T, context?: EventContext) => any
+export type TestCase<T> = (data: T, context: EventContext) => any
 export type TestCaseMap<T> = { [key: string]: TestCase<T> };
 
 export class TestSuite<T> {
@@ -19,7 +19,7 @@ export class TestSuite<T> {
     return this;
   }
 
-  run(testId: string, data: T, context?: EventContext): Promise<void> {
+  run(testId: string, data: T, context: EventContext): Promise<void> {
     let running: Array<Promise<any>> = [];
     for (let testName in this.tests) {
       if (!this.tests.hasOwnProperty(testName)) { continue; }

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -165,7 +165,7 @@ export interface TriggerAnnotated {
 
 /** A Runnable has a `run` method which directly invokes the user-defined function - useful for unit testing. */
 export interface Runnable<T> {
-  run: (data: T, context?: EventContext) => PromiseLike<any> | any;
+  run: (data: T, context: EventContext) => PromiseLike<any> | any;
 }
 
 /**
@@ -189,7 +189,7 @@ export interface MakeCloudFunctionArgs<EventData> {
   triggerResource: () => string;
   service: string;
   dataConstructor?: (raw: Event | LegacyEvent) => EventData;
-  handler: (data: EventData, context?: EventContext) => PromiseLike<any> | any;
+  handler: (data: EventData, context: EventContext) => PromiseLike<any> | any;
   before?: (raw: Event | LegacyEvent) => void;
   after?: (raw: Event | LegacyEvent) => void;
   legacyEventType?: string;

--- a/src/providers/analytics.ts
+++ b/src/providers/analytics.ts
@@ -66,7 +66,7 @@ export class AnalyticsEventBuilder {
    *   Cloud Function you can export.
    */
   onLog(
-    handler: (event: AnalyticsEvent, context?: EventContext) => PromiseLike<any> | any): CloudFunction<AnalyticsEvent> {
+    handler: (event: AnalyticsEvent, context: EventContext) => PromiseLike<any> | any): CloudFunction<AnalyticsEvent> {
     const dataConstructor = (raw: Event) => {
       return new AnalyticsEvent(raw.data);
     };

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -62,17 +62,17 @@ export class UserBuilder {
   constructor(private triggerResource: () => string) { }
 
   /** Respond to the creation of a Firebase Auth user. */
-  onCreate(handler: (user: UserRecord, context?: EventContext) => PromiseLike<any> | any): CloudFunction<UserRecord> {
+  onCreate(handler: (user: UserRecord, context: EventContext) => PromiseLike<any> | any): CloudFunction<UserRecord> {
     return this.onOperation(handler, 'user.create');
   }
 
   /** Respond to the deletion of a Firebase Auth user. */
-  onDelete(handler: (user: UserRecord, context?: EventContext) => PromiseLike<any> | any): CloudFunction<UserRecord> {
+  onDelete(handler: (user: UserRecord, context: EventContext) => PromiseLike<any> | any): CloudFunction<UserRecord> {
     return this.onOperation(handler, 'user.delete');
   }
 
   private onOperation(
-    handler: (user: UserRecord, context?: EventContext) => PromiseLike<any> | any,
+    handler: (user: UserRecord, context: EventContext) => PromiseLike<any> | any,
     eventType: string
   ): CloudFunction<UserRecord> {
     return makeCloudFunction({

--- a/src/providers/crashlytics.ts
+++ b/src/providers/crashlytics.ts
@@ -51,22 +51,22 @@ export class IssueBuilder {
   }
 
   /** Handle Crashlytics New Issue events. */
-  onNew(handler: (issue: Issue, context?: EventContext) => PromiseLike<any> | any): CloudFunction<Issue> {
+  onNew(handler: (issue: Issue, context: EventContext) => PromiseLike<any> | any): CloudFunction<Issue> {
     return this.onEvent(handler, 'issue.new');
   }
 
   /** Handle Crashlytics Regressed Issue events. */
-  onRegressed(handler: (issue: Issue, context?: EventContext) => PromiseLike<any> | any): CloudFunction<Issue> {
+  onRegressed(handler: (issue: Issue, context: EventContext) => PromiseLike<any> | any): CloudFunction<Issue> {
     return this.onEvent(handler, 'issue.regressed');
   }
 
   /** Handle Crashlytics Velocity Alert events. */
-  onVelocityAlert(handler: (issue: Issue, context?: EventContext) => PromiseLike<any> | any): CloudFunction<Issue> {
+  onVelocityAlert(handler: (issue: Issue, context: EventContext) => PromiseLike<any> | any): CloudFunction<Issue> {
     return this.onEvent(handler, 'issue.velocityAlert');
   }
 
   private onEvent(
-    handler: (issue: Issue, context?: EventContext) => PromiseLike<any> | any,
+    handler: (issue: Issue, context: EventContext) => PromiseLike<any> | any,
     eventType: string
   ): CloudFunction<Issue> {
     return makeCloudFunction({

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -103,7 +103,7 @@ export class RefBuilder {
   /** Respond to any write that affects a ref. */
   onWrite(handler: (
     change: Change<DataSnapshot>,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<Change<DataSnapshot>> {
     return this.onOperation(handler, 'ref.write', this.changeConstructor);
   }
@@ -111,7 +111,7 @@ export class RefBuilder {
   /** Respond to update on a ref. */
   onUpdate(handler: (
     change: Change<DataSnapshot>,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<Change<DataSnapshot>> {
     return this.onOperation(handler, 'ref.update', this.changeConstructor);
   }
@@ -119,7 +119,7 @@ export class RefBuilder {
   /** Respond to new data on a ref. */
   onCreate(handler: (
     snapshot: DataSnapshot,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<DataSnapshot> {
     let dataConstructor = (raw: LegacyEvent) => {
       let [dbInstance, path] = resourceToInstanceAndPath(raw.resource);
@@ -136,7 +136,7 @@ export class RefBuilder {
   /** Respond to all data being deleted from a ref. */
   onDelete(handler: (
     snapshot: DataSnapshot,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<DataSnapshot> {
     let dataConstructor = (raw: LegacyEvent) => {
       let [dbInstance, path] = resourceToInstanceAndPath(raw.resource);
@@ -151,7 +151,7 @@ export class RefBuilder {
   }
 
   private onOperation<T>(
-    handler: (data: T, context?: EventContext) => PromiseLike<any> | any,
+    handler: (data: T, context: EventContext) => PromiseLike<any> | any,
     eventType: string,
     dataConstructor: (raw: Event | LegacyEvent) => any): CloudFunction<T> {
 

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -136,7 +136,7 @@ export class DocumentBuilder {
   /** Respond to all document writes (creates, updates, or deletes). */
   onWrite(handler: (
     change: Change<DocumentSnapshot>,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<Change<DocumentSnapshot>> {
     return this.onOperation(handler, 'document.write', changeConstructor);
   };
@@ -144,7 +144,7 @@ export class DocumentBuilder {
   /** Respond only to document updates. */
   onUpdate(handler: (
     change: Change<DocumentSnapshot>,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<Change<DocumentSnapshot>> {
     return this.onOperation(handler, 'document.update', changeConstructor);
   }
@@ -152,7 +152,7 @@ export class DocumentBuilder {
   /** Respond only to document creations. */
   onCreate(handler: (
     snapshot: DocumentSnapshot,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<DocumentSnapshot> {
     return this.onOperation(handler, 'document.create', snapshotConstructor);
   }
@@ -160,13 +160,13 @@ export class DocumentBuilder {
   /** Respond only to document deletions. */
   onDelete(handler: (
     snapshot: DocumentSnapshot,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<DocumentSnapshot> {
     return this.onOperation(handler, 'document.delete', beforeSnapshotConstructor);
   }
 
   private onOperation<T>(
-    handler: (data: T, context?: EventContext) => PromiseLike<any> | any,
+    handler: (data: T, context: EventContext) => PromiseLike<any> | any,
     eventType: string,
     dataConstructor: (raw: Event | LegacyEvent) => any): CloudFunction<T> {
     return makeCloudFunction({

--- a/src/providers/pubsub.ts
+++ b/src/providers/pubsub.ts
@@ -48,7 +48,7 @@ export class TopicBuilder {
   constructor(private triggerResource: () => string) { }
 
   /** Handle a Pub/Sub message that was published to a Cloud Pub/Sub topic */
-  onPublish(handler: (message: Message, context?: EventContext) => PromiseLike<any> | any): CloudFunction<Message> {
+  onPublish(handler: (message: Message, context: EventContext) => PromiseLike<any> | any): CloudFunction<Message> {
     return makeCloudFunction({
       handler,
       provider,

--- a/src/providers/storage.ts
+++ b/src/providers/storage.ts
@@ -75,7 +75,7 @@ export class ObjectBuilder {
   /** Respond to archiving of an object, this is only for buckets that enabled object versioning. */
   onArchive(handler: (
     object: ObjectMetadata,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<ObjectMetadata> {
     return this.onOperation(handler, 'object.archive');
   }
@@ -83,7 +83,7 @@ export class ObjectBuilder {
   /** Respond to the deletion of an object (not to archiving, if object versioning is enabled). */
   onDelete(handler: (
     object: ObjectMetadata,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<ObjectMetadata> {
     return this.onOperation(handler, 'object.delete');
   }
@@ -91,7 +91,7 @@ export class ObjectBuilder {
   /** Respond to the successful creation of an object. */
   onFinalize(handler: (
     object: ObjectMetadata,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<ObjectMetadata> {
     return this.onOperation(handler, 'object.finalize');
   }
@@ -99,13 +99,13 @@ export class ObjectBuilder {
   /** Respond to metadata updates of existing objects. */
   onMetadataUpdate(handler: (
     object: ObjectMetadata,
-    context?: EventContext) => PromiseLike<any> | any,
+    context: EventContext) => PromiseLike<any> | any,
   ): CloudFunction<ObjectMetadata> {
     return this.onOperation(handler, 'object.metadataUpdate');
   }
 
   private onOperation(
-    handler: (object: ObjectMetadata, context?: EventContext) => PromiseLike<any> | any,
+    handler: (object: ObjectMetadata, context: EventContext) => PromiseLike<any> | any,
     eventType: string): CloudFunction<ObjectMetadata> {
     return makeCloudFunction({
       handler,


### PR DESCRIPTION
I've gone through the source code and it looks like `context` is always defined, so I made a type definition more strict.

Sorry that I didn't fit a changelog entry within 80 columns, I didn't know how your helper tools parses these entries so I didn't want to split it into multiple lines.
 
Fixes #227