### PR TITLE
Add region support for europe-west2 and asia-east2

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,1 +1,1 @@
-Feature - Adds region support for europe-west2 and asia-east2
+feature - Adds region support for europe-west2 and asia-east2

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+Feature - Adds region support for europe-west2 and asia-east2

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -122,7 +122,7 @@ describe('FunctionBuilder', () => {
       functions
         .runWith({ timeoutSeconds: 90, memory: '256MB' })
         .region('unsupported');
-    }).to.throw(Error);
+    }).to.throw(Error, 'region');
   });
 
   it('should fail if supported region but invalid runtime options are set (reverse order)', () => {

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -51,6 +51,29 @@ describe('FunctionBuilder', () => {
     expect(fn.__trigger.regions).to.deep.equal(['us-east1', 'us-central1']);
   });
 
+  it('should allow all supported regions to be set', () => {
+    let fn = functions
+      .region(
+        'us-central1',
+        'us-east1',
+        'europe-west1',
+        'europe-west2',
+        'asia-east2',
+        'asia-northeast1'
+      )
+      .auth.user()
+      .onCreate(user => user);
+
+    expect(fn.__trigger.regions).to.deep.equal([
+      'us-central1',
+      'us-east1',
+      'europe-west1',
+      'europe-west2',
+      'asia-east2',
+      'asia-northeast1',
+    ]);
+  });
+
   it('should allow valid runtime options to be set', () => {
     let fn = functions
       .runWith({
@@ -110,7 +133,7 @@ describe('FunctionBuilder', () => {
     }).to.throw(Error, 'TimeoutSeconds');
   });
 
-  it('should throw an error if user chooses an unsupported memory allocation', () => {
+  it('should throw an error if user chooses an invalid memory allocation', () => {
     expect(() => {
       return functions.runWith({
         memory: 'unsupported',

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -33,7 +33,7 @@ describe('FunctionBuilder', () => {
     delete process.env.GCLOUD_PROJECT;
   });
 
-  it('should allow region to be set', () => {
+  it('should allow supported region to be set', () => {
     let fn = functions
       .region('us-east1')
       .auth.user()
@@ -42,7 +42,7 @@ describe('FunctionBuilder', () => {
     expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
   });
 
-  it('should allow multiple regions to be set', () => {
+  it('should allow multiple supported regions to be set', () => {
     let fn = functions
       .region('us-east1', 'us-central1')
       .auth.user()
@@ -51,7 +51,7 @@ describe('FunctionBuilder', () => {
     expect(fn.__trigger.regions).to.deep.equal(['us-east1', 'us-central1']);
   });
 
-  it('should allow runtime options to be set', () => {
+  it('should allow valid runtime options to be set', () => {
     let fn = functions
       .runWith({
         timeoutSeconds: 90,
@@ -64,9 +64,9 @@ describe('FunctionBuilder', () => {
     expect(fn.__trigger.timeout).to.deep.equal('90s');
   });
 
-  it('should allow both region and runtime options to be set', () => {
+  it('should allow both supported region and valid runtime options to be set', () => {
     let fn = functions
-      .region('us-east1')
+      .region('europe-west2')
       .runWith({
         timeoutSeconds: 90,
         memory: '256MB',
@@ -74,24 +74,40 @@ describe('FunctionBuilder', () => {
       .auth.user()
       .onCreate(user => user);
 
-    expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
+    expect(fn.__trigger.regions).to.deep.equal(['europe-west2']);
     expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
     expect(fn.__trigger.timeout).to.deep.equal('90s');
   });
 
-  it('should allow both region and runtime options to be set (reverse order)', () => {
+  it('should allow both valid runtime options and supported region to be set in reverse order', () => {
     let fn = functions
       .runWith({
         timeoutSeconds: 90,
         memory: '256MB',
       })
-      .region('us-east1')
+      .region('europe-west1')
       .auth.user()
       .onCreate(user => user);
 
-    expect(fn.__trigger.regions).to.deep.equal(['us-east1']);
+    expect(fn.__trigger.regions).to.deep.equal(['europe-west1']);
     expect(fn.__trigger.availableMemoryMb).to.deep.equal(256);
     expect(fn.__trigger.timeout).to.deep.equal('90s');
+  });
+
+  it('should fail if valid runtime options but unsupported region are set (reverse order)', () => {
+    expect(() => {
+      functions
+        .runWith({ timeoutSeconds: 90, memory: '256MB' })
+        .region('unsupported');
+    }).to.throw(Error);
+  });
+
+  it('should fail if supported region but invalid runtime options are set (reverse order)', () => {
+    expect(() => {
+      functions
+        .region('asia-northeast1')
+        .runWith({ timeoutSeconds: 600, memory: '256MB' });
+    }).to.throw(Error, 'TimeoutSeconds');
   });
 
   it('should throw an error if user chooses an unsupported memory allocation', () => {
@@ -99,13 +115,13 @@ describe('FunctionBuilder', () => {
       return functions.runWith({
         memory: 'unsupported',
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'memory');
 
     expect(() => {
       return functions.region('us-east1').runWith({
         memory: 'unsupported',
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'memory');
   });
 
   it('should throw an error if user chooses an invalid timeoutSeconds', () => {
@@ -113,46 +129,46 @@ describe('FunctionBuilder', () => {
       return functions.runWith({
         timeoutSeconds: 1000000,
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'TimeoutSeconds');
 
     expect(() => {
-      return functions.region('us-east1').runWith({
+      return functions.region('asia-east2').runWith({
         timeoutSeconds: 1000000,
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'TimeoutSeconds');
   });
 
   it('should throw an error if user chooses an invalid region', () => {
     expect(() => {
       return functions.region('unsupported');
-    }).to.throw(Error);
+    }).to.throw(Error, 'region');
 
     expect(() => {
       return functions.region('unsupported').runWith({
         timeoutSeconds: 500,
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'region');
 
     expect(() => {
       return functions.region('unsupported', 'us-east1');
-    }).to.throw(Error);
+    }).to.throw(Error, 'region');
 
     expect(() => {
       return functions.region('unsupported', 'us-east1').runWith({
         timeoutSeconds: 500,
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'region');
   });
 
   it('should throw an error if user chooses no region when using .region()', () => {
     expect(() => {
       return functions.region();
-    }).to.throw(Error);
+    }).to.throw(Error, 'at least one region');
 
     expect(() => {
       return functions.region().runWith({
         timeoutSeconds: 500,
       } as any);
-    }).to.throw(Error);
+    }).to.throw(Error, 'at least one region');
   });
 });

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -49,7 +49,12 @@ const SUPPORTED_REGIONS = [
 /**
  * List of available memory options supported by Cloud Functions.
  */
-const MEMORY_OPTS = ['128MB', '256MB', '512MB', '1GB', '2GB'];
+const VALID_MEMORY_OPTS = ['128MB', '256MB', '512MB', '1GB', '2GB'];
+
+// Adding this memory type here to error on compile for TS users.
+// Unfortunately I have not found a way to merge this with VALID_MEMORY_OPS
+// without it being super ugly. But here they are right next to each other at least.
+type memory = '128MB' | '256MB' | '512MB' | '1GB' | '2GB';
 
 /**
  * Cloud Functions max timeout value.
@@ -64,10 +69,12 @@ const MAX_TIMEOUT_SECONDS = 540;
 function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   if (
     runtimeOptions.memory &&
-    !_.includes(MEMORY_OPTS, runtimeOptions.memory)
+    !_.includes(VALID_MEMORY_OPTS, runtimeOptions.memory)
   ) {
     throw new Error(
-      `The only valid memory allocation values are: ${MEMORY_OPTS.join(', ')}`
+      `The only valid memory allocation values are: ${VALID_MEMORY_OPTS.join(
+        ', '
+      )}`
     );
   }
   if (
@@ -124,13 +131,13 @@ export function runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
 
 export interface RuntimeOptions {
   timeoutSeconds?: number;
-  memory?: string;
+  memory?: memory;
 }
 
 export interface DeploymentOptions {
   regions?: string[];
   timeoutSeconds?: number;
-  memory?: string;
+  memory?: memory;
   schedule?: Schedule;
 }
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -32,37 +32,83 @@ import * as https from './providers/https';
 import * as pubsub from './providers/pubsub';
 import * as remoteConfig from './providers/remoteConfig';
 import * as storage from './providers/storage';
-import {
-  CloudFunction,
-  EventContext,
-  Runnable,
-  TriggerAnnotated,
-  Schedule,
-} from './cloud-functions';
+import { CloudFunction, EventContext, Schedule } from './cloud-functions';
+
+/**
+ * List of all regions supported by Cloud Functions.
+ */
+const SUPPORTED_REGIONS = [
+  'us-central1',
+  'us-east1',
+  'europe-west1',
+  'europe-west2',
+  'asia-east2',
+  'asia-northeast1',
+];
+
+/**
+ * List of available memory options supported by Cloud Functions.
+ */
+const MEMORY_OPTS = ['128MB', '256MB', '512MB', '1GB', '2GB'];
+
+/**
+ * Cloud Functions max timeout value.
+ */
+const MAX_TIMEOUT_SECONDS = 540;
+
+/**
+ * Assert that the runtime options passed in are valid.
+ * @param runtimeOptions object containing memory and timeout information.
+ * @throws { Error } Memory and TimeoutSeconds values must be valid.
+ */
+function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
+  if (
+    runtimeOptions.memory &&
+    !_.includes(MEMORY_OPTS, runtimeOptions.memory)
+  ) {
+    throw new Error(
+      `The only valid memory allocation values are: ${MEMORY_OPTS.join(', ')}`
+    );
+  }
+  if (
+    runtimeOptions.timeoutSeconds > MAX_TIMEOUT_SECONDS ||
+    runtimeOptions.timeoutSeconds < 0
+  ) {
+    throw new Error(
+      `TimeoutSeconds must be between 0 and ${MAX_TIMEOUT_SECONDS}`
+    );
+  }
+  return true;
+}
+
+/**
+ * Assert regions specified are valid.
+ * @param regions list of regions.
+ * @throws { Error } Regions must be in list of supported regions.
+ */
+function assertRegionsAreValid(...regions: string[]): boolean {
+  if (!regions.length) {
+    throw new Error('You must specify at least one region');
+  }
+  if (_.difference(regions, SUPPORTED_REGIONS).length) {
+    throw new Error(
+      `The only valid regions are: ${SUPPORTED_REGIONS.join(', ')}`
+    );
+  }
+  return true;
+}
 
 /**
  * Configure the regions that the function is deployed to.
  * @param regions One of more region strings.
  * For example: `functions.region('us-east1')` or `functions.region('us-east1', 'us-central1')`
  */
-export function region(...regions: string[]) {
-  if (!regions.length) {
-    throw new Error('You must specify at least one region');
+export function region(...regions: string[]): FunctionBuilder {
+  if (assertRegionsAreValid(...regions)) {
+    return new FunctionBuilder({ regions });
   }
-  if (
-    _.difference(regions, [
-      'us-central1',
-      'us-east1',
-      'europe-west1',
-      'asia-northeast1',
-    ]).length
-  ) {
-    throw new Error(
-      "The only valid regions are 'us-central1', 'us-east1', 'europe-west1', and 'asia-northeast1'"
-    );
-  }
-  return new FunctionBuilder({ regions });
 }
+
 /**
  * Configure runtime options for the function.
  * @param runtimeOptions Object with 2 optional fields:
@@ -70,28 +116,15 @@ export function region(...regions: string[]) {
  * 2. `memory`: amount of memory to allocate to the function,
  *    possible values are:  '128MB', '256MB', '512MB', '1GB', and '2GB'.
  */
-export function runWith(runtimeOptions: {
+export function runWith(runtimeOptions: RuntimeOptions) {
+  if (assertRuntimeOptionsValid(runtimeOptions)) {
+    return new FunctionBuilder(runtimeOptions);
+  }
+}
+
+export interface RuntimeOptions {
   timeoutSeconds?: number;
-  memory?: '128MB' | '256MB' | '512MB' | '1GB' | '2GB';
-}) {
-  if (
-    runtimeOptions.memory &&
-    !_.includes(
-      ['128MB', '256MB', '512MB', '1GB', '2GB'],
-      runtimeOptions.memory
-    )
-  ) {
-    throw new Error(
-      "The only valid memory allocation values are: '128MB', '256MB', '512MB', '1GB', and '2GB'"
-    );
-  }
-  if (
-    runtimeOptions.timeoutSeconds > 540 ||
-    runtimeOptions.timeoutSeconds < 0
-  ) {
-    throw new Error('TimeoutSeconds must be between 0 and 540');
-  }
-  return new FunctionBuilder(runtimeOptions);
+  memory?: string;
 }
 
 export interface DeploymentOptions {
@@ -109,10 +142,12 @@ export class FunctionBuilder {
    * @param regions One or more region strings.
    * For example: `functions.region('us-east1')`  or `functions.region('us-east1', 'us-central1')`
    */
-  region = (...regions: string[]) => {
-    this.options.regions = regions;
-    return this;
-  };
+  region(...regions: string[]) {
+    if (assertRegionsAreValid(...regions)) {
+      this.options.regions = regions;
+      return this;
+    }
+  }
 
   /**
    * Configure runtime options for the function.
@@ -121,30 +156,12 @@ export class FunctionBuilder {
    * 2. memory: amount of memory to allocate to the function, possible values are:
    * '128MB', '256MB', '512MB', '1GB', and '2GB'.
    */
-  runWith = (runtimeOptions: {
-    timeoutSeconds?: number;
-    memory?: '128MB' | '256MB' | '512MB' | '1GB' | '2GB';
-  }) => {
-    if (
-      runtimeOptions.memory &&
-      !_.includes(
-        ['128MB', '256MB', '512MB', '1GB', '2GB'],
-        runtimeOptions.memory
-      )
-    ) {
-      throw new Error(
-        "The only valid memory allocation values are: '128MB', '256MB', '512MB', '1GB', and '2GB'"
-      );
+  runWith(runtimeOptions: RuntimeOptions) {
+    if (assertRuntimeOptionsValid(runtimeOptions)) {
+      this.options = _.assign(this.options, runtimeOptions);
+      return this;
     }
-    if (
-      runtimeOptions.timeoutSeconds > 540 ||
-      runtimeOptions.timeoutSeconds < 0
-    ) {
-      throw new Error('TimeoutSeconds must be between 0 and 540');
-    }
-    this.options = _.assign(this.options, runtimeOptions);
-    return this;
-  };
+  }
 
   get https() {
     return {

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -54,7 +54,7 @@ const VALID_MEMORY_OPTS = ['128MB', '256MB', '512MB', '1GB', '2GB'];
 // Adding this memory type here to error on compile for TS users.
 // Unfortunately I have not found a way to merge this with VALID_MEMORY_OPS
 // without it being super ugly. But here they are right next to each other at least.
-type memory = '128MB' | '256MB' | '512MB' | '1GB' | '2GB';
+type Memory = '128MB' | '256MB' | '512MB' | '1GB' | '2GB';
 
 /**
  * Cloud Functions max timeout value.
@@ -131,13 +131,13 @@ export function runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
 
 export interface RuntimeOptions {
   timeoutSeconds?: number;
-  memory?: memory;
+  memory?: Memory;
 }
 
 export interface DeploymentOptions {
   regions?: string[];
   timeoutSeconds?: number;
-  memory?: memory;
+  memory?: Memory;
   schedule?: Schedule;
 }
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -86,7 +86,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
  * @param regions list of regions.
  * @throws { Error } Regions must be in list of supported regions.
  */
-function assertRegionsAreValid(...regions: string[]): boolean {
+function assertRegionsAreValid(regions: string[]): boolean {
   if (!regions.length) {
     throw new Error('You must specify at least one region');
   }
@@ -104,7 +104,7 @@ function assertRegionsAreValid(...regions: string[]): boolean {
  * For example: `functions.region('us-east1')` or `functions.region('us-east1', 'us-central1')`
  */
 export function region(...regions: string[]): FunctionBuilder {
-  if (assertRegionsAreValid(...regions)) {
+  if (assertRegionsAreValid(regions)) {
     return new FunctionBuilder({ regions });
   }
 }
@@ -116,7 +116,7 @@ export function region(...regions: string[]): FunctionBuilder {
  * 2. `memory`: amount of memory to allocate to the function,
  *    possible values are:  '128MB', '256MB', '512MB', '1GB', and '2GB'.
  */
-export function runWith(runtimeOptions: RuntimeOptions) {
+export function runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
   if (assertRuntimeOptionsValid(runtimeOptions)) {
     return new FunctionBuilder(runtimeOptions);
   }
@@ -142,8 +142,8 @@ export class FunctionBuilder {
    * @param regions One or more region strings.
    * For example: `functions.region('us-east1')`  or `functions.region('us-east1', 'us-central1')`
    */
-  region(...regions: string[]) {
-    if (assertRegionsAreValid(...regions)) {
+  region(...regions: string[]): FunctionBuilder {
+    if (assertRegionsAreValid(regions)) {
       this.options.regions = regions;
       return this;
     }
@@ -156,7 +156,7 @@ export class FunctionBuilder {
    * 2. memory: amount of memory to allocate to the function, possible values are:
    * '128MB', '256MB', '512MB', '1GB', and '2GB'.
    */
-  runWith(runtimeOptions: RuntimeOptions) {
+  runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
     if (assertRuntimeOptionsValid(runtimeOptions)) {
       this.options = _.assign(this.options, runtimeOptions);
       return this;


### PR DESCRIPTION
### Description
Adds support for new regions `europe-west2` and `asia-east2` to be consistent with [Google Cloud Functions](https://cloud.google.com/functions/docs/locations). The full list of regions supported:

* us-central1
* us-east1
* europe-west1
* europe-west2 <= NEW
* asia-east2 <= NEW
* asia-northeast1

This PR also fixes a bug I discovered while refactoring where if a user initialized a function with runtimeOptions first, and then set the region, region validation would not happen. It also contains some other refactors mainly removing duplicate code in `functions-builder.ts`. 

### Testing
* Added more rigorous unit tests to `function-builder.spec.ts`
* Ran integration tests: `./integration_tests/run_tests.sh chenky-test-3`