### PR TITLE
Fix auth UserRecord.metadata regression

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+* Fixes bug where auth.UserRecord.metadata was undefined.

--- a/integration_test/functions/src/auth-tests.ts
+++ b/integration_test/functions/src/auth-tests.ts
@@ -32,6 +32,8 @@ export const createUserTests: any = functions.auth.user().onCreate((u, c) => {
       expectEq((context as any).action, undefined)
     )
 
+    .it('should have properly defined meta', (user, context) => user.metadata)
+
     .run(testId, u, c);
 });
 

--- a/spec/providers/auth.spec.ts
+++ b/spec/providers/auth.spec.ts
@@ -178,6 +178,21 @@ describe('Auth Functions', () => {
       const record = auth.userRecordConstructor(raw);
       expect(record.toJSON()).to.deep.equal(raw);
     });
+
+    it('will convert raw wire fields createdAt and lastSignedInAt to creationTime and lastSignInTime', () => {
+      const raw: any = {
+        uid: '123',
+        metadata: {
+          createdAt: '2017-02-02T23:06:26.124Z',
+          lastSignedInAt: '2017-02-02T23:01:19.797Z',
+        },
+      };
+      const record = auth.userRecordConstructor(raw);
+      expect(record.metadata).to.deep.equal({
+        creationTime: '2017-02-02T23:06:26.124Z',
+        lastSignInTime: '2017-02-02T23:01:19.797Z',
+      });
+    });
   });
 
   describe('handler namespace', () => {

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -140,7 +140,10 @@ export function userRecordConstructor(
     _.set(
       record,
       'metadata',
-      new UserRecordMetadata(meta.creationTime, meta.lastSignInTime)
+      new UserRecordMetadata(
+        meta.createdAt || meta.creationTime,
+        meta.lastSignedInAt || meta.lastSignInTime
+      )
     );
   } else {
     _.set(record, 'metadata', new UserRecordMetadata(null, null));


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
There was a regression with v3 release where auth `creationTime` and `lastSignInTime` metadata 
values are undefined. This is because on the wire, auth is still sending `createdAt` and `lastSignedInAt` and we are no longer reading those. This PR reverts the auth change in https://github.com/firebase/firebase-functions/pull/460. 

### Testing
Unit tests and integration tests are both passing.