### PR TITLE
Fix lint errors in /spec files at the top level

### DIFF
--- a/spec/apps.spec.ts
+++ b/spec/apps.spec.ts
@@ -22,6 +22,7 @@
 
 import { expect } from 'chai';
 import { apps as appsNamespace } from '../src/apps';
+
 import * as firebase from 'firebase-admin';
 import * as _ from 'lodash';
 import * as sinon from 'sinon';
@@ -29,6 +30,7 @@ import * as sinon from 'sinon';
 describe('apps', () => {
   let apps: appsNamespace.Apps;
   let claims;
+
   beforeEach(() => {
     apps = new appsNamespace.Apps();
     // mock claims intentionally contains dots, square brackets, and nested paths
@@ -52,37 +54,37 @@ describe('apps', () => {
       clock.restore();
     });
 
-    it('should retain/release ref counters appropriately', function() {
+    it('should retain/release ref counters appropriately', () => {
       apps.retain();
-      expect(apps['_refCounter']).to.deep.equal({
+      expect(_.get(apps, '_refCounter')).to.deep.equal({
         __admin__: 1,
       });
       apps.release();
       clock.tick(appsNamespace.garbageCollectionInterval);
       return Promise.resolve().then(() => {
-        expect(apps['_refCounter']).to.deep.equal({
+        expect(_.get(apps, '_refCounter')).to.deep.equal({
           __admin__: 0,
         });
       });
     });
 
-    it('should only decrement counter after garbageCollectionInterval is up', function() {
+    it('should only decrement counter after garbageCollectionInterval is up', () => {
       apps.retain();
       apps.release();
       clock.tick(appsNamespace.garbageCollectionInterval / 2);
-      expect(apps['_refCounter']).to.deep.equal({
+      expect(_.get(apps, '_refCounter')).to.deep.equal({
         __admin__: 1,
       });
       clock.tick(appsNamespace.garbageCollectionInterval / 2);
       return Promise.resolve().then(() => {
-        expect(apps['_refCounter']).to.deep.equal({
+        expect(_.get(apps, '_refCounter')).to.deep.equal({
           __admin__: 0,
         });
       });
     });
 
-    it('should call _destroyApp if app no longer used', function() {
-      let spy = sinon.spy(apps, '_destroyApp');
+    it('should call _destroyApp if app no longer used', () => {
+      const spy = sinon.spy(apps, '_destroyApp');
       apps.retain();
       apps.release();
       clock.tick(appsNamespace.garbageCollectionInterval);
@@ -91,8 +93,8 @@ describe('apps', () => {
       });
     });
 
-    it('should not call _destroyApp if app used again while waiting for release', function() {
-      let spy = sinon.spy(apps, '_destroyApp');
+    it('should not call _destroyApp if app used again while waiting for release', () => {
+      const spy = sinon.spy(apps, '_destroyApp');
       apps.retain();
       apps.release();
       clock.tick(appsNamespace.garbageCollectionInterval / 2);
@@ -103,22 +105,22 @@ describe('apps', () => {
       });
     });
 
-    it('should increment ref counter for each subsequent retain', function() {
+    it('should increment ref counter for each subsequent retain', () => {
       apps.retain();
-      expect(apps['_refCounter']).to.deep.equal({
+      expect(_.get(apps, '_refCounter')).to.deep.equal({
         __admin__: 1,
       });
       apps.retain();
-      expect(apps['_refCounter']).to.deep.equal({
+      expect(_.get(apps, '_refCounter')).to.deep.equal({
         __admin__: 2,
       });
       apps.retain();
-      expect(apps['_refCounter']).to.deep.equal({
+      expect(_.get(apps, '_refCounter')).to.deep.equal({
         __admin__: 3,
       });
     });
 
-    it('should work with staggering sets of retain/release', function() {
+    it('should work with staggering sets of retain/release', () => {
       apps.retain();
       apps.release();
       clock.tick(appsNamespace.garbageCollectionInterval / 2);
@@ -128,14 +130,14 @@ describe('apps', () => {
       return Promise.resolve()
         .then(() => {
           // Counters are still 1 due second set of retain/release
-          expect(apps['_refCounter']).to.deep.equal({
+          expect(_.get(apps, '_refCounter')).to.deep.equal({
             __admin__: 1,
           });
           clock.tick(appsNamespace.garbageCollectionInterval / 2);
         })
         .then(() => {
           // It's now been a full interval since the second set of retain/release
-          expect(apps['_refCounter']).to.deep.equal({
+          expect(_.get(apps, '_refCounter')).to.deep.equal({
             __admin__: 0,
           });
         });

--- a/spec/cloud-functions.spec.ts
+++ b/spec/cloud-functions.spec.ts
@@ -20,14 +20,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import * as _ from 'lodash';
 import { expect } from 'chai';
+import * as _ from 'lodash';
+
 import {
+  Change,
   Event,
   EventContext,
   makeCloudFunction,
   MakeCloudFunctionArgs,
-  Change,
 } from '../src/cloud-functions';
 
 describe('makeCloudFunction', () => {
@@ -41,7 +42,7 @@ describe('makeCloudFunction', () => {
   };
 
   it('should put a __trigger on the returned CloudFunction', () => {
-    let cf = makeCloudFunction({
+    const cf = makeCloudFunction({
       provider: 'mock.provider',
       eventType: 'mock.event',
       service: 'service',
@@ -58,7 +59,7 @@ describe('makeCloudFunction', () => {
   });
 
   it('should have legacy event type in __trigger if provided', () => {
-    let cf = makeCloudFunction(cloudFunctionArgs);
+    const cf = makeCloudFunction(cloudFunctionArgs);
     expect(cf.__trigger).to.deep.equal({
       eventTrigger: {
         eventType: 'providers/provider/eventTypes/event',
@@ -69,11 +70,11 @@ describe('makeCloudFunction', () => {
   });
 
   it('should construct the right context for event', () => {
-    let args: any = _.assign({}, cloudFunctionArgs, {
+    const args: any = _.assign({}, cloudFunctionArgs, {
       handler: (data: any, context: EventContext) => context,
     });
-    let cf = makeCloudFunction(args);
-    let test: Event = {
+    const cf = makeCloudFunction(args);
+    const test: Event = {
       context: {
         eventId: '00000',
         timestamp: '2016-11-04T21:29:03.496Z',
@@ -99,12 +100,12 @@ describe('makeCloudFunction', () => {
   });
 
   it('should throw error when context.params accessed in handler environment', () => {
-    let args: any = _.assign({}, cloudFunctionArgs, {
+    const args: any = _.assign({}, cloudFunctionArgs, {
       handler: (data: any, context: EventContext) => context,
       triggerResource: () => null,
     });
-    let cf = makeCloudFunction(args);
-    let test: Event = {
+    const cf = makeCloudFunction(args);
+    const test: Event = {
       context: {
         eventId: '00000',
         timestamp: '2016-11-04T21:29:03.496Z',
@@ -179,7 +180,7 @@ describe('makeAuth and makeAuthType', () => {
       };
     },
   };
-  let cf = makeCloudFunction(args);
+  const cf = makeCloudFunction(args);
 
   it('should construct correct auth and authType for admin user', () => {
     const testEvent = {
@@ -311,7 +312,7 @@ describe('Change', () => {
 
   describe('fromJSON', () => {
     it('should create a Change object with a `before` and `after`', () => {
-      let created = Change.fromJSON<any>({
+      const created = Change.fromJSON<any>({
         before: { foo: 'bar' },
         after: { foo: 'faz' },
       });
@@ -325,7 +326,7 @@ describe('Change', () => {
         _.set(input, 'another', 'value');
         return input as T;
       }
-      let created = Change.fromJSON<Object>(
+      const created = Change.fromJSON<object>(
         {
           before: { foo: 'bar' },
           after: { foo: 'faz' },

--- a/spec/config.spec.ts
+++ b/spec/config.spec.ts
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import * as mockRequire from 'mock-require';
 import { expect } from 'chai';
+import * as mockRequire from 'mock-require';
 import { config, firebaseConfig } from '../src/config';
 
 describe('config()', () => {
@@ -34,7 +34,7 @@ describe('config()', () => {
 
   it('loads config values from .runtimeconfig.json', () => {
     mockRequire('../../../.runtimeconfig.json', { foo: 'bar', firebase: {} });
-    let loaded = config();
+    const loaded = config();
     expect(loaded).to.not.have.property('firebase');
     expect(loaded).to.have.property('foo', 'bar');
   });

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -34,7 +34,7 @@ describe('FunctionBuilder', () => {
   });
 
   it('should allow supported region to be set', () => {
-    let fn = functions
+    const fn = functions
       .region('us-east1')
       .auth.user()
       .onCreate(user => user);
@@ -43,7 +43,7 @@ describe('FunctionBuilder', () => {
   });
 
   it('should allow multiple supported regions to be set', () => {
-    let fn = functions
+    const fn = functions
       .region('us-east1', 'us-central1')
       .auth.user()
       .onCreate(user => user);
@@ -52,7 +52,7 @@ describe('FunctionBuilder', () => {
   });
 
   it('should allow all supported regions to be set', () => {
-    let fn = functions
+    const fn = functions
       .region(
         'us-central1',
         'us-east1',
@@ -75,7 +75,7 @@ describe('FunctionBuilder', () => {
   });
 
   it('should allow valid runtime options to be set', () => {
-    let fn = functions
+    const fn = functions
       .runWith({
         timeoutSeconds: 90,
         memory: '256MB',
@@ -88,7 +88,7 @@ describe('FunctionBuilder', () => {
   });
 
   it('should allow both supported region and valid runtime options to be set', () => {
-    let fn = functions
+    const fn = functions
       .region('europe-west2')
       .runWith({
         timeoutSeconds: 90,
@@ -103,7 +103,7 @@ describe('FunctionBuilder', () => {
   });
 
   it('should allow both valid runtime options and supported region to be set in reverse order', () => {
-    let fn = functions
+    const fn = functions
       .runWith({
         timeoutSeconds: 90,
         memory: '256MB',

--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -28,19 +28,20 @@ import * as nock from 'nock';
 nock.disableNetConnect();
 
 import 'mocha';
-import './utils.spec';
+
 import './apps.spec';
 import './cloud-functions.spec';
 import './config.spec';
-import './setup.spec';
-import './testing.spec';
 import './function-builder.spec';
 import './providers/analytics.spec';
 import './providers/auth.spec';
+import './providers/crashlytics.spec';
 import './providers/database.spec';
 import './providers/firestore.spec';
 import './providers/https.spec';
 import './providers/pubsub.spec';
 import './providers/remoteConfig.spec';
 import './providers/storage.spec';
-import './providers/crashlytics.spec';
+import './setup.spec';
+import './testing.spec';
+import './utils.spec';

--- a/spec/testing.spec.ts
+++ b/spec/testing.spec.ts
@@ -26,7 +26,7 @@ import * as testing from '../src/testing';
 
 // TODO(rjh): As actual testing methods become available, replace this with actual tests.
 describe('testing', () => {
-  it('should be accessible through the entrypoint', function() {
+  it('should be accessible through the entrypoint', () => {
     expect(testing.whereAreTheBugs()).to.not.equal('Earth');
   });
 });

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -20,8 +20,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { normalizePath, pathParts, valAt, applyChange } from '../src/utils';
 import { expect } from 'chai';
+import { applyChange, normalizePath, pathParts, valAt } from '../src/utils';
 
 describe('utils', () => {
   describe('.normalizePath(path: string)', () => {
@@ -71,9 +71,9 @@ describe('utils', () => {
     });
 
     it('should return the merged value of two objects', () => {
-      let from = { a: { b: 'foo', c: 23, d: 444 }, d: { e: 42 } };
-      let to: any = { a: { b: 'bar', c: null }, d: null, e: { f: 'g' } };
-      let result = { a: { b: 'bar', d: 444 }, e: { f: 'g' } };
+      const from = { a: { b: 'foo', c: 23, d: 444 }, d: { e: 42 } };
+      const to: any = { a: { b: 'bar', c: null }, d: null, e: { f: 'g' } };
+      const result = { a: { b: 'bar', d: 444 }, e: { f: 'g' } };
       expect(applyChange(from, to)).to.deep.equal(result);
     });
   });


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Fixes lint errors for all top level files in the `spec` directory.

### Testing
With the linter set up like in https://github.com/firebase/firebase-functions/pull/467:
`npm run lint | grep <filename>` should not return any warnings. 
For example: `npm run lint | grep apps.spec.ts`.
