### PR TITLE
Improve types of the `Change` class

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - improved types of the `Change` class to describe both `before` and `after` fields as non-optional

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -90,7 +90,7 @@ export interface EventContext {
  * to the event, "after" represents the state after the event.
  */
 export class Change<T> {
-  constructor(public before?: T, public after?: T) {}
+  constructor(public before: T, public after: T) {}
 }
 
 /** ChangeJson is the JSON format used to construct a Change object. */


### PR DESCRIPTION
Both `before` and `after` fields are now described as non-optional.

Resolves #402 

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

Fixes invalid typings of `before` and `after` fields of the `Change` class according to the specification. See #402 for context.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

This change does not expose any new APIs, only fixes an interface of the existing one. It's a non-breaking change since it tightens the interface, so any existing projects should compile just fine.