### PR TITLE
Increase type strictness of HttpsError class

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -27,7 +27,6 @@ import * as _ from 'lodash';
 import { apps } from '../apps';
 import { HttpsFunction, optionsToTrigger, Runnable } from '../cloud-functions';
 import { DeploymentOptions } from '../function-configuration';
-import { assertNever } from '../utilities/assertions';
 
 export interface Request extends express.Request {
   rawBody: Buffer;

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -220,7 +220,6 @@ export class HttpsError extends Error {
     this.httpErrorCode = errorCodeMap[code];
   }
 
-  /** @hidden */
   public toJSON(): HttpErrorWireFormat {
     const {
       details,

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -204,6 +204,8 @@ export class HttpsError extends Error {
 
   /**
    * A wire format representation of a provided error code.
+   *
+   * @hidden
    */
   public readonly httpErrorCode: HttpErrorCode;
 
@@ -220,6 +222,7 @@ export class HttpsError extends Error {
     this.httpErrorCode = errorCodeMap[code];
   }
 
+  /** @hidden */
   public toJSON(): HttpErrorWireFormat {
     const {
       details,


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

While working on changes to `providers/https.ts`, I got a little confused as there are three statuses we're dealing with:
- provided as an argument to HttpsError
- actual HTTP status code
- canonical error code for gRPC

This PR aims to minimise confusion by improving type strictness, so it's well defined what the return types of methods should be and how it's represented. It also moves the mapping into one place, instead of having a map outside of the class and a switch inside of it.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

Not relevant.