### PR TITLE
fixes error during tsc

### DIFF
--- a/src/providers/analytics.ts
+++ b/src/providers/analytics.ts
@@ -396,7 +396,7 @@ export class ExportBundleInfo {
 function copyFieldTo<T, K extends keyof T>(
   from: any,
   to: T,
-  fromField: string | number | symbol,
+  fromField: string,
   toField: K,
   transform: (val: any) => T[K] = _.identity
 ): void {
@@ -411,7 +411,7 @@ function copyField<T, K extends keyof T>(
   field: K,
   transform: (val: any) => T[K] = _.identity
 ): void {
-  copyFieldTo(from, to, field, field, transform);
+  copyFieldTo(from, to, field as string, field, transform);
 }
 
 function copyFields<T, K extends keyof T>(from: any, to: T, fields: K[]): void {

--- a/src/providers/analytics.ts
+++ b/src/providers/analytics.ts
@@ -396,7 +396,7 @@ export class ExportBundleInfo {
 function copyFieldTo<T, K extends keyof T>(
   from: any,
   to: T,
-  fromField: string,
+  fromField: string | number | symbol,
   toField: K,
   transform: (val: any) => T[K] = _.identity
 ): void {


### PR DESCRIPTION
### Description
In master, when you run tsc, there is an error because field, which infers to type string | number | symbol, isn't a valid for a param of type string.

Additonaly, it seems like 'fromField' is meant to represent the valid types for the key of an object, so excluding number and symbol was an oversight