### PR TITLE
Add required types to Functions SDK

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+* Includes required types for functions SDK.

--- a/package.json
+++ b/package.json
@@ -29,6 +29,10 @@
     "test": "mocha -r ts-node/register ./spec/index.spec.ts"
   },
   "dependencies": {
+    "@types/cors": "^2.8.5",
+    "@types/express": "^4.11.1",
+    "@types/jsonwebtoken": "^8.3.2",
+    "@types/lodash": "^4.14.133",
     "cors": "^2.8.4",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.3.2",

--- a/package.json
+++ b/package.json
@@ -41,10 +41,6 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/chai-as-promised": "^7.1.0",
-    "@types/cors": "^2.8.5",
-    "@types/express": "^4.11.1",
-    "@types/jsonwebtoken": "^8.3.2",
-    "@types/lodash": "^4.14.133",
     "@types/mocha": "^5.2.7",
     "@types/mock-require": "^2.0.0",
     "@types/nock": "^10.0.2",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Adds back the required types that were moved to devDependencies previously.