### PR TITLE
Make `context` argument in `run` optional again

### DIFF
--- a/integration_test/functions/src/testing.ts
+++ b/integration_test/functions/src/testing.ts
@@ -19,7 +19,7 @@ export class TestSuite<T> {
     return this;
   }
 
-  run(testId: string, data: T, context: EventContext): Promise<void> {
+  run(testId: string, data: T, context?: EventContext): Promise<void> {
     let running: Array<Promise<any>> = [];
     for (let testName in this.tests) {
       if (!this.tests.hasOwnProperty(testName)) { continue; }


### PR DESCRIPTION
This fixes https-tests in integration_test. An HTTP-triggered function takes only one argument and passes it to `run` so the `context` argument cannot be required in this case.