### PR TITLE
Update https types in function builder

### DIFF
--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -32,7 +32,7 @@ import * as https from './providers/https';
 import * as pubsub from './providers/pubsub';
 import * as remoteConfig from './providers/remoteConfig';
 import * as storage from './providers/storage';
-import { CloudFunction, EventContext, HttpsFunction } from './cloud-functions';
+import { CloudFunction, EventContext } from './cloud-functions';
 
 /**
  * Configure the regions that the function is deployed to.
@@ -122,7 +122,7 @@ export class FunctionBuilder {
        */
       onRequest: (
         handler: (req: express.Request, resp: express.Response) => void
-      ) => https._onRequestWithOpts(handler, this.options) as HttpsFunction,
+      ) => https._onRequestWithOpts(handler, this.options),
       /**
        * Declares a callable method for clients to call using a Firebase SDK.
        * @param handler A method that takes a data and context and returns a value.
@@ -132,7 +132,7 @@ export class FunctionBuilder {
           data: any,
           context: https.CallableContext
         ) => any | Promise<any>
-      ) => https._onCallWithOpts(handler, this.options) as HttpsFunction,
+      ) => https._onCallWithOpts(handler, this.options),
     };
   }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

Addresses https://github.com/firebase/firebase-functions/issues/369.

Function builder was casting https `onCall` and `onRequest` to `HttpsFunction`. Remove these since they can be inferred in typescript (`HttpsFunction & Runnable<any>` and `HttpsFunction` respectively).


<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->