### PR TITLE
Toggling off remote config tests, toggling on storage tests, fixing https tests

### DIFF
--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -12,8 +12,8 @@ export * from './database-tests';
 export * from './auth-tests';
 export * from './firestore-tests';
 export * from './https-tests';
-export * from './remoteConfig-tests';
-// export * from './storage-tests';
+// export * from './remoteConfig-tests';
+export * from './storage-tests';
 const numTests = Object.keys(exports).length; // Assumption: every exported function is its own test.
 
 import 'firebase-functions'; // temporary shim until process.env.FIREBASE_CONFIG available natively in GCF(BUG 63586213)

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -26,7 +26,7 @@ function callHttpsTrigger(name: string, data: any) {
     const request = https.request(
       {
         method: 'POST',
-        host: 'us-central1-' + firebaseConfig.projectId + '.' + firebaseConfig.baseUrl,
+        host: 'us-central1-' + firebaseConfig.projectId + '.' + firebaseConfig.test.test_domain,
         path: '/' + name,
         headers: {
           'Content-Type': 'application/json',

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -51,6 +51,8 @@ export const integrationTests: any = functions
     timeoutSeconds: 540,
   })
   .https.onRequest((req: Request, resp: Response) => {
+    // We take the base url for our https call (cloudfunctions.net, txckloud.net, etc) from the request
+    // so that it changes with the environment that the tests are run in
     const baseUrl = req.hostname.split('.').slice(1).join('.');
     let pubsub: any = require('@google-cloud/pubsub')();
     const testId = admin

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -51,6 +51,7 @@ export const integrationTests: any = functions
     timeoutSeconds: 540,
   })
   .https.onRequest((req: Request, resp: Response) => {
+    console.log(req.hostname);
     let pubsub: any = require('@google-cloud/pubsub')();
     const testId = admin
       .database()

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -88,33 +88,33 @@ export const integrationTests: any = functions
         .collection('tests')
         .doc(testId)
         .set({ test: testId }),
+      callHttpsTrigger('callableTests', { foo: 'bar', testId }),
       // A Remote Config update to trigger the Remote Config tests.
-      admin.credential
-        .applicationDefault()
-        .getAccessToken()
-        .then(accessToken => {
-          const options = {
-            hostname: 'firebaseremoteconfig.googleapis.com',
-            path: `/v1/projects/${firebaseConfig.projectId}/remoteConfig`,
-            method: 'PUT',
-            headers: {
-              Authorization: 'Bearer ' + accessToken.access_token,
-              'Content-Type': 'application/json; UTF-8',
-              'Accept-Encoding': 'gzip',
-              'If-Match': '*',
-            },
-          };
-          const request = https.request(options, resp => {});
-          request.write(JSON.stringify({ version: { description: testId } }));
-          request.end();
-        }),
+      // admin.credential
+      //   .applicationDefault()
+      //   .getAccessToken()
+      //   .then(accessToken => {
+      //     const options = {
+      //       hostname: 'firebaseremoteconfig.googleapis.com',
+      //       path: `/v1/projects/${firebaseConfig.projectId}/remoteConfig`,
+      //       method: 'PUT',
+      //       headers: {
+      //         Authorization: 'Bearer ' + accessToken.access_token,
+      //         'Content-Type': 'application/json; UTF-8',
+      //         'Accept-Encoding': 'gzip',
+      //         'If-Match': '*',
+      //       },
+      //     };
+      //     const request = https.request(options, resp => {});
+      //     request.write(JSON.stringify({ version: { description: testId } }));
+      //     request.end();
+      //   }),
       // A storage upload to trigger the Storage tests
       admin
         .storage()
         .bucket()
         .upload('/tmp/' + testId + '.txt'),
       // Invoke a callable HTTPS trigger.
-      callHttpsTrigger('callableTests', { foo: 'bar', testId }),
     ])
       .then(() => {
         // On test completion, check that all tests pass and reply "PASS", or provide further details.

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -26,7 +26,7 @@ function callHttpsTrigger(name: string, data: any) {
     const request = https.request(
       {
         method: 'POST',
-        host: 'us-central1-' + firebaseConfig.projectId + '.' + firebaseConfig.test.test_domain,
+        host: 'us-central1-' + firebaseConfig.projectId + '.' + functions.config().test.test_domain,
         path: '/' + name,
         headers: {
           'Content-Type': 'application/json',
@@ -52,7 +52,6 @@ export const integrationTests: any = functions
   })
   .https.onRequest((req: Request, resp: Response) => {
     let pubsub: any = require('@google-cloud/pubsub')();
-    console.log(firebaseConfig);
     const testId = admin
       .database()
       .ref()

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -52,7 +52,7 @@ export const integrationTests: any = functions
   })
   .https.onRequest((req: Request, resp: Response) => {
     let pubsub: any = require('@google-cloud/pubsub')();
-
+    console.log(firebaseConfig);
     const testId = admin
       .database()
       .ref()

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -21,12 +21,12 @@ const firebaseConfig = JSON.parse(process.env.FIREBASE_CONFIG);
 admin.initializeApp();
 
 // TODO(klimt): Get rid of this once the JS client SDK supports callable triggers.
-function callHttpsTrigger(name: string, data: any) {
+function callHttpsTrigger(name: string, data: any, baseUrl) {
   return new Promise((resolve, reject) => {
     const request = https.request(
       {
         method: 'POST',
-        host: 'us-central1-' + firebaseConfig.projectId + '.' + functions.config().test.test_domain,
+        host: 'us-central1-' + firebaseConfig.projectId + '.' + baseUrl,
         path: '/' + name,
         headers: {
           'Content-Type': 'application/json',
@@ -51,7 +51,7 @@ export const integrationTests: any = functions
     timeoutSeconds: 540,
   })
   .https.onRequest((req: Request, resp: Response) => {
-    console.log(req.hostname);
+    const baseUrl = req.hostname.split('.').slice(1).join('.');
     let pubsub: any = require('@google-cloud/pubsub')();
     const testId = admin
       .database()
@@ -88,7 +88,7 @@ export const integrationTests: any = functions
         .collection('tests')
         .doc(testId)
         .set({ test: testId }),
-      callHttpsTrigger('callableTests', { foo: 'bar', testId }),
+      callHttpsTrigger('callableTests', { foo: 'bar', testId }, baseUrl),
       // A Remote Config update to trigger the Remote Config tests.
       // admin.credential
       //   .applicationDefault()

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -26,7 +26,7 @@ function callHttpsTrigger(name: string, data: any) {
     const request = https.request(
       {
         method: 'POST',
-        host: 'us-central1-' + firebaseConfig.projectId + '.cloudfunctions.net',
+        host: 'us-central1-' + firebaseConfig.projectId + '.' + firebaseConfig.baseUrl,
         path: '/' + name,
         headers: {
           'Content-Type': 'application/json',

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -131,11 +131,16 @@ function cleanup {
   rm -rf $DIR/functions/node_modules/firebase-functions
 }
 
+function setConfig {
+  firebase functions:config:set test.test_domain=$TEST_URL
+}
+
 build_sdk
 pick_node8
 install_deps
 delete_all_functions
 announce "Deploying functions to Node 8 runtime ..."
+setConfig
 deploy
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
   waitForPropagation
@@ -143,6 +148,7 @@ if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
 fi
 pick_node6
 announce "Re-deploying the same functions to Node 6 runtime ..."
+setConfig
 deploy
 waitForPropagation
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -131,17 +131,11 @@ function cleanup {
   rm -rf $DIR/functions/node_modules/firebase-functions
 }
 
-function setConfig {
-  firebase functions:config:set test.test_domain=$TEST_URL --project $PROJECT_ID_NODE_6
-  firebase functions:config:set test.test_domain=$TEST_URL --project $PROJECT_ID_NODE_8
-}
-
 build_sdk
 pick_node8
 install_deps
 delete_all_functions
 announce "Deploying functions to Node 8 runtime ..."
-setConfig
 deploy
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
   waitForPropagation

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -132,8 +132,8 @@ function cleanup {
 }
 
 function setConfig {
-  firebase functions:config:get
-  firebase functions:config:set test.test_domain=$TEST_URL
+  firebase functions:config:set test.test_domain=$TEST_URL --project $PROJECT_ID_NODE_6
+  firebase functions:config:set test.test_domain=$TEST_URL --project $PROJECT_ID_NODE_8
   firebase functions:config:get
 }
 
@@ -150,7 +150,6 @@ if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
 fi
 pick_node6
 announce "Re-deploying the same functions to Node 6 runtime ..."
-setConfig
 deploy
 waitForPropagation
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -140,7 +140,7 @@ pick_node8
 install_deps
 delete_all_functions
 announce "Deploying functions to Node 8 runtime ..."
-setConfig
+# setConfig
 deploy
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
   waitForPropagation
@@ -148,7 +148,7 @@ if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
 fi
 pick_node6
 announce "Re-deploying the same functions to Node 6 runtime ..."
-setConfig
+# setConfig
 deploy
 waitForPropagation
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -132,7 +132,9 @@ function cleanup {
 }
 
 function setConfig {
+  firebase functions:config:get
   firebase functions:config:set test.test_domain=$TEST_URL
+  firebase functions:config:get
 }
 
 build_sdk
@@ -140,7 +142,7 @@ pick_node8
 install_deps
 delete_all_functions
 announce "Deploying functions to Node 8 runtime ..."
-# setConfig
+setConfig
 deploy
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
   waitForPropagation
@@ -148,7 +150,7 @@ if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
 fi
 pick_node6
 announce "Re-deploying the same functions to Node 6 runtime ..."
-# setConfig
+setConfig
 deploy
 waitForPropagation
 if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -134,7 +134,6 @@ function cleanup {
 function setConfig {
   firebase functions:config:set test.test_domain=$TEST_URL --project $PROJECT_ID_NODE_6
   firebase functions:config:set test.test_domain=$TEST_URL --project $PROJECT_ID_NODE_8
-  firebase functions:config:get
 }
 
 build_sdk


### PR DESCRIPTION
### Description
Disables remote config tests becuase they are broken in preprod ONLY
Enables storage tests because they are working now on gcf-release-firebase-test
Changing https tests to use the correct url in all environments