### PR TITLE
Fix failing unit test due to new Firestore SDK

### DIFF
--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -494,10 +494,6 @@ describe('Firestore Functions', () => {
       });
 
       it('should support #ref', () => {
-        expect(Object.keys(snapshot.ref)).to.deep.equal([
-          '_firestore',
-          '_referencePath',
-        ]);
         expect(snapshot.ref.path).to.equal('collection/123');
       });
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Due to a new update in the firestore SDK, the keys for "snapshot.ref" now has an additional field called "_validator", which was causing the unit test to fail. Since it's not good to rely on the implementation of the ref object anyhow, I removed that line altogether. 

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->