### PR TITLE
 Fix exhaustiveness of error code switch in http status conversion

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -27,6 +27,7 @@ import * as _ from 'lodash';
 import { apps } from '../apps';
 import { HttpsFunction, optionsToTrigger, Runnable } from '../cloud-functions';
 import { DeploymentOptions } from '../function-configuration';
+import { assertNever } from '../utilities/assertions';
 
 export interface Request extends express.Request {
   rawBody: Buffer;
@@ -231,7 +232,7 @@ export class HttpsError extends Error {
         return 500;
       // This should never happen as long as the type system is doing its job.
       default:
-        throw new Error('Invalid error code: ' + this.code);
+        assertNever(this.code);
     }
   }
 

--- a/src/utilities/assertions.ts
+++ b/src/utilities/assertions.ts
@@ -1,0 +1,13 @@
+/**
+ * @file Provides common assertion helpers which can be used to improve
+ * strictness of both type checking and runtime.
+ */
+
+ /**
+  * Checks that the given value is of type `never` — the type that’s left after
+  * all other cases have been removed.
+  * @param x A value of type `never`.
+  */
+export function assertNever(x: never): never {
+  throw new Error(`Unhandled discriminated union member: ${JSON.stringify(x)}`);
+}

--- a/src/utilities/assertions.ts
+++ b/src/utilities/assertions.ts
@@ -3,11 +3,13 @@
  * strictness of both type checking and runtime.
  */
 
- /**
-  * Checks that the given value is of type `never` — the type that’s left after
-  * all other cases have been removed.
-  * @param x A value of type `never`.
-  */
+/**
+ * Checks that the given value is of type `never` — the type that’s left after
+ * all other cases have been removed.
+ * @param x A value of type `never`.
+ */
 export function assertNever(x: never): never {
-  throw new Error(`Unhandled discriminated union member: ${JSON.stringify(x)}`);
+  throw new Error(
+    `Unhandled discriminated union member: ${JSON.stringify(x)}.`
+  );
 }

--- a/src/utilities/assertions.ts
+++ b/src/utilities/assertions.ts
@@ -6,6 +6,7 @@
 /**
  * Checks that the given value is of type `never` — the type that’s left after
  * all other cases have been removed.
+ *
  * @param x A value of type `never`.
  */
 export function assertNever(x: never): never {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

This is only a type safety change, does not change actual behaviour. Whereas the comment before the default stated that it should never get there unless TypeScript does its job, it didn't hold true - an error was thrown in the default case, which is a branch of execution that is perfectly correct. An unreachable code is represented by a `never` type in TypeScript.

This PR adds a function that accepts a parameter of type `never`, which will not be allowed by the compiler. If the impossible happens, a readable error will be thrown.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

```ts
// This will compile
function f(x: 'a' | 'b'): void {
  switch (x) {
    case 'a':
    case 'b':
      console.log('reachable');

      return;
    default:
      assertNever(x);
  }
}

// While this will throw an error during compilation
function f(x: 'a' | 'b'): void {
  switch (x) {
    case 'a':
      console.log('reachable');

      return;
    default:
      assertNever(x);
  }
}
```