### PR TITLE
adding errors for invalid region and timeoutSeconds values

### DIFF
--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -35,11 +35,11 @@ describe('FunctionBuilder', () => {
 
   it('should allow region to be set', () => {
     let fn = functions
-      .region('my-region')
+      .region('us-east1')
       .auth.user()
       .onCreate(user => user);
 
-    expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+    expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
   });
 
   // it('should allow multiple regions to be set', () => {
@@ -69,7 +69,7 @@ describe('FunctionBuilder', () => {
 
   it('should allow both region and runtime options to be set', () => {
     let fn = functions
-      .region('my-region')
+      .region('us-east1')
       .runWith({
         timeoutSeconds: 90,
         memory: '256MB',
@@ -77,7 +77,7 @@ describe('FunctionBuilder', () => {
       .auth.user()
       .onCreate(user => user);
 
-    expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+    expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
     expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
     expect(fn.__trigger.timeout).to.deep.equal('90s');
   });
@@ -88,11 +88,11 @@ describe('FunctionBuilder', () => {
         timeoutSeconds: 90,
         memory: '256MB',
       })
-      .region('my-region')
+      .region('us-east1')
       .auth.user()
       .onCreate(user => user);
 
-    expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+    expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
     expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
     expect(fn.__trigger.timeout).to.deep.equal('90s');
   });
@@ -105,9 +105,36 @@ describe('FunctionBuilder', () => {
     }).to.throw(Error);
 
     expect(() => {
-      return functions.region('some-region').runWith({
+      return functions.region('us-east1').runWith({
         memory: 'unsupported',
       } as any);
     }).to.throw(Error);
   });
+
+  it('should throw an error if user chooses an invalid timeoutSeconds', () => {
+    expect(() => {
+      return functions.runWith({
+        timeoutSeconds: 1000000,
+      } as any);
+    }).to.throw(Error);
+
+    expect(() => {
+      return functions.region('us-east1').runWith({
+        timeoutSeconds: 1000000,
+      } as any);
+    }).to.throw(Error);
+  });
+
+  it('should throw an error if user chooses an invalid region', () => {
+    expect(() => {
+      return functions.region('unsupported');
+    }).to.throw(Error);
+
+    expect(() => {
+      return functions.region('unsupported').runWith({
+        timeoutSeconds: 500,
+      } as any);
+    }).to.throw(Error);
+  });
+  
 });

--- a/spec/providers/analytics.spec.ts
+++ b/spec/providers/analytics.spec.ts
@@ -38,7 +38,7 @@ describe('Analytics Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -46,7 +46,7 @@ describe('Analytics Functions', () => {
         .analytics.event('event')
         .onLog(event => event);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/auth.spec.ts
+++ b/spec/providers/auth.spec.ts
@@ -40,7 +40,7 @@ describe('Auth Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -48,7 +48,7 @@ describe('Auth Functions', () => {
         .auth.user()
         .onCreate(() => null);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/crashlytics.spec.ts
+++ b/spec/providers/crashlytics.spec.ts
@@ -40,7 +40,7 @@ describe('Crashlytics Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -48,7 +48,7 @@ describe('Crashlytics Functions', () => {
         .crashlytics.issue()
         .onNew(issue => issue);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -44,7 +44,7 @@ describe('Database Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -52,7 +52,7 @@ describe('Database Functions', () => {
         .database.ref('/')
         .onCreate(snap => snap);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -122,7 +122,7 @@ describe('Firestore Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -130,7 +130,7 @@ describe('Firestore Functions', () => {
         .firestore.document('doc')
         .onCreate(snap => snap);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/https.spec.ts
+++ b/spec/providers/https.spec.ts
@@ -42,14 +42,14 @@ describe('CloudHttpsBuilder', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
         })
         .https.onRequest(() => null);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });
@@ -508,14 +508,14 @@ describe('callable.FunctionBuilder', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
         })
         .https.onCall(() => null);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/pubsub.spec.ts
+++ b/spec/providers/pubsub.spec.ts
@@ -73,7 +73,7 @@ describe('Pubsub Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -81,7 +81,7 @@ describe('Pubsub Functions', () => {
         .pubsub.topic('toppy')
         .onPublish(() => null);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/remoteConfig.spec.ts
+++ b/spec/providers/remoteConfig.spec.ts
@@ -87,14 +87,14 @@ describe('RemoteConfig Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       const cloudFunction = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
         })
         .remoteConfig.onUpdate(() => null);
 
-      expect(cloudFunction.__trigger.regions).to.deep.equal(['my-region']);
+      expect(cloudFunction.__trigger.regions).to.deep.equal(['us-east1']);
       expect(cloudFunction.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(cloudFunction.__trigger.timeout).to.deep.equal('90s');
     });

--- a/spec/providers/storage.spec.ts
+++ b/spec/providers/storage.spec.ts
@@ -38,7 +38,7 @@ describe('Storage Functions', () => {
 
     it('should allow both region and runtime options to be set', () => {
       let fn = functions
-        .region('my-region')
+        .region('us-east1')
         .runWith({
           timeoutSeconds: 90,
           memory: '256MB',
@@ -46,7 +46,7 @@ describe('Storage Functions', () => {
         .storage.object()
         .onArchive(() => null);
 
-      expect(fn.__trigger.regions).to.deep.equal(['my-region']);
+      expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
       expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
       expect(fn.__trigger.timeout).to.deep.equal('90s');
     });

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -40,13 +40,23 @@ import { CloudFunction, EventContext, HttpsFunction } from './cloud-functions';
  * For example: `functions.region('us-east1')`
  */
 export function region(region: string) {
+  if (
+    !_.includes(
+      ['us-central1', 'us-east1', 'europe-west1', 'asia-northeast1'],
+      region
+    )
+  ) {
+    throw new Error(
+      "The only valid regions are 'us-central1', 'us-east1', 'europe-west1', and 'asia-northeast1'"
+    );
+  }
   return new FunctionBuilder({ regions: [region] });
 }
 
 /**
  * Configure runtime options for the function.
  * @param runtimeOptions Object with 2 optional fields:
- * 1. `timeoutSeconds`: timeout for the function in seconds.
+ * 1. `timeoutSeconds`: timeout for the function in seconds, possible values are 0 to 540
  * 2. `memory`: amount of memory to allocate to the function,
  *    possible values are:  '128MB', '256MB', '512MB', '1GB', and '2GB'.
  */
@@ -63,6 +73,13 @@ export function runWith(runtimeOptions: {
   ) {
     throw new Error(
       "The only valid memory allocation values are: '128MB', '256MB', '512MB', '1GB', and '2GB'"
+    );
+  }
+  if (
+    runtimeOptions.timeoutSeconds > 540 || runtimeOptions.timeoutSeconds < 0
+  ) {
+    throw new Error(
+      "TimeoutSeconds must be between 0 and 540" 
     );
   }
   return new FunctionBuilder(runtimeOptions);
@@ -90,7 +107,7 @@ export class FunctionBuilder {
   /**
    * Configure runtime options for the function.
    * @param runtimeOptions Object with 2 optional fields:
-   * 1. timeoutSeconds: timeout for the function in seconds.
+   * 1. timeoutSeconds: timeout for the function in seconds, possible values are 0 to 540
    * 2. memory: amount of memory to allocate to the function, possible values are:
    * '128MB', '256MB', '512MB', '1GB', and '2GB'.
    */
@@ -107,6 +124,13 @@ export class FunctionBuilder {
     ) {
       throw new Error(
         "The only valid memory allocation values are: '128MB', '256MB', '512MB', '1GB', and '2GB'"
+      );
+    }
+    if (
+      runtimeOptions.timeoutSeconds > 540 || runtimeOptions.timeoutSeconds < 0
+    ) {
+      throw new Error(
+        "TimeoutSeconds must be between 0 and 540" 
       );
     }
     this.options = _.assign(this.options, runtimeOptions);


### PR DESCRIPTION
### Description
Adds errors when invalid values are passed to functions.runWith or functions.region

Internal bug reference: 115062564