### PR TITLE
Fix sed command that breaks on linux

### DIFF
--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -107,7 +107,7 @@ function run_tests {
 function cleanup {
   announce "Performing cleanup..."
   delete_all_functions
-  rm "${DIR}/functions/firebase-functions-*.tgz"
+  rm "${DIR}/functions/firebase-functions-${TIMESTAMP}.tgz"
   rm "${DIR}/functions/package.json"
   rm -f "${DIR}/functions/firebase-debug.log"
   rm -rf "${DIR}/functions/lib"

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -41,13 +41,19 @@ function build_sdk {
 function pick_node8 {
   cd "${DIR}"
   cp package.node8.json functions/package.json
-  sed -i '' "s/firebase-functions.tgz/firebase-functions-${TIMESTAMP}.tgz/g" functions/package.json
+  # we have to do the -e flag here so that it work both on linux and mac os, but that creates an extra
+  # backup file called package.json-e that we should clean up afterwards.
+  sed -i -e "s/firebase-functions.tgz/firebase-functions-${TIMESTAMP}.tgz/g" functions/package.json
+  rm -f functions/package.json-e
 }
 
 function pick_node10 {
   cd "${DIR}"
   cp package.node10.json functions/package.json
-  sed -i '' "s/firebase-functions.tgz/firebase-functions-${TIMESTAMP}.tgz/g" functions/package.json
+  # we have to do the -e flag here so that it work both on linux and mac os, but that creates an extra
+  # backup file called package.json-e that we should clean up afterwards.
+  sed -i -e "s/firebase-functions.tgz/firebase-functions-${TIMESTAMP}.tgz/g" functions/package.json
+  rm -f functions/package.json-e
 }
 
 function install_deps {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description
The `sed` command that was recently added to the integration tests in #539. This command works on Mac OS but not on linux, and this PR fixes that. 
