### PR TITLE
Fix Node 10 functions not setting FIREBASE_CONFIG and functions.config()

### DIFF
--- a/spec/config.spec.ts
+++ b/spec/config.spec.ts
@@ -27,7 +27,7 @@ import { config, firebaseConfig } from '../src/config';
 const NODE8_NODE10_PATH = '/srv/.runtimeconfig.json';
 const NODE6_PATH = '/user_code/.runtimeconfig.json';
 
-describe.only('config()', () => {
+describe('config()', () => {
   afterEach(() => {
     mockRequire.stopAll();
     delete config.singleton;
@@ -46,7 +46,7 @@ describe.only('config()', () => {
     );
   });
 
-  it('does not provide firebase config if .runtimeconfig.json not invalid', () => {
+  it('does not provide firebase config if .runtimeconfig.json is invalid', () => {
     mockRequire(NODE8_NODE10_PATH, 'does-not-exist');
 
     expect(firebaseConfig()).to.be.null;
@@ -69,6 +69,7 @@ describe.only('config()', () => {
         cloudResourceLocation: 'us-central',
       },
     });
+
     let loaded = firebaseConfig();
 
     expect(loaded).to.have.keys(
@@ -90,6 +91,7 @@ describe.only('config()', () => {
         cloudResourceLocation: 'us-central',
       },
     });
+
     let loaded = firebaseConfig();
 
     expect(loaded).to.have.keys(
@@ -111,6 +113,7 @@ describe.only('config()', () => {
         cloudResourceLocation: 'us-central',
       },
     });
+
     let loaded = firebaseConfig();
 
     expect(loaded).to.have.keys(
@@ -124,6 +127,7 @@ describe.only('config()', () => {
   it('loads config values from .runtimeconfig.json properly for Node 6 functions', () => {
     process.env.PWD = '/user_code';
     mockRequire(NODE6_PATH, { foo: 'bar', firebase: {} });
+
     let loaded = config();
 
     expect(loaded).to.not.have.property('firebase');
@@ -133,6 +137,7 @@ describe.only('config()', () => {
   it('loads config values from .runtimeconfig.json properly for Node 8 functions', () => {
     process.env.PWD = '/srv';
     mockRequire(NODE8_NODE10_PATH, { foo: 'bar', firebase: {} });
+
     let loaded = config();
 
     expect(loaded).to.not.have.property('firebase');
@@ -142,6 +147,7 @@ describe.only('config()', () => {
   it('loads config values from .runtimeconfig.json properly for Node 10 functions', () => {
     process.env.PWD = '/srv/functions';
     mockRequire(NODE8_NODE10_PATH, { foo: 'bar', firebase: {} });
+    
     let loaded = config();
 
     expect(loaded).to.not.have.property('firebase');


### PR DESCRIPTION
### Description
Fix a bug that is occurring in Node 10 functions only where `FIREBASE_CONFIG` env var is not being set, and `functions.config()` returns `undefined`. Both of these values are coming from `.runtimeconfig.json`, which I realized is not being imported correctly in Node 10 runtime because of a changed directory structure. I verified that the Firebase CLI is indeed pulling in `.runtimeconfig.json` and uploading it properly in Node 10 so the problem is on firebase-functions SDK.

All three runtimes have different root directory defined for where the user code lives, and is represented by the environment variable `PWD` in each runtime: 
* Node 6: `/user_code`
* Node 8: `/srv`
* Node 10: `/srv/functions`

Because we were accessing `.runtimeconfig.json` with relative paths like `../../../.runtimeconfig.json`, it worked for Node 6 and 8 but the addition of an extra `functions` dir in Node 10 runtime broke it.

Fixes https://github.com/firebase/firebase-functions/issues/433 and probably https://github.com/firebase/firebase-functions/issues/432.

### Tests
* Added tests to `config.spec.ts` covering the different runtimes with different env vars set to mimic the runtimes: `process.env.PWD`
* All unit tests are passing
* Ran integration tests: `integration_test/run_tests.sh` - all passing.
* Did quite a lot of manual deploys of the same function that uses the RTDB and also sets config vars with `firebase functions:config:set key=value`. Validated that `FIREBASE_CONFIG` is set and `functions.config()` returns expected results in Node 6, 8, and 10. 

### Legacy Behavior
I removed legacy behavior from two years ago when we were anticipating `FIREBASE_PROJECT` and `CLOUD_RUNTIME_CONFIG` env vars to be set by GCF (https://github.com/firebase/firebase-functions/pull/51). This did not happen and as far as I can tell we are mostly relying on Runtime Config to set env vars now. 

@mbleigh @laurenzlong you both probably have more context here, does this sound right? 