### PR TITLE
Add better cleanup to integration tests

### DIFF
--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -101,7 +101,8 @@ function cleanup {
   rm $DIR/functions/firebase-functions.tgz
   rm $DIR/functions/package.json
   rm -f $DIR/functions/firebase-debug.log
-  rm -rf $DIR/functions/node_modules/firebase-functions
+  rm -rf $DIR/functions/lib
+  rm -rf $DIR/functions/node_modules
 }
 
 # Setup


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine. 
We've hooked up this repo with continuous integration to double check those things for you. 

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->


### Description
Clean up node_modules and lib directories after running the integration tests - node_modules specifically were making it so that tests would pass even if `install_deps` was not doing anything, which is the issue that was resolved in https://github.com/firebase/firebase-functions/pull/485.

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->