### PR TITLE
Improving stability and speed of intergration tests

### DIFF
--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -148,7 +148,7 @@ export const integrationTests: any = functions
       })
       .then(() => {
         console.log('All tests pass!');
-        resp.status(200).send('PASS');
+        resp.status(200).send('PASS \n');
       })
       .catch(err => {
         console.log(`Some tests failed: ${err}`);

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -77,7 +77,7 @@ function deploy {
   # Deploy functions, and security rules for database and Firestore
   firebase deploy --project=$PROJECT_ID --only functions,database,firestore || \
   firebase deploy --project=$PROJECT_ID --only functions,database,firestore || \
-  firebase deploy --project=$PROJECT_ID --only functions,database,firestore ## TODO: try using $() and sed to parse echo to find the printed deploy the rest text
+for i in 1 2 3; do firebase deploy --project=$PROJECT_ID --only functions,database,firestore && break; done
 }
 
 # At the moment, functions take 30-40 seconds AFTER firebase deploy returns successfully to go live

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -75,12 +75,14 @@ function deploy {
   cd $DIR
   ./functions/node_modules/.bin/tsc -p functions/
   # Deploy functions, and security rules for database and Firestore
-  firebase deploy --project=$PROJECT_ID --only functions,database,firestore
+  firebase deploy --project=$PROJECT_ID --only functions,database,firestore || \
+  firebase deploy --project=$PROJECT_ID --only functions,database,firestore || \
+  firebase deploy --project=$PROJECT_ID --only functions,database,firestore ## TODO: try using $() and sed to parse echo to find the printed deploy the rest text
 }
 
-# At the moment, functions take 30-40 seconds AFTER firebase dpeloy return successfully to go live
+# At the moment, functions take 30-40 seconds AFTER firebase deploy returns successfully to go live
 # This needs to be fixed separately
-# However, so that we have workign integration tests in the interim, waitForPropagation is a workaround
+# However, so that we have working integration tests in the interim, waitForPropagation is a workaround
 function waitForPropagation {
   announce "Waiting 50 seconds for functions changes to propagate"
   sleep 50


### PR DESCRIPTION
### Description

- Integration tests now wait 50 seconds after deploying to ensure that function changes propagate
- Intergration tests now retry deployment 2 times in the case of failure
- integration_tests/run_tests.sh now can be given 2 project ids, and will run node6 and node8 tests in parallel on the 2 different projects.

### Code sample

./run_tests.sh project1 project2 // runs node6 tests on project1 and node8 tests on project2, in parallel
./run_tests.sh projectId // runs node6 and node8 tests on projectId, in series