### PR TITLE
Linking to external types - docgen

### DIFF
--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -39,8 +39,7 @@ const contentPath = path.resolve(`${__dirname}/content-sources`);
 const tempHomePath = path.resolve(`${contentPath}/HOME_TEMP.md`);
 const devsitePath = `/docs/reference/functions/`;
 
-const jsdom = require("jsdom");
-const { JSDOM } = jsdom;
+const { JSDOM } = require("jsdom");
 
 /**
  * Strips path prefix and returns only filename.
@@ -106,7 +105,6 @@ function renameFiles() {
  */
 function fixLinks(file) {
   return fs.readFile(file, 'utf8').then(data => {
-    console.log(file);
     data = addTypeAliasLinks(data);
     const flattenedLinks = data
       .replace(/\.\.\//g, '')
@@ -134,9 +132,9 @@ function addTypeAliasLinks(data) {
     for (const type of typeMap.keys()) {
       const lastTypeOccurrence = tag.textContent.lastIndexOf(type);
 
-      // Helps to prevent matching similar types, like 'UserRecord' and 'UserRecordMetadata'.
+      // Helps to prevent matching similar types, like `UserRecord` and `UserRecordMetadata`.
       if (lastTypeOccurrence >= 0 && lastTypeOccurrence + type.length == tag.textContent.length) {
-        console.log('  Found the '+type+' type! Adding link.');
+        console.log('Adding link to '+type);
         
         // Add the corresponding document link to this type
         const linkChild = htmlDom.window.document.createElement('a');
@@ -305,12 +303,18 @@ function fixAllLinks(htmlFiles) {
  *    links as needed.
  * 5) Check for mismatches between TOC list and generated file list.
  */
-
 var typeMap = new Map();
-typeMap.set('DocumentSnapshot', `https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html`);
-typeMap.set('UserRecord', 'https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html');
-typeMap.set('UserInfo', 'https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html');
+fs.readFile('./type-aliases.json', (err, jsonString) => {
+  if (err) {
+    console.log('Error: type-aliases.json not found in this directory. Unable to link to external library documentation.');
+    return;
+  }
 
+  typeJson = JSON.parse(jsonString);
+  typeJson.forEach(alias => {
+    typeMap.set(alias.type, alias.link);
+  });
+});
 Promise.all([
   fs.readFile(`${contentPath}/toc.yaml`, 'utf8'),
   fs.readFile(`${contentPath}/HOME.md`, 'utf8')

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -308,8 +308,8 @@ function fixAllLinks(htmlFiles) {
 
 var typeMap = new Map();
 typeMap.set('DocumentSnapshot', `https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html`);
-typeMap.set('UserRecord', 'https://firebase.google.com/docs/reference/functions/functions.auth.UserRecord.html');
-typeMap.set('UserInfo', 'https://firebase.google.com/docs/reference/functions/functions.auth.UserInfo.html');
+typeMap.set('UserRecord', 'https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html');
+typeMap.set('UserInfo', 'https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html');
 
 Promise.all([
   fs.readFile(`${contentPath}/toc.yaml`, 'utf8'),

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -129,6 +129,10 @@ function fixLinks(file) {
  */
 function addTypeAliasLinks(data) {
   const htmlDom = new JSDOM(data);
+  /**
+   * Select .tsd-signature-type because all potential external
+   * links will have this identifier.
+   */
   const fileTags = htmlDom.window.document.querySelectorAll(".tsd-signature-type");
   fileTags.forEach(tag => {
     const mapping = typeMap[tag.textContent];

--- a/docgen/type-aliases.json
+++ b/docgen/type-aliases.json
@@ -1,0 +1,5 @@
+[
+    { "type": "DocumentSnapshot", "link": "https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html" },
+    { "type": "UserRecord", "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html" },
+    { "type": "UserInfo", "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html" }
+]

--- a/docgen/type-aliases.json
+++ b/docgen/type-aliases.json
@@ -1,14 +1,5 @@
-[
-  {
-    "type": "DocumentSnapshot",
-    "link": "https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html"
-  },
-  {
-    "type": "UserRecord",
-    "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html"
-  },
-  {
-    "type": "UserInfo",
-    "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html"
-  }
-]
+{
+  "firebase.firestore.DocumentSnapshot": "https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html",
+  "firebase.auth.UserRecord": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html",
+  "firebase.auth.UserInfo": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html"
+}

--- a/docgen/type-aliases.json
+++ b/docgen/type-aliases.json
@@ -1,5 +1,14 @@
 [
-    { "type": "DocumentSnapshot", "link": "https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html" },
-    { "type": "UserRecord", "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html" },
-    { "type": "UserInfo", "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html" }
+  {
+    "type": "DocumentSnapshot",
+    "link": "https://googleapis.dev/nodejs/firestore/latest/DocumentSnapshot.html"
+  },
+  {
+    "type": "UserRecord",
+    "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserRecord.html"
+  },
+  {
+    "type": "UserInfo",
+    "link": "https://firebase.google.com/docs/reference/admin/node/admin.auth.UserInfo.html"
+  }
 ]

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "firebase-admin": "^8.2.0",
     "istanbul": "^0.4.5",
     "js-yaml": "^3.13.1",
+    "jsdom": "^15.2.0",
     "mocha": "^6.1.4",
     "mock-require": "^3.0.3",
     "mz": "^2.7.0",


### PR DESCRIPTION
This is the first iteration of my solution to linking to external library types for the Firebase Functions Reference documentation.
1. Map external types to their links.
1. Create a DOM of each HTML file.
1. When fixing links, intersect HTML data of generated doc and query tags of type `tsd-signature-type`.
1. Add link to matching types

In these staged files, there are now links to `UserInfo`, `UserRecord`, and `DocumentSnapshot` types:
* [functions.auth](https://firebase.devsite.corp.google.com/docs/reference/functions/providers_auth_.html)
* [functions.auth.UserBuilder](https://firebase.devsite.corp.google.com/docs/reference/functions/providers_auth_.userbuilder.html)
* [functions.firestore](https://firebase.devsite.corp.google.com/docs/reference/functions/providers_firestore_.html)
* [functions.firestore.DocumentBuilder](https://firebase.devsite.corp.google.com/docs/reference/functions/providers_firestore_.documentbuilder.html)