### PR TITLE
Remove Node 6 from Integration Tests

### DIFF
--- a/integration_test/package.node10.json
+++ b/integration_test/package.node10.json
@@ -8,7 +8,7 @@
     "@google-cloud/pubsub": "~0.19.0",
     "@types/google-cloud__pubsub": "^0.18.0",
     "@types/lodash": "~4.14.41",
-    "firebase-admin": "^7.0.0",
+    "firebase-admin": "^8.0.0",
     "firebase-functions": "./firebase-functions.tgz",
     "lodash": "~4.17.2"
   },
@@ -17,7 +17,7 @@
     "typescript": "~3.1.0"
   },
   "engines": {
-    "node": "6"
+    "node": "10"
   },
   "private": true
 }

--- a/integration_test/package.node8.json
+++ b/integration_test/package.node8.json
@@ -8,7 +8,7 @@
     "@google-cloud/pubsub": "~0.19.0",
     "@types/google-cloud__pubsub": "^0.18.0",
     "@types/lodash": "~4.14.41",
-    "firebase-admin": "^7.0.0",
+    "firebase-admin": "^8.0.0",
     "firebase-functions": "./firebase-functions.tgz",
     "lodash": "~4.17.2"
   },

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -39,16 +39,16 @@ function build_sdk {
   mv firebase-functions-*.tgz integration_test/functions/firebase-functions.tgz
 }
 
-function pick_node10 {
-  cd $DIR
-  PROJECT_ID=$PROJECT_ID_NODE_10
-  cp package.node10.json functions/package.json
-}
-
 function pick_node8 {
   cd $DIR
   PROJECT_ID=$PROJECT_ID_NODE_8
   cp package.node8.json functions/package.json
+}
+
+function pick_node10 {
+  cd $DIR
+  PROJECT_ID=$PROJECT_ID_NODE_10
+  cp package.node10.json functions/package.json
 }
 
 function install_deps {
@@ -141,6 +141,7 @@ if [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
   waitForPropagation
   run_tests
 fi
+# TODO(b/134418760) Uncomment this when Node 10 issues are fixed:
 # pick_node10
 # announce "Re-deploying the same functions to Node 10 runtime ..."
 # deploy

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -141,7 +141,7 @@ if [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
   waitForPropagation
   run_tests
 fi
-# TODO(b/134418760) Uncomment this when Node 10 issues are fixed:
+# TODO(b/134418760): Uncomment this when Node 10 issues are fixed
 # pick_node10
 # announce "Re-deploying the same functions to Node 10 runtime ..."
 # deploy

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -4,24 +4,24 @@
 set -e
 
 function usage {
-  echo "Usage: $0 <project_id_node_6> [<project_id_node_8>]"
+  echo "Usage: $0 <project_id_node_8> [<project_id_node_10>]"
   exit 1
 }
 
-# This script takes 1 or 2 params, both of which are Firebase project ids.
-# If there is only one given, that project will be used for both node6 and node8
-# Otherwise, param1 will be used for node6
-# and param2 will be used for node8
-# The first parameter is required and is the Firebase project id.
+# This script takes 1 or 2 arguments, both of which are Firebase project ids.
+# If only one argument is given, that project will be used for both node 8 and node 10
+# Otherwise, first argument will be used for node 8 and second argument will be used 
+# for node 10. 
+# Note that at least one argument is required.
 if [[ $1 == "" ]]; then
   usage
 fi
 if [[ $2 == "" ]]; then
-  PROJECT_ID_NODE_6=$1
   PROJECT_ID_NODE_8=$1
+  PROJECT_ID_NODE_10=$1
 else
-  PROJECT_ID_NODE_6=$1
-  PROJECT_ID_NODE_8=$2
+  PROJECT_ID_NODE_8=$1
+  PROJECT_ID_NODE_10=$2
 fi
 
 # Directory where this script lives.
@@ -39,10 +39,10 @@ function build_sdk {
   mv firebase-functions-*.tgz integration_test/functions/firebase-functions.tgz
 }
 
-function pick_node6 {
+function pick_node10 {
   cd $DIR
-  PROJECT_ID=$PROJECT_ID_NODE_6
-  cp package.node6.json functions/package.json
+  PROJECT_ID=$PROJECT_ID_NODE_10
+  cp package.node10.json functions/package.json
 }
 
 function pick_node8 {
@@ -63,9 +63,9 @@ function delete_all_functions {
   cd $DIR
   # Try to delete, if there are errors it is because the project is already empty,
   # in that case do nothing. 
-  firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID_NODE_6 || : &
-  if ! [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
-    firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID_NODE_8 || : &
+  firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID_NODE_8 || : &
+  if ! [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
+    firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID_NODE_10 || : &
   fi
   wait
   announce "Project emptied."
@@ -96,14 +96,14 @@ function run_all_tests {
   if [[ $FIREBASE_FUNCTIONS_URL == "https://preprod-cloudfunctions.sandbox.googleapis.com" ]]; then
     TEST_DOMAIN="txcloud.net"
   fi
-  TEST_URL_NODE_6="https://us-central1-$PROJECT_ID_NODE_6.$TEST_DOMAIN/integrationTests"
   TEST_URL_NODE_8="https://us-central1-$PROJECT_ID_NODE_8.$TEST_DOMAIN/integrationTests"
-  echo $TEST_URL_NODE_6
+  TEST_URL_NODE_10="https://us-central1-$PROJECT_ID_NODE_10.$TEST_DOMAIN/integrationTests"
   echo $TEST_URL_NODE_8
-  curl --fail $TEST_URL_NODE_6 & NODE6PID=$!
+  echo $TEST_URL_NODE_10
   curl --fail $TEST_URL_NODE_8 & NODE8PID=$!
-  wait $NODE6PID && echo 'node 6 passed' || (announce 'Node 6 tests failed'; cleanup; announce 'Tests failed'; exit 1)
+  curl --fail $TEST_URL_NODE_10 & NODE10PID=$!
   wait $NODE8PID && echo 'node 8 passed' || (announce 'Node 8 tests failed'; cleanup; announce 'Tests failed'; exit 1)
+  wait $NODE10PID && echo 'node 10 passed' || (announce 'Node 10 tests failed'; cleanup; announce 'Tests failed'; exit 1)
 }
 
 function run_tests {
@@ -137,18 +137,18 @@ install_deps
 delete_all_functions
 announce "Deploying functions to Node 8 runtime ..."
 deploy
-if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
+if [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
   waitForPropagation
   run_tests
 fi
-pick_node6
-announce "Re-deploying the same functions to Node 6 runtime ..."
-deploy
-waitForPropagation
-if [[ $PROJECT_ID_NODE_6 == $PROJECT_ID_NODE_8 ]]; then
-  run_tests
-else
-  run_all_tests
-fi
+# pick_node10
+# announce "Re-deploying the same functions to Node 10 runtime ..."
+# deploy
+# waitForPropagation
+# if [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
+#   run_tests
+# else
+#   run_all_tests
+# fi
 cleanup
 announce "All tests pass!"


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Removes Node 6 from integration tests, adds Node 10. Currently Node 10 is commented out since there are a couple outstanding issues with Node 10 that will need to be resolved. Additionally, update admin dependency in integration tests to `^8.0.0`.

### Testing
Tested running integration tests for Node 8. Tests are consistently passing.