### PR TITLE
fix bug in integration tests where deps not installed

### DIFF
--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -93,17 +93,18 @@ function cleanup {
 
 # Setup
 build_sdk
-install_deps
 delete_all_functions
 
 # Node 8 tests
 pick_node8
+install_deps
 announce "Deploying functions to Node 8 runtime ..."
 deploy
 run_tests
 
 # Node 10 tests
 pick_node10
+install_deps
 announce "Re-deploying the same functions to Node 10 runtime ..."
 deploy
 run_tests


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Integration tests broke because `pick_node8` step was moved after the `install_deps` step, which did not have a package.json to install from. This was difficult to debug because when running locally (running the firebase test directly), all of the node_modules, package.json, etc, is left in the functions directory, so the test passes even when it's broken, while the GCF test fails because it cleans everything up. I'll be making another PR to clean up all the artifacts created by the integration test so that this does not happen in the future.

### Errors fixed
GCF tests were failing with the following error:

```
##### Deploying functions to Node 8 runtime ...
./run_tests.sh: line 64: ./functions/node_modules/.bin/tsc: No such file or directory
```

This PR fixes this.

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->