### PR TITLE
Make Event Context Generic

### DIFF
--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -86,6 +86,31 @@ export interface EventContext {
   };
 }
 
+export interface EventContextGeneric<P> {
+  /** ID of the event */
+  eventId: string;
+  /** Timestamp for when the event occured (ISO string) */
+  timestamp: string;
+  /** Type of event */
+  eventType: string;
+  /** Resource that triggered the event */
+  resource: Resource;
+  /** Key-value pairs that represent the values of wildcards in a database reference */
+  params: P; // added by SDK, but may be {}
+  /** Type of authentication for the triggering action, valid value are: 'ADMIN', 'USER',
+   * 'UNAUTHENTICATED'. Only available for database functions.
+   */
+  authType?: 'ADMIN' | 'USER' | 'UNAUTHENTICATED';
+  /** Firebase auth variable for the user whose action triggered the function. Field will be
+   * null for unauthenticated users, and will not exist for admin users. Only available
+   * for database functions.
+   */
+  auth?: {
+    uid: string;
+    token: object;
+  };
+}
+
 /** Change describes a change of state - "before" represents the state prior
  * to the event, "after" represents the state after the event.
  */

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -30,6 +30,7 @@ import {
   Change,
   Event,
   EventContext,
+  EventContextGeneric,
 } from '../cloud-functions';
 import { dateToTimestampProto } from '../encoder';
 import { DeploymentOptions } from '../function-builder';
@@ -189,40 +190,40 @@ export class DocumentBuilder {
   }
 
   /** Respond to all document writes (creates, updates, or deletes). */
-  onWrite(
+  onWrite<P = { [option: string]: any }>(
     handler: (
       change: Change<DocumentSnapshot>,
-      context: EventContext
+      context: EventContext | EventContextGeneric<P>
     ) => PromiseLike<any> | any
   ): CloudFunction<Change<DocumentSnapshot>> {
     return this.onOperation(handler, 'document.write', changeConstructor);
   }
 
   /** Respond only to document updates. */
-  onUpdate(
+  onUpdate<P = { [option: string]: any }>(
     handler: (
       change: Change<DocumentSnapshot>,
-      context: EventContext
+      context: EventContext | EventContextGeneric<P>
     ) => PromiseLike<any> | any
   ): CloudFunction<Change<DocumentSnapshot>> {
     return this.onOperation(handler, 'document.update', changeConstructor);
   }
 
   /** Respond only to document creations. */
-  onCreate(
+  onCreate<P = { [option: string]: any }>(
     handler: (
       snapshot: DocumentSnapshot,
-      context: EventContext
+      context: EventContext | EventContextGeneric<P>
     ) => PromiseLike<any> | any
   ): CloudFunction<DocumentSnapshot> {
     return this.onOperation(handler, 'document.create', snapshotConstructor);
   }
 
   /** Respond only to document deletions. */
-  onDelete(
+  onDelete<P = { [option: string]: any }>(
     handler: (
       snapshot: DocumentSnapshot,
-      context: EventContext
+      context: EventContext | EventContextGeneric<P>
     ) => PromiseLike<any> | any
   ): CloudFunction<DocumentSnapshot> {
     return this.onOperation(
@@ -232,8 +233,8 @@ export class DocumentBuilder {
     );
   }
 
-  private onOperation<T>(
-    handler: (data: T, context: EventContext) => PromiseLike<any> | any,
+  private onOperation<T, P = { [option: string]: any }>(
+    handler: (data: T, context: EventContext | EventContextGeneric<P>) => PromiseLike<any> | any,
     eventType: string,
     dataConstructor: (raw: Event) => any
   ): CloudFunction<T> {


### PR DESCRIPTION
### Description

Add EventContext generic type. And add supporting generic in firestore document functions

### Code sample

```
export const test = functions.firestore.document('test/{testID}').onCreate<{ testID: string }>((snapshot, context) => {
  return context.params.testID;
});
```