### PR TITLE
Add issue template metadata for the OSS bot

### DIFF
--- a/.github/ISSUE_TEMPLATE/---feature-request.md
+++ b/.github/ISSUE_TEMPLATE/---feature-request.md
@@ -7,6 +7,10 @@ labels: ''
 assignees: ''
 
 ---
+<!-- DO NOT DELETE 
+validate_template=false
+template_path=.github/ISSUE_TEMPLATE/---feature-request.md
+-->
 
 <!--
 Thank you for contributing to the Firebase community!

--- a/.github/ISSUE_TEMPLATE/---report-a-bug.md
+++ b/.github/ISSUE_TEMPLATE/---report-a-bug.md
@@ -6,6 +6,11 @@ labels: ''
 assignees: ''
 
 ---
+<!-- DO NOT DELETE 
+validate_template=true
+template_path=.github/ISSUE_TEMPLATE/---report-a-bug.md
+-->
+
 ### Related issues
 
 <!-- Are there any related firebase-functions issues that you found on this topic before deciding to open a new issue? Please link them here-->


### PR DESCRIPTION
The OSS bot was failing to validate issue templates because it was looking for `.github/ISSUE_TEMPLATE.md` which doesn't exist.

Adding this to the top of the template lets the bot work backwards from the issue text to the original template (since the GitHub API does not preserve that information).

I will also submit a PR to the bot to be more resilient to this failure.