### PR TITLE
Pass request headers to CallableContext

### DIFF
--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -443,6 +443,27 @@ describe('callable.FunctionBuilder', () => {
         },
       });
     });
+
+    it('should handle headers', async () => {
+      const mockRequest = request(null, 'application/json', {});
+      await runTest({
+        httpRequest: mockRequest,
+        expectedData: null,
+        callableFunction: (data, context) => {
+          expect(context.auth).to.be.undefined;
+          expect(context.headers).to.not.be.undefined;
+          expect(context.headers).to.equal(mockRequest.headers);
+          expect(context.instanceIdToken).to.be.undefined;
+          return null;
+        },
+        expectedHttpResponse: {
+          status: 200,
+          headers: expectedResponseHeaders,
+          body: {result: null},
+        },
+      });
+    });
+
   });
 });
 

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -26,6 +26,7 @@ import * as firebase from 'firebase-admin';
 import { apps } from '../apps';
 import * as _ from 'lodash';
 import * as cors from 'cors';
+import {IncomingHttpHeaders} from 'http';
 
 export function onRequest(handler: (req: express.Request, resp: express.Response) => void): HttpsFunction {
   // lets us add __trigger without altering handler:
@@ -214,6 +215,11 @@ export interface CallableContext {
   };
 
   /**
+   * Incoming headers.
+   */
+  headers: IncomingHttpHeaders;
+
+  /**
    * An unverified token for a Firebase Instance ID.
    */
   instanceIdToken?: string;
@@ -373,7 +379,7 @@ export function onCall(
         throw new HttpsError('invalid-argument', 'Bad Request');
       }
 
-      const context: CallableContext = {};
+      const context: CallableContext = { headers: req.headers };
 
       const authorization = req.header('Authorization');
       if (authorization) {


### PR DESCRIPTION
### Description

The purpose of this PR is to make the headers of the request handled by an HTTPS Callable accessible to API users by passing request headers to `CallableContext`.

Getting access to headers is convenient for several use cases. For instance, retrieving the IP of the client invoking the callable (`x-forwarded-for`), detecting client language (`accept-language`), etc. 

### Code sample

Here is how to use the new property:

```
functions.https.onCall(async (data, context) => {
    const clientIp = context.headers['x-forwarded-for'];
    // ...
});
```