### PR TITLE
Update firebase-admin in integration tests to v6.0.0

### DIFF
--- a/integration_test/package.node6.json
+++ b/integration_test/package.node6.json
@@ -8,7 +8,7 @@
     "@google-cloud/pubsub": "~0.19.0",
     "@types/google-cloud__pubsub": "^0.18.0",
     "@types/lodash": "~4.14.41",
-    "firebase-admin": "~5.13.0",
+    "firebase-admin": "~6.0.0",
     "firebase-functions": "./firebase-functions.tgz",
     "lodash": "~4.17.2"
   },

--- a/integration_test/package.node8.json
+++ b/integration_test/package.node8.json
@@ -8,7 +8,7 @@
     "@google-cloud/pubsub": "~0.19.0",
     "@types/google-cloud__pubsub": "^0.18.0",
     "@types/lodash": "~4.14.41",
-    "firebase-admin": "~5.13.0",
+    "firebase-admin": "~6.0.0",
     "firebase-functions": "./firebase-functions.tgz",
     "lodash": "~4.17.2"
   },


### PR DESCRIPTION
Updating firebase-admin version in the integration test dependencies to v5.12.0 so that it matches the peer dependency requirement of firebase-functions. This fixes the integration tests.

/cc @laurenzlong for review