### PR TITLE
Remove LegacyEvent, change all tests to use new Event format

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,4 @@
-- important - [breaking change] The Firebase Functions SDK no longer supports Node 6. Developers must use Node 8.13.0 or higher.
-- important - [breaking change] The Firebase Functions SDK no longer supports Firebase Tools SDK below version 6.8.0.
-- important - [breaking change] FIREBASE_PROJECT environment variable is no longer supported and has been supplanted by FIREBASE_CONFIG.
+important - [breaking change] The Firebase Functions SDK no longer supports Node 6. Developers must use Node 8.13.0 or higher.
+important - [breaking change] The Firebase Functions SDK no longer supports Firebase Tools SDK below version 6.8.0.
+important - [breaking change] FIREBASE_PROJECT environment variable is no longer supported and has been supplanted by FIREBASE_CONFIG.
+fixed - Fixed bug in Node 10 where events from Node 10 were not parsed properly resulting in undefined.

--- a/spec/cloud-functions.spec.ts
+++ b/spec/cloud-functions.spec.ts
@@ -25,7 +25,6 @@ import { expect } from 'chai';
 import {
   Event,
   EventContext,
-  LegacyEvent,
   makeCloudFunction,
   MakeCloudFunctionArgs,
   Change,

--- a/spec/cloud-functions.spec.ts
+++ b/spec/cloud-functions.spec.ts
@@ -68,7 +68,7 @@ describe('makeCloudFunction', () => {
     });
   });
 
-  it('should construct the right context for new event format', () => {
+  it('should construct the right context for event', () => {
     let args: any = _.assign({}, cloudFunctionArgs, {
       handler: (data: any, context: EventContext) => context,
     });
@@ -95,41 +95,6 @@ describe('makeCloudFunction', () => {
         name: 'resource',
       },
       params: {},
-    });
-  });
-
-  it('should handle Node 8 function signature', () => {
-    let args: any = _.assign({}, cloudFunctionArgs, {
-      handler: (data: any, context: EventContext) => {
-        return { data, context };
-      },
-    });
-    process.env.X_GOOGLE_NEW_FUNCTION_SIGNATURE = 'true';
-    let cf = makeCloudFunction(args);
-    delete process.env.X_GOOGLE_NEW_FUNCTION_SIGNATURE;
-    let testContext = {
-      eventId: '00000',
-      timestamp: '2016-11-04T21:29:03.496Z',
-      eventType: 'provider.event',
-      resource: {
-        service: 'provider',
-        name: 'resource',
-      },
-    };
-    let testData = 'data';
-
-    return expect(cf(testData, testContext)).to.eventually.deep.equal({
-      data: 'data',
-      context: {
-        eventId: '00000',
-        timestamp: '2016-11-04T21:29:03.496Z',
-        eventType: 'provider.event',
-        resource: {
-          service: 'provider',
-          name: 'resource',
-        },
-        params: {},
-      },
     });
   });
 
@@ -178,7 +143,7 @@ describe('makeParams', () => {
   };
   const cf = makeCloudFunction(args);
 
-  it('should construct params from the event resource of new format events', () => {
+  it('should construct params from the event resource of events', () => {
     const testEvent: Event = {
       context: {
         eventId: '111',

--- a/spec/providers/analytics.spec.input.ts
+++ b/spec/providers/analytics.spec.input.ts
@@ -117,10 +117,15 @@ export const fullPayload = JSON.parse(`{
       }
     }
   },
-  "eventId": "1486080145623867projects/analytics-integration-fd82a/events/i_made_this_upproviders/google.firebase.analytics/eventTypes/event.sendprojects/f949d1bb9ef782579-tp/topics/cloud-functions-u54ejabpzs4prfjh7433eklhae",
-  "eventType": "providers/google.firebase.analytics/eventTypes/event.send",
-  "resource": "projects/analytics-integration-fd82a/events/i_made_this_up",
-  "timestamp": "2017-03-29T23:59:59.986371388Z"
+  "context": {
+    "eventId": "1486080145623867projects/analytics-integration-fd82a/events/i_made_this_upproviders/google.firebase.analytics/eventTypes/event.sendprojects/f949d1bb9ef782579-tp/topics/cloud-functions-u54ejabpzs4prfjh7433eklhae",
+    "eventType": "providers/google.firebase.analytics/eventTypes/event.send",
+    "timestamp": "2017-03-29T23:59:59.986371388Z",
+    "resource": {
+      "service": "app-measurement.com",
+      "name": "projects/analytics-integration-fd82a/events/i_made_this_up"
+    }
+  }
 }`);
 
 // The event data that we expect would be constructed if the payload above were to arrive.

--- a/spec/providers/analytics.spec.ts
+++ b/spec/providers/analytics.spec.ts
@@ -22,7 +22,7 @@
 
 import * as analytics from '../../src/providers/analytics';
 import { expect } from 'chai';
-import { LegacyEvent } from '../../src/cloud-functions';
+import { EventContext, Event } from '../../src/cloud-functions';
 import * as analytics_spec_input from './analytics.spec.input';
 import * as functions from '../../src/index';
 
@@ -69,22 +69,33 @@ describe('Analytics Functions', () => {
       it('should handle an event with the appropriate fields', () => {
         const cloudFunction = analytics
           .event('first_open')
-          .onLog((data: analytics.AnalyticsEvent) => data);
+          .onLog(
+            (data: analytics.AnalyticsEvent, context: EventContext) => data
+          );
 
         // The event data delivered over the wire will be the JSON for an AnalyticsEvent:
         // https://firebase.google.com/docs/auth/admin/manage-users#retrieve_user_data
-        let event: LegacyEvent = {
-          eventId: 'f2e2f0bf-2e47-4d92-b009-e7a375ecbd3e',
-          eventType: 'providers/google.firebase.analytics/eventTypes/event.log',
-          resource: 'projects/myUnitTestProject/events/first_open',
+        let event: Event = {
           data: {
             userDim: {
               userId: 'hi!',
             },
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType:
+              'providers/google.firebase.analytics/eventTypes/event.log',
+            resource: {
+              service: 'app-measurement.com',
+              name: 'projects/project1/events/first_open',
+            },
+          },
         };
 
-        return expect(cloudFunction(event)).to.eventually.deep.equal({
+        return expect(
+          cloudFunction(event.data, event.context)
+        ).to.eventually.deep.equal({
           params: {},
           user: {
             userId: 'hi!',
@@ -96,12 +107,14 @@ describe('Analytics Functions', () => {
       it('should remove xValues', () => {
         const cloudFunction = analytics
           .event('first_open')
-          .onLog((data: analytics.AnalyticsEvent) => data);
+          .onLog(
+            (data: analytics.AnalyticsEvent, context: EventContext) => data
+          );
 
         // Incoming events will have four kinds of "xValue" fields: "intValue",
         // "stringValue", "doubleValue" and "floatValue". We expect those to get
         // flattened away, leaving just their values.
-        let event: LegacyEvent = {
+        let event: Event = {
           data: {
             eventDim: [
               {
@@ -133,9 +146,21 @@ describe('Analytics Functions', () => {
               },
             },
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType:
+              'providers/google.firebase.analytics/eventTypes/event.log',
+            resource: {
+              service: 'app-measurement.com',
+              name: 'projects/project1/events/first_open',
+            },
+          },
         };
 
-        return expect(cloudFunction(event)).to.eventually.deep.equal({
+        return expect(
+          cloudFunction(event.data, event.context)
+        ).to.eventually.deep.equal({
           reportingDate: '20170202',
           name: 'Loaded_In_Background',
           params: {
@@ -159,7 +184,7 @@ describe('Analytics Functions', () => {
           .event('first_open')
           .onLog((data: analytics.AnalyticsEvent) => data);
 
-        let event: LegacyEvent = {
+        let event: Event = {
           data: {
             eventDim: [
               {
@@ -181,9 +206,21 @@ describe('Analytics Functions', () => {
               },
             },
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType:
+              'providers/google.firebase.analytics/eventTypes/event.log',
+            resource: {
+              service: 'app-measurement.com',
+              name: 'projects/project1/events/first_open',
+            },
+          },
         };
 
-        return expect(cloudFunction(event)).to.eventually.deep.equal({
+        return expect(
+          cloudFunction(event.data, event.context)
+        ).to.eventually.deep.equal({
           reportingDate: '20170202',
           name: 'Loaded_In_Background',
           params: {},
@@ -217,7 +254,7 @@ describe('Analytics Functions', () => {
         //
         // Separately, the input has a number of microsecond timestamps that we'd
         // like to rename and scale down to milliseconds.
-        let event: LegacyEvent = {
+        let event: Event = {
           data: {
             eventDim: [
               {
@@ -227,9 +264,21 @@ describe('Analytics Functions', () => {
               },
             ],
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType:
+              'providers/google.firebase.analytics/eventTypes/event.log',
+            resource: {
+              service: 'app-measurement.com',
+              name: 'projects/project1/events/first_open',
+            },
+          },
         };
 
-        return expect(cloudFunction(event)).to.eventually.deep.equal({
+        return expect(
+          cloudFunction(event.data, event.context)
+        ).to.eventually.deep.equal({
           reportingDate: '20170202',
           name: 'Loaded_In_Background',
           params: {},
@@ -242,9 +291,11 @@ describe('Analytics Functions', () => {
           .event('first_open')
           .onLog((data: analytics.AnalyticsEvent) => data);
         // The payload in analytics_spec_input contains all possible fields at least once.
-        return expect(
-          cloudFunction(analytics_spec_input.fullPayload)
-        ).to.eventually.deep.equal(analytics_spec_input.data);
+        const data = analytics_spec_input.fullPayload.data;
+        const context = analytics_spec_input.fullPayload.context;
+        return expect(cloudFunction(data, context)).to.eventually.deep.equal(
+          analytics_spec_input.data
+        );
       });
     });
   });
@@ -260,23 +311,35 @@ describe('Analytics Functions', () => {
 
       it('should handle an event with the appropriate fields', () => {
         const cloudFunction = functions.handler.analytics.event.onLog(
-          (data: analytics.AnalyticsEvent) => data
+          (data: analytics.AnalyticsEvent, context: EventContext) => data
         );
 
         // The event data delivered over the wire will be the JSON for an AnalyticsEvent:
         // https://firebase.google.com/docs/auth/admin/manage-users#retrieve_user_data
-        let event: LegacyEvent = {
-          eventId: 'f2e2f0bf-2e47-4d92-b009-e7a375ecbd3e',
-          eventType: 'providers/google.firebase.analytics/eventTypes/event.log',
-          resource: 'projects/myUnitTestProject/events/first_open',
+        let event: Event = {
+          // eventId: 'f2e2f0bf-2e47-4d92-b009-e7a375ecbd3e',
+          // eventType: 'providers/google.firebase.analytics/eventTypes/event.log',
+          // resource: 'projects/myUnitTestProject/events/first_open',
           data: {
             userDim: {
               userId: 'hi!',
             },
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType:
+              'providers/google.firebase.analytics/eventTypes/event.log',
+            resource: {
+              service: 'app-measurement.com',
+              name: 'projects/project1/events/first_open',
+            },
+          },
         };
 
-        return expect(cloudFunction(event)).to.eventually.deep.equal({
+        return expect(
+          cloudFunction(event.data, event.context)
+        ).to.eventually.deep.equal({
           params: {},
           user: {
             userId: 'hi!',

--- a/spec/providers/analytics.spec.ts
+++ b/spec/providers/analytics.spec.ts
@@ -317,9 +317,6 @@ describe('Analytics Functions', () => {
         // The event data delivered over the wire will be the JSON for an AnalyticsEvent:
         // https://firebase.google.com/docs/auth/admin/manage-users#retrieve_user_data
         let event: Event = {
-          // eventId: 'f2e2f0bf-2e47-4d92-b009-e7a375ecbd3e',
-          // eventType: 'providers/google.firebase.analytics/eventTypes/event.log',
-          // resource: 'projects/myUnitTestProject/events/first_open',
           data: {
             userDim: {
               userId: 'hi!',

--- a/spec/providers/auth.spec.ts
+++ b/spec/providers/auth.spec.ts
@@ -23,10 +23,28 @@
 import { expect } from 'chai';
 import * as firebase from 'firebase-admin';
 import * as auth from '../../src/providers/auth';
-import { CloudFunction } from '../../src/cloud-functions';
+import { CloudFunction, EventContext, Event } from '../../src/cloud-functions';
 import * as functions from '../../src/index';
 
 describe('Auth Functions', () => {
+  const event: Event = {
+    data: {
+      metadata: {
+        creationTime: '2016-12-15T19:37:37.059Z',
+        lastSignInTime: '2017-01-01T00:00:00.000Z',
+      },
+    },
+    context: {
+      eventId: '70172329041928',
+      timestamp: '2018-04-09T07:56:12.975Z',
+      eventType: 'providers/firebase.auth/eventTypes/user.delete',
+      resource: {
+        service: 'firebaseauth.googleapis.com',
+        name: 'projects/project1',
+      },
+    },
+  };
+
   describe('AuthBuilder', () => {
     let handler: (user: firebase.auth.UserRecord) => PromiseLike<any> | any;
 
@@ -82,74 +100,31 @@ describe('Auth Functions', () => {
     describe('#_dataConstructor', () => {
       let cloudFunctionCreate: CloudFunction<firebase.auth.UserRecord>;
       let cloudFunctionDelete: CloudFunction<firebase.auth.UserRecord>;
-      let event: any;
 
       before(() => {
         cloudFunctionCreate = auth
           .user()
-          .onCreate((data: firebase.auth.UserRecord) => data);
+          .onCreate(
+            (data: firebase.auth.UserRecord, context: EventContext) => data
+          );
         cloudFunctionDelete = auth
           .user()
-          .onDelete((data: firebase.auth.UserRecord) => data);
-        event = {
-          data: {
-            metadata: {
-              createdAt: '2016-12-15T19:37:37.059Z',
-              lastSignedInAt: '2017-01-01T00:00:00.000Z',
-            },
-          },
-        };
+          .onDelete(
+            (data: firebase.auth.UserRecord, context: EventContext) => data
+          );
       });
 
-      it('should transform wire format for UserRecord into v5.0.0 format', () => {
-        return Promise.all([
-          cloudFunctionCreate(event).then((data: any) => {
+      it('should handle wire format as of v5.0.0 of firebase-admin', () => {
+        return cloudFunctionDelete(event.data, event.context).then(
+          (data: any) => {
             expect(data.metadata.creationTime).to.equal(
               '2016-12-15T19:37:37.059Z'
             );
             expect(data.metadata.lastSignInTime).to.equal(
               '2017-01-01T00:00:00.000Z'
             );
-          }),
-          cloudFunctionDelete(event).then((data: any) => {
-            expect(data.metadata.creationTime).to.equal(
-              '2016-12-15T19:37:37.059Z'
-            );
-            expect(data.metadata.lastSignInTime).to.equal(
-              '2017-01-01T00:00:00.000Z'
-            );
-          }),
-        ]);
-      });
-
-      it('should handle new wire format if/when there is a change', () => {
-        const newEvent = {
-          data: {
-            metadata: {
-              creationTime: '2016-12-15T19:37:37.059Z',
-              lastSignInTime: '2017-01-01T00:00:00.000Z',
-            },
-          },
-        };
-
-        return Promise.all([
-          cloudFunctionCreate(newEvent).then((data: any) => {
-            expect(data.metadata.creationTime).to.equal(
-              '2016-12-15T19:37:37.059Z'
-            );
-            expect(data.metadata.lastSignInTime).to.equal(
-              '2017-01-01T00:00:00.000Z'
-            );
-          }),
-          cloudFunctionDelete(newEvent).then((data: any) => {
-            expect(data.metadata.creationTime).to.equal(
-              '2016-12-15T19:37:37.059Z'
-            );
-            expect(data.metadata.lastSignInTime).to.equal(
-              '2017-01-01T00:00:00.000Z'
-            );
-          }),
-        ]);
+          }
+        );
       });
     });
   });
@@ -213,46 +188,6 @@ describe('Auth Functions', () => {
         const cloudFunction = functions.handler.auth.user.onCreate(() => null);
         expect(cloudFunction.__trigger).to.deep.equal({});
       });
-
-      it('should transform wire format for UserRecord into v5.0.0 format', () => {
-        const event = {
-          data: {
-            metadata: {
-              createdAt: '2016-12-15T19:37:37.059Z',
-              lastSignedInAt: '2017-01-01T00:00:00.000Z',
-            },
-          },
-        };
-
-        return cloudFunctionCreate(event).then((data: any) => {
-          expect(data.metadata.creationTime).to.equal(
-            '2016-12-15T19:37:37.059Z'
-          );
-          expect(data.metadata.lastSignInTime).to.equal(
-            '2017-01-01T00:00:00.000Z'
-          );
-        });
-      });
-
-      it('should handle new wire format if/when there is a change', () => {
-        const newEvent = {
-          data: {
-            metadata: {
-              creationTime: '2016-12-15T19:37:37.059Z',
-              lastSignInTime: '2017-01-01T00:00:00.000Z',
-            },
-          },
-        };
-
-        return cloudFunctionCreate(newEvent).then((data: any) => {
-          expect(data.metadata.creationTime).to.equal(
-            '2016-12-15T19:37:37.059Z'
-          );
-          expect(data.metadata.lastSignInTime).to.equal(
-            '2017-01-01T00:00:00.000Z'
-          );
-        });
-      });
     });
 
     describe('#onDelete', () => {
@@ -268,44 +203,17 @@ describe('Auth Functions', () => {
         expect(cloudFunction.__trigger).to.deep.equal({});
       });
 
-      it('should transform wire format for UserRecord into v5.0.0 format', () => {
-        const event = {
-          data: {
-            metadata: {
-              createdAt: '2016-12-15T19:37:37.059Z',
-              lastSignedInAt: '2017-01-01T00:00:00.000Z',
-            },
-          },
-        };
-
-        return cloudFunctionDelete(event).then((data: any) => {
-          expect(data.metadata.creationTime).to.equal(
-            '2016-12-15T19:37:37.059Z'
-          );
-          expect(data.metadata.lastSignInTime).to.equal(
-            '2017-01-01T00:00:00.000Z'
-          );
-        });
-      });
-
-      it('should handle new wire format if/when there is a change', () => {
-        const newEvent = {
-          data: {
-            metadata: {
-              creationTime: '2016-12-15T19:37:37.059Z',
-              lastSignInTime: '2017-01-01T00:00:00.000Z',
-            },
-          },
-        };
-
-        return cloudFunctionDelete(newEvent).then((data: any) => {
-          expect(data.metadata.creationTime).to.equal(
-            '2016-12-15T19:37:37.059Z'
-          );
-          expect(data.metadata.lastSignInTime).to.equal(
-            '2017-01-01T00:00:00.000Z'
-          );
-        });
+      it('should handle wire format as of v5.0.0 of firebase-admin', () => {
+        return cloudFunctionDelete(event.data, event.context).then(
+          (data: any) => {
+            expect(data.metadata.creationTime).to.equal(
+              '2016-12-15T19:37:37.059Z'
+            );
+            expect(data.metadata.lastSignInTime).to.equal(
+              '2017-01-01T00:00:00.000Z'
+            );
+          }
+        );
       });
     });
   });

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -83,7 +83,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -93,10 +93,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.write',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
         let handler = database.ref('/users/{id}').onWrite((change, context) => {
@@ -132,7 +129,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -142,10 +139,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.create',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
 
@@ -182,7 +176,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -192,10 +186,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.update',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
 
@@ -234,7 +225,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: { foo: 'bar' },
             delta: null,
@@ -244,10 +235,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.delete',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
 
@@ -273,7 +261,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -283,10 +271,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.write',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
 
@@ -312,7 +297,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -322,10 +307,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.create',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
         let handler = functions.handler.database.ref.onCreate(
@@ -350,7 +332,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -360,10 +342,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.update',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
         let handler = functions.handler.database.ref.onUpdate(
@@ -388,7 +367,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event: Event = {
+        const event = {
           data: {
             data: { foo: 'bar' },
             delta: null,
@@ -398,10 +377,7 @@ describe('Database Functions', () => {
             eventType:
               'providers/google.firebase.database/eventTypes/ref.delete',
             timestamp: '2018-04-09T07:56:12.975Z',
-            resource: {
-              name: 'projects/_/instances/subdomains/refs/users',
-              service: 'firebaseio.com',
-            },
+            resource: 'projects/_/instances/subdomains/refs/users',
           },
         };
 

--- a/spec/providers/database.spec.ts
+++ b/spec/providers/database.spec.ts
@@ -25,6 +25,7 @@ import { expect } from 'chai';
 import { apps as appsNamespace } from '../../src/apps';
 import { applyChange } from '../../src/utils';
 import * as functions from '../../src/index';
+import { Event } from '../../src/index';
 
 describe('Database Functions', () => {
   describe('DatabaseBuilder', () => {
@@ -82,18 +83,27 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = database.ref('/users/{id}').onWrite(change => {
-          expect(change.after.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.write',
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.write',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+        let handler = database.ref('/users/{id}').onWrite((change, context) => {
+          expect(change.after.val()).to.deep.equal({ foo: 'bar' });
         });
+
+        return handler(event.data, event.context);
       });
     });
 
@@ -122,18 +132,28 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = database.ref('/users/{id}').onCreate(data => {
-          expect(data.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.create',
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.create',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+
+        let handler = database.ref('/users/{id}').onCreate((data, context) => {
+          expect(data.val()).to.deep.equal({ foo: 'bar' });
         });
+
+        return handler(event.data, event.context);
       });
     });
 
@@ -162,18 +182,30 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = database.ref('/users/{id}').onUpdate(change => {
-          expect(change.after.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.update',
-        });
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.update',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+
+        let handler = database
+          .ref('/users/{id}')
+          .onUpdate((change, context) => {
+            expect(change.after.val()).to.deep.equal({ foo: 'bar' });
+          });
+
+        return handler(event.data, event.context);
       });
     });
 
@@ -202,18 +234,28 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = database.ref('/users/{id}').onDelete(data => {
-          expect(data.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: { foo: 'bar' },
             delta: null,
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.delete',
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.delete',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+
+        let handler = database.ref('/users/{id}').onDelete((data, context) => {
+          expect(data.val()).to.deep.equal({ foo: 'bar' });
         });
+
+        return handler(event.data, event.context);
       });
     });
   });
@@ -231,18 +273,30 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = functions.handler.database.ref.onWrite(change => {
-          return expect(change.after.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.write',
-        });
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.write',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+
+        let handler = functions.handler.database.ref.onWrite(
+          (change, context) => {
+            return expect(change.after.val()).to.deep.equal({ foo: 'bar' });
+          }
+        );
+
+        return handler(event.data, event.context);
       });
     });
 
@@ -258,18 +312,29 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = functions.handler.database.ref.onCreate(data => {
-          return expect(data.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.create',
-        });
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.create',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+        let handler = functions.handler.database.ref.onCreate(
+          (data, context) => {
+            return expect(data.val()).to.deep.equal({ foo: 'bar' });
+          }
+        );
+
+        return handler(event.data, event.context);
       });
     });
 
@@ -285,18 +350,29 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = functions.handler.database.ref.onUpdate(change => {
-          return expect(change.after.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: null,
             delta: { foo: 'bar' },
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.update',
-        });
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.update',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+        let handler = functions.handler.database.ref.onUpdate(
+          (change, context) => {
+            return expect(change.after.val()).to.deep.equal({ foo: 'bar' });
+          }
+        );
+
+        return handler(event.data, event.context);
       });
     });
 
@@ -312,18 +388,30 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        let handler = functions.handler.database.ref.onDelete(data => {
-          return expect(data.val()).to.deep.equal({ foo: 'bar' });
-        });
-
-        return handler({
+        const event: Event = {
           data: {
             data: { foo: 'bar' },
             delta: null,
           },
-          resource: 'projects/_/instances/subdomains/refs/users',
-          eventType: 'providers/google.firebase.database/eventTypes/ref.delete',
-        });
+          context: {
+            eventId: '70172329041928',
+            eventType:
+              'providers/google.firebase.database/eventTypes/ref.delete',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            resource: {
+              name: 'projects/_/instances/subdomains/refs/users',
+              service: 'firebaseio.com',
+            },
+          },
+        };
+
+        let handler = functions.handler.database.ref.onDelete(
+          (data, context) => {
+            return expect(data.val()).to.deep.equal({ foo: 'bar' });
+          }
+        );
+
+        return handler(event.data, event.context);
       });
     });
   });

--- a/spec/providers/firestore.spec.ts
+++ b/spec/providers/firestore.spec.ts
@@ -231,55 +231,69 @@ describe('Firestore Functions', () => {
     });
 
     it('constructs appropriate fields and getters for event.data on "document.write" events', () => {
-      let testFunction = firestore.document('path').onWrite(change => {
-        expect(change.before.data()).to.deep.equal({ key1: false, key2: 111 });
-        expect(change.before.get('key1')).to.equal(false);
-        expect(change.after.data()).to.deep.equal({ key1: true, key2: 123 });
-        expect(change.after.get('key1')).to.equal(true);
-        return true; // otherwise will get warning about returning undefined
-      });
+      let testFunction = firestore
+        .document('path')
+        .onWrite((change, context) => {
+          expect(change.before.data()).to.deep.equal({
+            key1: false,
+            key2: 111,
+          });
+          expect(change.before.get('key1')).to.equal(false);
+          expect(change.after.data()).to.deep.equal({ key1: true, key2: 123 });
+          expect(change.after.get('key1')).to.equal(true);
+          return true; // otherwise will get warning about returning undefined
+        });
       let data = constructEvent(
         createOldValue(),
         createValue(),
         'document.write'
       );
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
 
     it('constructs appropriate fields and getters for event.data on "document.create" events', () => {
-      let testFunction = firestore.document('path').onCreate(data => {
-        expect(data.data()).to.deep.equal({ key1: true, key2: 123 });
-        expect(data.get('key1')).to.equal(true);
-        return true; // otherwise will get warning about returning undefined
-      });
+      let testFunction = firestore
+        .document('path')
+        .onCreate((data, context) => {
+          expect(data.data()).to.deep.equal({ key1: true, key2: 123 });
+          expect(data.get('key1')).to.equal(true);
+          return true; // otherwise will get warning about returning undefined
+        });
       let data = constructEvent({}, createValue(), 'document.create');
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
 
     it('constructs appropriate fields and getters for event.data on "document.update" events', () => {
-      let testFunction = firestore.document('path').onUpdate(change => {
-        expect(change.before.data()).to.deep.equal({ key1: false, key2: 111 });
-        expect(change.before.get('key1')).to.equal(false);
-        expect(change.after.data()).to.deep.equal({ key1: true, key2: 123 });
-        expect(change.after.get('key1')).to.equal(true);
-        return true; // otherwise will get warning about returning undefined
-      });
+      let testFunction = firestore
+        .document('path')
+        .onUpdate((change, context) => {
+          expect(change.before.data()).to.deep.equal({
+            key1: false,
+            key2: 111,
+          });
+          expect(change.before.get('key1')).to.equal(false);
+          expect(change.after.data()).to.deep.equal({ key1: true, key2: 123 });
+          expect(change.after.get('key1')).to.equal(true);
+          return true; // otherwise will get warning about returning undefined
+        });
       let data = constructEvent(
         createOldValue(),
         createValue(),
         'document.update'
       );
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
 
     it('constructs appropriate fields and getters for event.data on "document.delete" events', () => {
-      let testFunction = firestore.document('path').onDelete(data => {
-        expect(data.data()).to.deep.equal({ key1: false, key2: 111 });
-        expect(data.get('key1')).to.equal(false);
-        return true; // otherwise will get warning about returning undefined
-      });
+      let testFunction = firestore
+        .document('path')
+        .onDelete((data, context) => {
+          expect(data.data()).to.deep.equal({ key1: false, key2: 111 });
+          expect(data.get('key1')).to.equal(false);
+          return true; // otherwise will get warning about returning undefined
+        });
       let data = constructEvent(createOldValue(), {}, 'document.delete');
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
   });
 
@@ -294,7 +308,7 @@ describe('Firestore Functions', () => {
 
     it('constructs correct data type and sets trigger to {} on "document.write" events', () => {
       let testFunction = functions.handler.firestore.document.onWrite(
-        change => {
+        (change, context) => {
           expect(change.before.data()).to.deep.equal({
             key1: false,
             key2: 111,
@@ -311,18 +325,20 @@ describe('Firestore Functions', () => {
         createValue(),
         'document.write'
       );
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
 
     it('constructs correct data type and sets trigger to {} on "document.create" events', () => {
-      let testFunction = functions.handler.firestore.document.onCreate(data => {
-        expect(data.data()).to.deep.equal({ key1: true, key2: 123 });
-        expect(data.get('key1')).to.equal(true);
-        return true; // otherwise will get warning about returning undefined
-      });
+      let testFunction = functions.handler.firestore.document.onCreate(
+        (data, context) => {
+          expect(data.data()).to.deep.equal({ key1: true, key2: 123 });
+          expect(data.get('key1')).to.equal(true);
+          return true; // otherwise will get warning about returning undefined
+        }
+      );
       expect(testFunction.__trigger).to.deep.equal({});
       let data = constructEvent({}, createValue(), 'document.create');
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
 
     it('constructs correct data type and sets trigger to {} on "document.update" events', () => {
@@ -344,18 +360,20 @@ describe('Firestore Functions', () => {
         createValue(),
         'document.update'
       );
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
 
     it('constructs correct data type and sets trigger to {} on "document.delete" events', () => {
-      let testFunction = functions.handler.firestore.document.onDelete(data => {
-        expect(data.data()).to.deep.equal({ key1: false, key2: 111 });
-        expect(data.get('key1')).to.equal(false);
-        return true; // otherwise will get warning about returning undefined
-      });
+      let testFunction = functions.handler.firestore.document.onDelete(
+        (data, context) => {
+          expect(data.data()).to.deep.equal({ key1: false, key2: 111 });
+          expect(data.get('key1')).to.equal(false);
+          return true; // otherwise will get warning about returning undefined
+        }
+      );
       let data = constructEvent(createOldValue(), {}, 'document.delete');
       expect(testFunction.__trigger).to.deep.equal({});
-      return testFunction(data);
+      return testFunction(data.data, data.context);
     }).timeout(5000);
   });
 

--- a/spec/providers/pubsub.spec.ts
+++ b/spec/providers/pubsub.spec.ts
@@ -23,6 +23,7 @@
 import { expect } from 'chai';
 import * as pubsub from '../../src/providers/pubsub';
 import * as functions from '../../src/index';
+import { Event } from '../../src/index';
 
 describe('Pubsub Functions', () => {
   describe('pubsub.Message', () => {
@@ -105,16 +106,25 @@ describe('Pubsub Functions', () => {
 
       it('should properly handle a new-style event', () => {
         const raw = new Buffer('{"hello":"world"}', 'utf8').toString('base64');
-        const event = {
+        const event: Event = {
           data: {
             data: raw,
             attributes: {
               foo: 'bar',
             },
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.pubsub.topic.publish',
+            resource: {
+              service: 'pubsub.googleapis.com',
+              name: 'projects/project1/topics/toppy',
+            },
+          },
         };
 
-        const result = pubsub.topic('toppy').onPublish(data => {
+        const result = pubsub.topic('toppy').onPublish((data, context) => {
           return {
             raw: data.data,
             json: data.json,
@@ -122,13 +132,16 @@ describe('Pubsub Functions', () => {
           };
         });
 
-        return expect(result(event)).to.eventually.deep.equal({
+        return expect(
+          result(event.data, event.context)
+        ).to.eventually.deep.equal({
           raw,
           json: { hello: 'world' },
           attributes: { foo: 'bar' },
         });
       });
     });
+
     describe('#schedule', () => {
       it('should return a trigger with schedule', () => {
         let result = pubsub.schedule('every 5 minutes').onRun(context => null);
@@ -136,6 +149,7 @@ describe('Pubsub Functions', () => {
           schedule: 'every 5 minutes',
         });
       });
+
       it('should return a trigger with schedule and timeZone when one is chosen', () => {
         let result = pubsub
           .schedule('every 5 minutes')
@@ -146,6 +160,7 @@ describe('Pubsub Functions', () => {
           timeZone: 'America/New_York',
         });
       });
+
       it('should return a trigger with schedule and retry config when called with retryConfig', () => {
         let retryConfig = {
           retryCount: 3,
@@ -166,6 +181,7 @@ describe('Pubsub Functions', () => {
           'deployment-scheduled': 'true',
         });
       });
+
       it('should return a trigger with schedule, timeZone and retry config when called with retryConfig and timeout', () => {
         let retryConfig = {
           retryCount: 3,
@@ -188,6 +204,7 @@ describe('Pubsub Functions', () => {
           'deployment-scheduled': 'true',
         });
       });
+
       it('should return an appropriate trigger when called with region and options', () => {
         let result = functions
           .region('us-east1')
@@ -204,6 +221,7 @@ describe('Pubsub Functions', () => {
         expect(result.__trigger.availableMemoryMb).to.deep.equal(256);
         expect(result.__trigger.timeout).to.deep.equal('90s');
       });
+
       it('should return an appropriate trigger when called with region, timeZone, and options', () => {
         let result = functions
           .region('us-east1')
@@ -222,6 +240,7 @@ describe('Pubsub Functions', () => {
         expect(result.__trigger.availableMemoryMb).to.deep.equal(256);
         expect(result.__trigger.timeout).to.deep.equal('90s');
       });
+
       it('should return an appropriate trigger when called with region, options and retryConfig', () => {
         let retryConfig = {
           retryCount: 3,
@@ -250,6 +269,7 @@ describe('Pubsub Functions', () => {
         expect(result.__trigger.availableMemoryMb).to.deep.equal(256);
         expect(result.__trigger.timeout).to.deep.equal('90s');
       });
+
       it('should return an appropriate trigger when called with region, options, retryConfig, and timeZone', () => {
         let retryConfig = {
           retryCount: 3,
@@ -299,6 +319,15 @@ describe('Pubsub Functions', () => {
               foo: 'bar',
             },
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.pubsub.topic.publish',
+            resource: {
+              service: 'pubsub.googleapis.com',
+              name: 'projects/project1/topics/toppy',
+            },
+          },
         };
 
         const result = functions.handler.pubsub.topic.onPublish(data => {
@@ -309,7 +338,9 @@ describe('Pubsub Functions', () => {
           };
         });
 
-        return expect(result(event)).to.eventually.deep.equal({
+        return expect(
+          result(event.data, event.context)
+        ).to.eventually.deep.equal({
           raw,
           json: { hello: 'world' },
           attributes: { foo: 'bar' },

--- a/spec/providers/remoteConfig.spec.ts
+++ b/spec/providers/remoteConfig.spec.ts
@@ -20,10 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 import { expect } from 'chai';
-import * as admin from 'firebase-admin';
 import * as _ from 'lodash';
 
-import { CloudFunction } from '../../src/cloud-functions';
+import {
+  CloudFunction,
+  Event,
+  TriggerAnnotated,
+  EventContext,
+} from '../../src/cloud-functions';
 import * as functions from '../../src/index';
 import * as remoteConfig from '../../src/providers/remoteConfig';
 
@@ -42,7 +46,7 @@ describe('RemoteConfig Functions', () => {
     };
   }
 
-  function makeEvent(data: any, context?: { [key: string]: any }) {
+  function makeEvent(data: any, context: { [key: string]: any }): Event {
     context = context || {};
     return {
       data: data,
@@ -62,12 +66,14 @@ describe('RemoteConfig Functions', () => {
   }
 
   describe('#onUpdate', () => {
-    function expectedTrigger() {
+    function expectedTrigger(): TriggerAnnotated {
       return {
-        eventTrigger: {
-          resource: 'projects/project1',
-          eventType: 'google.firebase.remoteconfig.update',
-          service: 'firebaseremoteconfig.googleapis.com',
+        __trigger: {
+          eventTrigger: {
+            resource: 'projects/project1',
+            eventType: 'google.firebase.remoteconfig.update',
+            service: 'firebaseremoteconfig.googleapis.com',
+          },
         },
       };
     }
@@ -82,7 +88,9 @@ describe('RemoteConfig Functions', () => {
 
     it('should have the correct trigger', () => {
       const cloudFunction = remoteConfig.onUpdate(() => null);
-      expect(cloudFunction.__trigger).to.deep.equal(expectedTrigger());
+      expect(cloudFunction.__trigger).to.deep.equal(
+        expectedTrigger().__trigger
+      );
     });
 
     it('should allow both region and runtime options to be set', () => {
@@ -102,14 +110,26 @@ describe('RemoteConfig Functions', () => {
 
   describe('unwraps TemplateVersion', () => {
     let cloudFunctionUpdate: CloudFunction<remoteConfig.TemplateVersion>;
-    let event: any;
+    let event: Event;
+
     before(() => {
       process.env.GCLOUD_PROJECT = 'project1';
       cloudFunctionUpdate = remoteConfig.onUpdate(
-        (version: remoteConfig.TemplateVersion) => version
+        (version: remoteConfig.TemplateVersion, context: EventContext) =>
+          version
       );
+
       event = {
         data: constructVersion(),
+        context: {
+          eventId: '70172329041928',
+          timestamp: '2018-04-09T07:56:12.975Z',
+          eventType: 'google.firebase.remoteconfig.update',
+          resource: {
+            service: 'firebaseremoteconfig.googleapis.com',
+            name: 'projects/project1',
+          },
+        },
       };
     });
 
@@ -119,9 +139,11 @@ describe('RemoteConfig Functions', () => {
 
     it('should unwrap the version in the event', () => {
       return Promise.all([
-        cloudFunctionUpdate(event).then((data: any) => {
-          expect(data).to.deep.equal(constructVersion());
-        }),
+        cloudFunctionUpdate(event.data, event.context).then(
+          (data: any, context: any) => {
+            expect(data).to.deep.equal(constructVersion());
+          }
+        ),
       ]);
     });
   });
@@ -137,16 +159,28 @@ describe('RemoteConfig Functions', () => {
 
       it('should correctly unwrap the event', () => {
         let cloudFunctionUpdate = functions.handler.remoteConfig.onUpdate(
-          (version: remoteConfig.TemplateVersion) => version
+          (version: remoteConfig.TemplateVersion, context: EventContext) =>
+            version
         );
-        let event = {
+        let event: Event = {
           data: constructVersion(),
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.firebase.remoteconfig.update',
+            resource: {
+              service: 'firebaseremoteconfig.googleapis.com',
+              name: 'projects/project1',
+            },
+          },
         };
 
         return Promise.all([
-          cloudFunctionUpdate(event).then((data: any) => {
-            expect(data).to.deep.equal(constructVersion());
-          }),
+          cloudFunctionUpdate(event.data, event.context).then(
+            (data: any, context: any) => {
+              expect(data).to.deep.equal(constructVersion());
+            }
+          ),
         ]);
       });
     });

--- a/spec/providers/storage.spec.ts
+++ b/spec/providers/storage.spec.ts
@@ -23,6 +23,7 @@
 import { expect } from 'chai';
 import * as storage from '../../src/providers/storage';
 import * as functions from '../../src/index';
+import { Event, EventContext } from '../../src/index';
 
 describe('Storage Functions', () => {
   describe('ObjectBuilder', () => {
@@ -106,14 +107,26 @@ describe('Storage Functions', () => {
         let cloudFunction = storage.object().onArchive(data => {
           return data.mediaLink;
         });
-        let goodMediaLinkEvent = {
+        let goodMediaLinkEvent: Event = {
           data: {
             mediaLink:
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.archive',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -180,8 +193,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.delete',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -248,8 +273,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.finalize',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -316,8 +353,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.metadataUpdate',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -353,8 +402,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.archive',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -378,8 +439,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.delete',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -405,8 +478,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.finalize',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });
@@ -432,8 +517,20 @@ describe('Storage Functions', () => {
               'https://www.googleapis.com/storage/v1/b/mybucket.appspot.com' +
               '/o/nestedfolder%2Fanotherfolder%2Fmyobject.file?generation=12345&alt=media',
           },
+          context: {
+            eventId: '70172329041928',
+            timestamp: '2018-04-09T07:56:12.975Z',
+            eventType: 'google.storage.object.metadataUpdate',
+            resource: {
+              service: 'storage.googleapis.com',
+              name: 'projects/_/buckets/bucky',
+            },
+          },
         };
-        return cloudFunction(goodMediaLinkEvent).then((result: any) => {
+        return cloudFunction(
+          goodMediaLinkEvent.data,
+          goodMediaLinkEvent.context
+        ).then((result: any, context: EventContext) => {
           expect(result).equals(goodMediaLinkEvent.data.mediaLink);
         });
       });

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -28,19 +28,6 @@ export { Request, Response };
 
 const WILDCARD_REGEX = new RegExp('{[^/{}]*}', 'g');
 
-/** Legacy wire format for an event
- * @internal
- */
-export interface LegacyEvent {
-  data: any;
-  eventType?: string;
-  resource?: string;
-  eventId?: string;
-  timestamp?: string;
-  params?: { [option: string]: any };
-  auth?: apps.AuthMode;
-}
-
 /** Wire format for an event
  * @internal
  */
@@ -338,10 +325,6 @@ export function makeCloudFunction<EventData>({
 
   cloudFunction.run = handler || contextOnlyHandler;
   return cloudFunction;
-}
-
-function isEvent(event: Event | LegacyEvent): event is Event {
-  return _.has(event, 'context');
 }
 
 function _makeParams(

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -239,9 +239,7 @@ export function makeCloudFunction<EventData>({
   opts = {},
   labels = {},
 }: MakeCloudFunctionArgs<EventData>): CloudFunction<EventData> {
-  let cloudFunction;
-
-  let cloudFunctionNewSignature: any = (data: any, context: any) => {
+  let cloudFunction: any = (data: any, context: any) => {
     if (legacyEventType && context.eventType === legacyEventType) {
       // v1beta1 event flow has different format for context, transform them to new format.
       context.eventType = provider + '.' + eventType;
@@ -300,8 +298,6 @@ export function makeCloudFunction<EventData>({
         return Promise.reject(err);
       });
   };
-
-  cloudFunction = cloudFunctionNewSignature;
 
   Object.defineProperty(cloudFunction, '__trigger', {
     get: () => {

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -255,6 +255,15 @@ export function makeCloudFunction<EventData>({
   let cloudFunction;
 
   let cloudFunctionNewSignature: any = (data: any, context: any) => {
+    if (legacyEventType && context.eventType === legacyEventType) {
+      // v1beta1 event flow has different format for context, transform them to new format.
+      context.eventType = provider + '.' + eventType;
+      context.resource = {
+        service: service,
+        name: context.resource,
+      };
+    }
+
     let event: Event = {
       data,
       context,

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -140,11 +140,7 @@ export function userRecordConstructor(
     _.set(
       record,
       'metadata',
-      new UserRecordMetadata(
-        // Transform payload to firebase-admin v5.0.0 format because wire format is different (BUG 63167395)
-        meta.createdAt || meta.creationTime,
-        meta.lastSignedInAt || meta.lastSignInTime
-      )
+      new UserRecordMetadata(meta.creationTime, meta.lastSignInTime)
     );
   } else {
     _.set(record, 'metadata', new UserRecordMetadata(null, null));


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
As part of dropping Node 6 support, we can drop support for `LegacyEvent`, which was the event format used in the Node 6 runtime in Cloud Functions.

`LegacyEvent` refers to the old function signature used in Node 6 runtime where the event comes in as a [single param](https://cloud.google.com/functions/docs/writing/background#functions_background_parameters-node6). `Event` is the new function signature used in Node 8 and up where the function accepts [two parameters](https://cloud.google.com/functions/docs/writing/background#functions_background_parameters-node8-10): `data, context`. Now, `LegacyEventType` refers to `v1beta1` format and is unrelated to `LegacyEvent`. We still need to support `v1beta1` formats while removing Node 6 event format.

Additionally, this PR fixes https://github.com/firebase/firebase-functions/issues/447 since I've now removed the fork in the code that looks for an env var that is only set in Node 8.

### Testing
Integration tests are passing and they test all our providers. Providers are split between using `v1beta1` format and `v1beta2` format with most still on `v1beta1`.

#### `v1beta1`
* Auth
* Analytics
* Crashlytics
* Database (even though they have entries in both, they're still on v1beta1)
* Firestore

#### `v1beta2`
* Pubsub
* RemoteConfig
* Storage
