### PR TITLE
Pass the raw Express request to CallableContext

### DIFF
--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -443,6 +443,24 @@ describe('callable.FunctionBuilder', () => {
         },
       });
     });
+
+    it('should expose raw request', async () => {
+      const mockRequest = request(null, 'application/json', {});
+      await runTest({
+        httpRequest: mockRequest,
+        expectedData: null,
+        callableFunction: (data, context) => {
+          expect(context.rawRequest).to.not.be.undefined;
+          expect(context.rawRequest).to.equal(mockRequest);
+          return null;
+        },
+        expectedHttpResponse: {
+          status: 200,
+          headers: expectedResponseHeaders,
+          body: {result: null},
+        },
+      });
+    });
   });
 });
 

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -217,6 +217,11 @@ export interface CallableContext {
    * An unverified token for a Firebase Instance ID.
    */
   instanceIdToken?: string;
+
+  /**
+   * The raw request handled by the callable.
+   */
+  rawRequest: express.Request;
 }
 
 // The allowed interface for an http request for a callable function.
@@ -373,7 +378,7 @@ export function onCall(
         throw new HttpsError('invalid-argument', 'Bad Request');
       }
 
-      const context: CallableContext = {};
+      const context: CallableContext = { rawRequest: req };
 
       const authorization = req.header('Authorization');
       if (authorization) {


### PR DESCRIPTION
This PR generalizes what was originally proposed in #262. 

Here is a summary of the spec shared by laurenzlong:

> The approved API is to add a field to CallableContext called "rawRequest", which would be the type "express.Request", and it would be the entire HTTP request. Let me know if you have any questions or need any help.
