### PR TITLE
Makes message param required, per Google Cloud standards

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -164,7 +164,7 @@ export class HttpsError extends Error {
    */
   readonly details?: any;
 
-  constructor(code: FunctionsErrorCode, message?: string, details?: any) {
+  constructor(code: FunctionsErrorCode, message: string, details?: any) {
     super(message);
 
     // This is a workaround for a bug in TypeScript when extending Error:


### PR DESCRIPTION
### Description
Makes the Message param of HttpsError required, to line up with Google Cloud standards/
Addresses #350 
Relevant cloud docs: https://firebase.google.com/docs/functions/callable-reference#response_body