### PR TITLE
Remove delay from integration tests and remove parallelization

### DIFF
--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -4,25 +4,18 @@
 set -e
 
 function usage {
-  echo "Usage: $0 <project_id_node_8> [<project_id_node_10>]"
+  echo "Usage: $0 <project_id>"
   exit 1
 }
 
-# This script takes 1 or 2 arguments, both of which are Firebase project ids.
-# If only one argument is given, that project will be used for both node 8 and node 10
-# Otherwise, first argument will be used for node 8 and second argument will be used 
-# for node 10. 
-# Note that at least one argument is required.
+# This script takes in one argument specifying a project_id
+# Example usage (from root dir):
+# ./integration_test/run_tests.sh chenky-test-proj
 if [[ $1 == "" ]]; then
   usage
 fi
-if [[ $2 == "" ]]; then
-  PROJECT_ID_NODE_8=$1
-  PROJECT_ID_NODE_10=$1
-else
-  PROJECT_ID_NODE_8=$1
-  PROJECT_ID_NODE_10=$2
-fi
+
+PROJECT_ID=$1
 
 # Directory where this script lives.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -41,13 +34,11 @@ function build_sdk {
 
 function pick_node8 {
   cd $DIR
-  PROJECT_ID=$PROJECT_ID_NODE_8
   cp package.node8.json functions/package.json
 }
 
 function pick_node10 {
   cd $DIR
-  PROJECT_ID=$PROJECT_ID_NODE_10
   cp package.node10.json functions/package.json
 }
 
@@ -63,10 +54,7 @@ function delete_all_functions {
   cd $DIR
   # Try to delete, if there are errors it is because the project is already empty,
   # in that case do nothing. 
-  firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID_NODE_8 || : &
-  if ! [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
-    firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID_NODE_10 || : &
-  fi
+  firebase functions:delete callableTests createUserTests databaseTests deleteUserTests firestoreTests integrationTests pubsubTests remoteConfigTests --force --project=$PROJECT_ID || : &
   wait
   announce "Project emptied."
 }
@@ -76,34 +64,6 @@ function deploy {
   ./functions/node_modules/.bin/tsc -p functions/
   # Deploy functions, and security rules for database and Firestore. If the deploy fails, retry twice
   for i in 1 2 3; do firebase deploy --project=$PROJECT_ID --only functions,database,firestore && break; done
-}
-
-# At the moment, functions take 30-40 seconds AFTER firebase deploy returns successfully to go live
-# This needs to be fixed separately
-# However, so that we have working integration tests in the interim, waitForPropagation is a workaround
-function waitForPropagation {
-  announce "Waiting 50 seconds for functions changes to propagate"
-  sleep 50
-}
-
-function run_all_tests {
-  announce "Running the integration tests..."
-
-  # Constructs the URLs for both test functions. This may change in the future,
-  # causing this script to start failing, but currently we don't have a very
-  # reliable way of determining the URL dynamically.
-  TEST_DOMAIN="cloudfunctions.net"
-  if [[ $FIREBASE_FUNCTIONS_URL == "https://preprod-cloudfunctions.sandbox.googleapis.com" ]]; then
-    TEST_DOMAIN="txcloud.net"
-  fi
-  TEST_URL_NODE_8="https://us-central1-$PROJECT_ID_NODE_8.$TEST_DOMAIN/integrationTests"
-  TEST_URL_NODE_10="https://us-central1-$PROJECT_ID_NODE_10.$TEST_DOMAIN/integrationTests"
-  echo $TEST_URL_NODE_8
-  echo $TEST_URL_NODE_10
-  curl --fail $TEST_URL_NODE_8 & NODE8PID=$!
-  curl --fail $TEST_URL_NODE_10 & NODE10PID=$!
-  wait $NODE8PID && echo 'node 8 passed' || (announce 'Node 8 tests failed'; cleanup; announce 'Tests failed'; exit 1)
-  wait $NODE10PID && echo 'node 10 passed' || (announce 'Node 10 tests failed'; cleanup; announce 'Tests failed'; exit 1)
 }
 
 function run_tests {
@@ -131,24 +91,23 @@ function cleanup {
   rm -rf $DIR/functions/node_modules/firebase-functions
 }
 
+# Setup
 build_sdk
-pick_node8
 install_deps
 delete_all_functions
+
+# Node 8 tests
+pick_node8
 announce "Deploying functions to Node 8 runtime ..."
 deploy
-if [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
-  waitForPropagation
-  run_tests
-fi
+run_tests
+
+# Node 10 tests
 pick_node10
 announce "Re-deploying the same functions to Node 10 runtime ..."
 deploy
-waitForPropagation
-if [[ $PROJECT_ID_NODE_8 == $PROJECT_ID_NODE_10 ]]; then
-  run_tests
-else
-  run_all_tests
-fi
+run_tests
+
+# Cleanup
 cleanup
 announce "All tests pass!"


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
We no longer need to wait after function deployment for the changes to propagate, since that bug was fixed on the backend, so I removed the 50 second delay between deployment and running tests. Internal bug reference: 74138171.

Additionally, since that delay was the slowest part of the integration tests and it was no longer needed, I removed the parallelization of running Node 8 and Node 10 tests on different projects and simplified the code. The slowest part now is the deployment of functions, which was still happening serially. 

### Testing
Run integration tests:
```
./integration_test/run_tests.sh <project_id>
```