### PR TITLE
Allow functions to deploy to multiple regions

### DIFF
--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -42,17 +42,17 @@ describe('FunctionBuilder', () => {
     expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
   });
 
-  // it('should allow multiple regions to be set', () => {
-  //   let fn = functions
-  //     .region('my-region', 'my-other-region')
-  //     .auth.user()
-  //     .onCreate(user => user);
+  it('should allow multiple regions to be set', () => {
+    let fn = functions
+      .region('us-east1', 'us-central1')
+      .auth.user()
+      .onCreate(user => user);
 
-  //   expect(fn.__trigger.regions).to.deep.equal([
-  //     'my-region',
-  //     'my-other-region',
-  //   ]);
-  // });
+    expect(fn.__trigger.regions).to.deep.equal([
+      'us-east1',
+      'us-central1',
+    ]);
+  });
 
   it('should allow runtime options to be set', () => {
     let fn = functions
@@ -132,6 +132,28 @@ describe('FunctionBuilder', () => {
 
     expect(() => {
       return functions.region('unsupported').runWith({
+        timeoutSeconds: 500,
+      } as any);
+    }).to.throw(Error);
+
+    expect(() => {
+      return functions.region('unsupported', 'us-east1');
+    }).to.throw(Error);
+
+    expect(() => {
+      return functions.region('unsupported', 'us-east1').runWith({
+        timeoutSeconds: 500,
+      } as any);
+    }).to.throw(Error);
+  });
+
+  it('should throw an error if user chooses no region when using .region()', () => {
+    expect(() => {
+      return functions.region();
+    }).to.throw(Error);
+
+    expect(() => {
+      return functions.region().runWith({
         timeoutSeconds: 500,
       } as any);
     }).to.throw(Error);

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -36,23 +36,29 @@ import { CloudFunction, EventContext } from './cloud-functions';
 
 /**
  * Configure the regions that the function is deployed to.
- * @param region Region string.
- * For example: `functions.region('us-east1')`
+ * @param regions One of more region strings.
+ * For example: `functions.region('us-east1') or functions.region('us-east1', 'us-central1')`
  */
-export function region(region: string) {
-  if (
-    !_.includes(
-      ['us-central1', 'us-east1', 'europe-west1', 'asia-northeast1'],
-      region
-    )
-  ) {
+export function region(...regions: string[]) {
+  if (!regions.length) {
     throw new Error(
-      "The only valid regions are 'us-central1', 'us-east1', 'europe-west1', and 'asia-northeast1'"
+      "You must specify at least one region"
     );
   }
-  return new FunctionBuilder({ regions: [region] });
+  regions.forEach((region) => {
+    if (
+      !_.includes(
+        ['us-central1', 'us-east1', 'europe-west1', 'asia-northeast1'],
+        region
+      )
+    ) {
+      throw new Error(
+        "The only valid regions are 'us-central1', 'us-east1', 'europe-west1', and 'asia-northeast1'"
+      );
+    }
+  });
+  return new FunctionBuilder({ regions });
 }
-
 /**
  * Configure runtime options for the function.
  * @param runtimeOptions Object with 2 optional fields:
@@ -96,11 +102,11 @@ export class FunctionBuilder {
 
   /**
    * Configure the regions that the function is deployed to.
-   * @param region Region string.
-   * For example: `functions.region('us-east1')`
+   * @param regions One or more region strings.
+   * For example: `functions.region('us-east1')  or functions.region('us-east1', 'us-central1')`
    */
-  region = (region: string) => {
-    this.options.regions = [region];
+  region = (...regions: string[]) => {
+    this.options.regions = regions;
     return this;
   };
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -45,18 +45,16 @@ export function region(...regions: string[]) {
       "You must specify at least one region"
     );
   }
-  regions.forEach((region) => {
-    if (
-      !_.includes(
-        ['us-central1', 'us-east1', 'europe-west1', 'asia-northeast1'],
-        region
-      )
-    ) {
-      throw new Error(
-        "The only valid regions are 'us-central1', 'us-east1', 'europe-west1', and 'asia-northeast1'"
-      );
-    }
-  });
+  if (
+    _.difference(
+      regions,
+      ['us-central1', 'us-east1', 'europe-west1', 'asia-northeast1']
+    ).length
+  ) {
+    throw new Error(
+      "The only valid regions are 'us-central1', 'us-east1', 'europe-west1', and 'asia-northeast1'"
+    );
+  }
   return new FunctionBuilder({ regions });
 }
 /**

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -37,7 +37,7 @@ import { CloudFunction, EventContext } from './cloud-functions';
 /**
  * Configure the regions that the function is deployed to.
  * @param regions One of more region strings.
- * For example: `functions.region('us-east1') or functions.region('us-east1', 'us-central1')`
+ * For example: `functions.region('us-east1')` or `functions.region('us-east1', 'us-central1')`
  */
 export function region(...regions: string[]) {
   if (!regions.length) {
@@ -101,7 +101,7 @@ export class FunctionBuilder {
   /**
    * Configure the regions that the function is deployed to.
    * @param regions One or more region strings.
-   * For example: `functions.region('us-east1')  or functions.region('us-east1', 'us-central1')`
+   * For example: `functions.region('us-east1')`  or `functions.region('us-east1', 'us-central1')`
    */
   region = (...regions: string[]) => {
     this.options.regions = regions;


### PR DESCRIPTION
### Description
Allows users to deploy a function to multiple regions by passing extra region strings to .region()
Addresses #317 and internal bug ref: 122527860

### Code sample
functions.region('us-east1', 'us-central1').https(...)