### PR TITLE
Allow storage bucket url and database url to be explicitly defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,8 @@ if (!process.env.FIREBASE_CONFIG) {
       'Warning, estimating Firebase Config based on GCLOUD_PROJECT. Initializing firebase-admin may fail'
     );
     process.env.FIREBASE_CONFIG = JSON.stringify({
-      databaseURL: `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`,
-      storageBucket: `${process.env.GCLOUD_PROJECT}.appspot.com`,
+      databaseURL: `${process.env.DATABASE_URL}` || `https://${process.env.GCLOUD_PROJECT}.firebaseio.com`,
+      storageBucket: `${process.env.STORAGE_BUCKET_URL}` || `${process.env.GCLOUD_PROJECT}.appspot.com`,
       projectId: process.env.GCLOUD_PROJECT,
     });
   } else {


### PR DESCRIPTION
### Description
When running the integration tests, GCF needed to be able to configure the storageBucket to something other than the default. This enables them to do so by setting the environment variable STORAGE_BUCKET_URL (and also, to set the database url  by using DATABASE_URL)
### Code sample
 export STORAGE_BUCKET_URL = "blah.com"
./run_tests.sh