### PR TITLE
Add RC integration tests back in

### DIFF
--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -12,7 +12,7 @@ export * from './database-tests';
 export * from './auth-tests';
 export * from './firestore-tests';
 export * from './https-tests';
-// export * from './remoteConfig-tests';
+export * from './remoteConfig-tests';
 export * from './storage-tests';
 const numTests = Object.keys(exports).length; // Assumption: every exported function is its own test.
 
@@ -127,25 +127,25 @@ export const integrationTests: any = functions
       // Invoke a callable HTTPS trigger.
       callHttpsTrigger('callableTests', { foo: 'bar', testId }, baseUrl),
       // A Remote Config update to trigger the Remote Config tests.
-      // admin.credential
-      //   .applicationDefault()
-      //   .getAccessToken()
-      //   .then(accessToken => {
-      //     const options = {
-      //       hostname: 'firebaseremoteconfig.googleapis.com',
-      //       path: `/v1/projects/${firebaseConfig.projectId}/remoteConfig`,
-      //       method: 'PUT',
-      //       headers: {
-      //         Authorization: 'Bearer ' + accessToken.access_token,
-      //         'Content-Type': 'application/json; UTF-8',
-      //         'Accept-Encoding': 'gzip',
-      //         'If-Match': '*',
-      //       },
-      //     };
-      //     const request = https.request(options, resp => {});
-      //     request.write(JSON.stringify({ version: { description: testId } }));
-      //     request.end();
-      //   }),
+      admin.credential
+        .applicationDefault()
+        .getAccessToken()
+        .then(accessToken => {
+          const options = {
+            hostname: 'firebaseremoteconfig.googleapis.com',
+            path: `/v1/projects/${firebaseConfig.projectId}/remoteConfig`,
+            method: 'PUT',
+            headers: {
+              Authorization: 'Bearer ' + accessToken.access_token,
+              'Content-Type': 'application/json; UTF-8',
+              'Accept-Encoding': 'gzip',
+              'If-Match': '*',
+            },
+          };
+          const request = https.request(options, resp => {});
+          request.write(JSON.stringify({ version: { description: testId } }));
+          request.end();
+        }),
       // A storage upload to trigger the Storage tests
       admin
         .storage()

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -130,7 +130,7 @@ export const integrationTests: any = functions
       admin.credential
         .applicationDefault()
         .getAccessToken()
-        .then(accessToken => {
+        .then((accessToken) => {
           const options = {
             hostname: 'firebaseremoteconfig.googleapis.com',
             path: `/v1/projects/${firebaseConfig.projectId}/remoteConfig`,
@@ -142,7 +142,7 @@ export const integrationTests: any = functions
               'If-Match': '*',
             },
           };
-          const request = https.request(options, resp => {});
+          const request = https.request(options, (resp) => {});
           request.write(JSON.stringify({ version: { description: testId } }));
           request.end();
         }),


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Remote Config integration tests were previously commented out because of an issue running them in preprod environment (bug reference 124524632). I was able to run with these tests uncommented out in both prod and preprod environments with all tests passing.

### Code sample
Ensure the project you're using to run the tests has billing enabled and Firestore API enabled with Firestore created.

```
# to run in prod:
./integration_test/run_tests.sh <project_id>

# to run in preprod, first set this env var:
export FIREBASE_FUNCTIONS_URL="https://preprod-cloudfunctions.sandbox.googleapis.com"
./integration_test/run_tests.sh <project_id>

# unset the env var:
unset FIREBASE_FUNCTIONS_URL
```