### PR TITLE
Fix integration test.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
-- '6.11.5'
+- '6.14.0'
+- '8'
 - stable
 sudo: false

--- a/integration_test/firebase.json
+++ b/integration_test/firebase.json
@@ -5,8 +5,5 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
-  },
-  "functions": {
-    "predeploy": "npm --prefix $RESOURCE_DIR run build"
   }
 }

--- a/integration_test/firebase.json
+++ b/integration_test/firebase.json
@@ -5,5 +5,8 @@
   "firestore": {
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
+  },
+  "functions": {
+    "predeploy": "npm --prefix $RESOURCE_DIR run build"
   }
 }

--- a/integration_test/functions/package.json
+++ b/integration_test/functions/package.json
@@ -14,7 +14,7 @@
   },
   "main": "lib/index.js",
   "devDependencies": {
-    "typescript": "^2.0.10"
+    "typescript": "^2.8.3"
   },
   "engines": {
     "node": "8"

--- a/integration_test/functions/package.json
+++ b/integration_test/functions/package.json
@@ -16,8 +16,5 @@
   "devDependencies": {
     "typescript": "^2.8.3"
   },
-  "engines": {
-    "node": "6"
-  },
   "private": true
 }

--- a/integration_test/functions/package.json
+++ b/integration_test/functions/package.json
@@ -8,13 +8,16 @@
     "@google-cloud/pubsub": "^0.6.0",
     "@types/lodash": "^4.14.41",
     "firebase": "^4.9.1",
-    "firebase-admin": "~5.12.0",
+    "firebase-admin": "~5.12.1",
     "firebase-functions": "./firebase-functions.tgz",
     "lodash": "^4.17.2"
   },
   "main": "lib/index.js",
   "devDependencies": {
     "typescript": "^2.0.10"
+  },
+  "engines": {
+    "node": "8"
   },
   "private": true
 }

--- a/integration_test/functions/package.json
+++ b/integration_test/functions/package.json
@@ -17,7 +17,7 @@
     "typescript": "^2.8.3"
   },
   "engines": {
-    "node": "8"
+    "node": "6"
   },
   "private": true
 }

--- a/integration_test/functions/src/auth-tests.ts
+++ b/integration_test/functions/src/auth-tests.ts
@@ -9,12 +9,12 @@ export const createUserTests: any = functions.auth.user().onCreate((u, c) => {
 
   return new TestSuite<UserMetadata>('auth user onCreate')
     .it('should have a project as resource', (user, context) => expectEq(
-      context.resource, `projects/${process.env.GCLOUD_PROJECT}`))
+      context.resource.name, `projects/${process.env.GCLOUD_PROJECT}`))
 
     .it('should not have a path', (user, context) => expectEq((context as any).path, undefined))
 
     .it('should have the correct eventType', (user, context) => expectEq(
-      context.eventType, 'providers/firebase.auth/eventTypes/user.create'))
+      context.eventType, 'google.firebase.auth.user.create'))
 
     .it('should have an eventId', (user, context)=> context.eventId)
 
@@ -33,12 +33,12 @@ export const deleteUserTests: any = functions.auth.user().onDelete((u, c) => {
 
   return new TestSuite<UserMetadata>('auth user onDelete')
     .it('should have a project as resource', (user, context) => expectEq(
-      context.resource, `projects/${process.env.GCLOUD_PROJECT}`))
+      context.resource.name, `projects/${process.env.GCLOUD_PROJECT}`))
 
     .it('should not have a path', (user, context) => expectEq((context as any).path, undefined))
 
     .it('should have the correct eventType', (user, context) => expectEq(
-      context.eventType, 'providers/firebase.auth/eventTypes/user.delete'))
+      context.eventType, 'google.firebase.auth.user.delete'))
 
     .it('should have an eventId', (user, context) => context.eventId)
 

--- a/integration_test/functions/src/database-tests.ts
+++ b/integration_test/functions/src/database-tests.ts
@@ -2,7 +2,6 @@ import * as functions from 'firebase-functions';
 import { TestSuite, expectEq, expectMatches } from './testing';
 import * as admin from 'firebase-admin';
 import DataSnapshot = admin.database.DataSnapshot;
-import { Change } from '../../../src/cloud-functions';
 
 const testIdFieldName = 'testId';
 
@@ -14,7 +13,7 @@ export const databaseTests: any = functions.database.ref('dbTests/{testId}/start
     return;
   }
 
-  return new TestSuite<Change<DataSnapshot>>('database ref onWrite')
+  return new TestSuite<functions.Change<DataSnapshot>>('database ref onWrite')
 
     .it('should not have event.app', (change, context)  => !(context as any).app)
 

--- a/integration_test/functions/src/firestore-tests.ts
+++ b/integration_test/functions/src/firestore-tests.ts
@@ -19,7 +19,7 @@ export const firestoreTests: any = functions.firestore.document('tests/{document
     )
 
     .it('should have the right eventType', (snap, context) => expectEq(
-      context.eventType, 'providers/cloud.firestore/eventTypes/document.create'))
+      context.eventType, 'google.firestore.document.create'))
 
     .it('should have eventId', (snap, context) => context.eventId)
 

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -11,8 +11,9 @@ export * from './firestore-tests';
 export * from './https-tests';
 const numTests = Object.keys(exports).length;  // Assumption: every exported function is its own test.
 
-// Client SDK doesn't support auto initialization:
-firebase.initializeApp(JSON.parse(process.env.FIREBASE_CONFIG));
+import 'firebase-functions'; // temporary shim until process.env.FIREBASE_CONFIG available natively in GCF(BUG 63586213)
+const firebaseConfig = JSON.parse(process.env.FIREBASE_CONFIG);
+firebase.initializeApp(firebaseConfig);
 console.log('initializing admin');
 admin.initializeApp();
 
@@ -21,7 +22,7 @@ function callHttpsTrigger(name: string, data: any) {
   return new Promise((resolve, reject) => {
     const request = https.request({
       method: 'POST',
-      host: 'us-central1-' + functions.config().firebase.projectId + '.cloudfunctions.net',
+      host: 'us-central1-' + firebaseConfig.projectId + '.cloudfunctions.net',
       path: '/' + name,
       headers: {
         'Content-Type': 'application/json',

--- a/integration_test/functions/src/pubsub-tests.ts
+++ b/integration_test/functions/src/pubsub-tests.ts
@@ -19,7 +19,7 @@ export const pubsubTests: any = functions.pubsub.topic('pubsubTests').onPublish(
     .it('should not have a path', (message, context) => expectEq((context as any).path, undefined))
 
     .it('should have the correct eventType', (message, context) => expectEq(
-      context.eventType, 'providers/cloud.pubsub/eventTypes/topic.publish'))
+      context.eventType, 'google.pubsub.topic.publish'))
 
     .it('should have an eventId', (message, context) => context.eventId)
 

--- a/integration_test/functions/src/testing.ts
+++ b/integration_test/functions/src/testing.ts
@@ -2,7 +2,7 @@ import * as firebase from 'firebase-admin';
 import * as _ from 'lodash';
 import { EventContext } from 'firebase-functions';
 
-export type TestCase<T> = (data: T, context: EventContext) => any
+export type TestCase<T> = (data: T, context?: EventContext) => any
 export type TestCaseMap<T> = { [key: string]: TestCase<T> };
 
 export class TestSuite<T> {
@@ -19,7 +19,7 @@ export class TestSuite<T> {
     return this;
   }
 
-  run(testId: string, data: T, context: EventContext): Promise<void> {
+  run(testId: string, data: T, context?: EventContext): Promise<void> {
     let running: Array<Promise<any>> = [];
     for (let testName in this.tests) {
       if (!this.tests.hasOwnProperty(testName)) { continue; }

--- a/integration_test/functions/tsconfig.json
+++ b/integration_test/functions/tsconfig.json
@@ -1,9 +1,6 @@
 {
   "compilerOptions": {
-    "lib": [
-      "es6",
-      "es2015.promise"
-    ],
+    "lib": ["es6"],
     "module": "commonjs",
     "target": "es6",
     "noImplicitAny": false,

--- a/package.json
+++ b/package.json
@@ -61,8 +61,5 @@
     "jsonwebtoken": "^8.2.1",
     "lodash": "^4.6.1"
   },
-  "engines": {
-    "node": ">=6.0.0"
-  },
   "typings": "lib/index.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "nock": "^9.0.0",
     "sinon": "^1.17.4",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.3"
+    "typescript": "^2.8.3"
   },
   "peerDependencies": {
     "firebase-admin": "~5.12.1"

--- a/package.json
+++ b/package.json
@@ -61,5 +61,8 @@
     "jsonwebtoken": "^8.2.1",
     "lodash": "^4.6.1"
   },
+  "engines": {
+    "node": ">=6.0.0"
+  },
   "typings": "lib/index.d.ts"
 }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

In fixing a TS error in the integration test, I discovered that post-1.0, our integration test was actually not testing anything. Due to the line `import { Change } from '../../../src/cloud-functions';` that VSCode automatically added to the file `integration_test/functions/src/database-tests.ts` when I used the variable `Change`, `integration_test/lib` actually had the same directory structure as the entire `firebase-functions` folder, instead of `integration_test/src`. This led to no functions being deployed during the "create" and "update" stages of the test, leading to false passing. This PR fixes the error. 

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->