### PR TITLE
Fix ts errors

### DIFF
--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -9,7 +9,7 @@ export const SUPPORTED_REGIONS = [
   'europe-west2',
   'asia-east2',
   'asia-northeast1',
-] as const;
+];
 
 /**
  * Cloud Functions min timeout value.
@@ -30,7 +30,7 @@ export const VALID_MEMORY_OPTIONS = [
   '512MB',
   '1GB',
   '2GB',
-] as const;
+];
 
 /**
  * Scheduler retry options. Applies only to scheduled functions.

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -24,13 +24,7 @@ export const MAX_TIMEOUT_SECONDS = 540;
 /**
  * List of available memory options supported by Cloud Functions.
  */
-export const VALID_MEMORY_OPTIONS = [
-  '128MB',
-  '256MB',
-  '512MB',
-  '1GB',
-  '2GB',
-];
+export const VALID_MEMORY_OPTIONS = ['128MB', '256MB', '512MB', '1GB', '2GB'];
 
 /**
  * Scheduler retry options. Applies only to scheduled functions.


### PR DESCRIPTION
TS seems to be throwing errors after declaring an array as const (as done in https://github.com/firebase/firebase-functions/pull/494/files#diff-7cf7b382494701156aea855b99879b90R12). You can simulate these errors on a regular deploy or by running integration tests: `./integration_tests/run_tests.sh <project_id>`

```
##### Deploying functions to Node 8 runtime ...
functions/node_modules/firebase-functions/lib/function-configuration.d.ts:4:64 - error TS1005: ']' expected.

4 export declare const SUPPORTED_REGIONS: readonly ["us-central1", "us-east1", "us-east4", "europe-west1", "europe-west2", "asia-east2", "asia-northeast1"];
                                                                 ~

functions/node_modules/firebase-functions/lib/function-configuration.d.ts:4:66 - error TS1134: Variable declaration expected.

4 export declare const SUPPORTED_REGIONS: readonly ["us-central1", "us-east1", "us-east4", "europe-west1", "europe-west2", "asia-east2", "asia-northeast1"];
                                                                   ~~~~~~~~~~

functions/node_modules/firebase-functions/lib/function-configuration.d.ts:4:153 - error TS1005: ';' expected.

4 export declare const SUPPORTED_REGIONS: readonly ["us-central1", "us-east1", "us-east4", "europe-west1", "europe-west2", "asia-east2", "asia-northeast1"];
                                                                                                                                                          ~

functions/node_modules/firebase-functions/lib/function-configuration.d.ts:16:61 - error TS1005: ']' expected.

16 export declare const VALID_MEMORY_OPTIONS: readonly ["128MB", "256MB", "512MB", "1GB", "2GB"];
                                                               ~

functions/node_modules/firebase-functions/lib/function-configuration.d.ts:16:63 - error TS1134: Variable declaration expected.

16 export declare const VALID_MEMORY_OPTIONS: readonly ["128MB", "256MB", "512MB", "1GB", "2GB"];
                                                                 ~~~~~~~

functions/node_modules/firebase-functions/lib/function-configuration.d.ts:16:93 - error TS1005: ';' expected.

16 export declare const VALID_MEMORY_OPTIONS: readonly ["128MB", "256MB", "512MB", "1GB", "2GB"];
```