### PR TITLE
Extract and document path manipulation utilities

### DIFF
--- a/spec/index.spec.ts
+++ b/spec/index.spec.ts
@@ -43,4 +43,5 @@ import './providers/pubsub.spec';
 import './providers/remoteConfig.spec';
 import './providers/storage.spec';
 import './setup.spec';
+import './utilities/path.spec';
 import './utils.spec';

--- a/spec/utilities/path.spec.ts
+++ b/spec/utilities/path.spec.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { normalizePath, pathParts } from '../../src/utilities/path';
+
+describe('utilities', () => {
+  describe('path', () => {
+    describe('#normalizePath', () => {
+      it('should strip leading and trailing slash', () => {
+        expect(normalizePath('/my/path/is/{rad}/')).to.eq('my/path/is/{rad}');
+      });
+    });
+
+    describe('#pathParts', () => {
+      it('should turn a path into an array of strings', () => {
+        expect(pathParts('/foo/bar/baz')).to.deep.equal(['foo', 'bar', 'baz']);
+      });
+
+      it('should turn a root path, empty string, or null path into an empty array', () => {
+        expect(pathParts('')).to.deep.equal([]);
+        expect(pathParts(null)).to.deep.equal([]);
+        expect(pathParts('/')).to.deep.equal([]);
+      });
+    });
+  });
+});

--- a/spec/utils.spec.ts
+++ b/spec/utils.spec.ts
@@ -21,27 +21,9 @@
 // SOFTWARE.
 
 import { expect } from 'chai';
-import { applyChange, normalizePath, pathParts, valAt } from '../src/utils';
+import { applyChange, valAt } from '../src/utils';
 
 describe('utils', () => {
-  describe('.normalizePath(path: string)', () => {
-    it('should strip leading and trailing slash', () => {
-      expect(normalizePath('/my/path/is/{rad}/')).to.eq('my/path/is/{rad}');
-    });
-  });
-
-  describe('.pathParts(path: string): string[]', () => {
-    it('should turn a path into an array of strings', () => {
-      expect(pathParts('/foo/bar/baz')).to.deep.equal(['foo', 'bar', 'baz']);
-    });
-
-    it('should turn a root path, empty string, or null path into an empty array', () => {
-      expect(pathParts('')).to.deep.equal([]);
-      expect(pathParts(null)).to.deep.equal([]);
-      expect(pathParts('/')).to.deep.equal([]);
-    });
-  });
-
   describe('.valAt(source: any, path?: string): any', () => {
     it('should be null if null along any point in the path', () => {
       expect(valAt(null)).to.be.null;

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -32,7 +32,8 @@ import {
 } from '../cloud-functions';
 import { firebaseConfig } from '../config';
 import { DeploymentOptions } from '../function-configuration';
-import { applyChange, joinPath, normalizePath, pathParts } from '../utils';
+import { joinPath, normalizePath, pathParts } from '../utilities/path';
+import { applyChange } from '../utils';
 
 /** @hidden */
 export const provider = 'google.firebase.database';

--- a/src/utilities/path.ts
+++ b/src/utilities/path.ts
@@ -1,0 +1,35 @@
+/**
+ * Removes leading and trailing slashes from a path.
+ *
+ * @param path A path to normalize, in POSIX format.
+ */
+export function normalizePath(path: string): string {
+  if (!path) {
+    return '';
+  }
+  return path.replace(/^\//, '').replace(/\/$/, '');
+}
+
+/**
+ * Normalizes a given path and splits it into an array of segments.
+ *
+ * @param path A path to split, in POSIX format.
+ */
+export function pathParts(path: string): string[] {
+  if (!path || path === '' || path === '/') {
+    return [];
+  }
+  return normalizePath(path).split('/');
+}
+
+/**
+ * Normalizes given paths and joins these together using a POSIX separator.
+ *
+ * @param base A first path segment, in POSIX format.
+ * @param child A second path segment, in POSIX format.
+ */
+export function joinPath(base: string, child: string) {
+  return pathParts(base)
+    .concat(pathParts(child))
+    .join('/');
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,26 +21,7 @@
 // SOFTWARE.
 
 import * as _ from 'lodash';
-
-export function normalizePath(path: string): string {
-  if (!path) {
-    return '';
-  }
-  return path.replace(/^\//, '').replace(/\/$/, '');
-}
-
-export function pathParts(path: string): string[] {
-  if (!path || path === '' || path === '/') {
-    return [];
-  }
-  return normalizePath(path).split('/');
-}
-
-export function joinPath(base: string, child: string) {
-  return pathParts(base)
-    .concat(pathParts(child))
-    .join('/');
-}
+import { pathParts } from './utilities/path';
 
 export function applyChange(src: any, dest: any) {
   // if not mergeable, don't merge


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

While working on a small fix I wanted to add a utility function that could be reused across the codebase. I noticed that all utilities live in one file, which makes it too easy to throw everything in there. I started by removing an unused function in #513. This PR extracts path manipulation utilities into its own file. I created `utilities` directory, so more well-named, well-scoped files and methods can be added there.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

Not relevant.