### PR TITLE
Resolve security vulnerability CVE-2019-10744

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## [3.1.1] - 2019-07-16
+
 ### Changed
+
 - Upgraded lodash dependency to resolve security vulnerability CVE-2019-10744
 
 [3.1.1]: https://github.com/firebase/firebase-functions/compare/v3.1.0...v3.1.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## [3.1.1] - 2019-07-16
-
-### Changed
-
-- Upgraded lodash dependency to resolve security vulnerability CVE-2019-10744
-
-[3.1.1]: https://github.com/firebase/firebase-functions/compare/v3.1.0...v3.1.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [3.1.1] - 2019-07-16
+### Changed
+- Upgraded lodash dependency to resolve security vulnerability CVE-2019-10744
+
+[3.1.1]: https://github.com/firebase/firebase-functions/compare/v3.1.0...v3.1.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+fixed - Upgrade lodash dependency to resolve security vulnerability CVE-2019-10744

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-functions",
-  "version": "3.1.1",
+  "version": "3.1.0",
   "description": "Firebase SDK for Cloud Functions",
   "keywords": [
     "firebase",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firebase-functions",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Firebase SDK for Cloud Functions",
   "keywords": [
     "firebase",
@@ -39,7 +39,7 @@
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-    "lodash": "^4.17.11"
+    "lodash": "^4.17.14"
   },
   "devDependencies": {
     "@types/chai": "^4.1.7",


### PR DESCRIPTION
### Description

CVE-2019-10744 is a high priority security flaw in lodash that has been resolved in lodash verisons higher or equal than 4.17.13, this library is currently depending on 4.17.11. More information on this CVE can be found [here](https://snyk.io/blog/snyk-research-team-discovers-severe-prototype-pollution-security-vulnerabilities-affecting-all-versions-of-lodash/)

Furthermore
- I've actually put some content in `changelog.md` (a renamed file for `changelog.txt` to allow for markdown) since it was completely blank for no apparent reason.
- I've bumped the version to 3.1.1 in the package.json as you should release a version with the upgraded version of lodash asap to fix the security issue in the published version.

Signed-off-by: Jeroen Claassens <support@favware.tech>
