### PR TITLE
Add validation on instance name

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+added - validation on instance name for realtime database triggers

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -245,6 +245,24 @@ describe('Database Functions', () => {
       expect(instance).to.equal('https://foo.firebaseio.com');
       expect(path).to.equal('/bar');
     });
+
+    it('should throw an error if the given instance name contains anything except alphanumerics and dashes', () => {
+      expect(() => {
+        return database.resourceToInstanceAndPath(
+          'projects/_/instances/a.bad.name/refs/bar'
+        );
+      }).to.throw(Error)
+      expect(() => {
+        return database.resourceToInstanceAndPath(
+          'projects/_/instances/a_different_bad_name/refs/bar'
+        );
+      }).to.throw(Error)
+      expect(() => {
+        return database.resourceToInstanceAndPath(
+          'projects/_/instances/BAD!!!!/refs/bar'
+        );
+      }).to.throw(Error)
+    });
   });
 
   describe('DataSnapshot', () => {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -240,7 +240,7 @@ export class RefBuilder {
 /* Utility function to extract database reference from resource string */
 /** @internal */
 export function resourceToInstanceAndPath(resource: string) {
-  let resourceRegex = `projects/([^/]+)/instances/([^/]+)/refs(/.+)?`;
+  let resourceRegex = `projects/([^/]+)/instances/([a-zA-Z0-9\-^/]+)/refs(/.+)?`;
   let match = resource.match(new RegExp(resourceRegex));
   if (!match) {
     throw new Error(


### PR DESCRIPTION
### Description
Adds validation on instance names of functions.database() functions, since GCF doesn't allow instance names with characters other than alphanumerics or dashes.
Addresses internal bug 111292940