### PR TITLE
Add emulator app override function

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,1 @@
+feature - Add a helper function for the Firebase Emulator suite.

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -58,6 +58,7 @@ export namespace apps {
 
   export class Apps {
     private _refCounter: RefCounter;
+    private _emulatedAdminApp?: firebase.app.App;
 
     constructor() {
       this._refCounter = {};
@@ -105,10 +106,23 @@ export namespace apps {
     }
 
     get admin(): firebase.app.App {
+      if (this._emulatedAdminApp) {
+        return this._emulatedAdminApp;
+      }
+
       if (this._appAlive('__admin__')) {
         return firebase.app('__admin__');
       }
       return firebase.initializeApp(this.firebaseArgs, '__admin__');
+    }
+
+    /**
+     * This function allows the Firebase Emulator Suite to override the FirebaseApp instance
+     * used by the Firebase Functions SDK. Developers should never call this function for
+     * other purposes.
+     */
+    setEmulatedAdminApp(app: firebase.app.App) {
+      this._emulatedAdminApp = app;
     }
 
     private get firebaseArgs() {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

This is motivated by:
https://github.com/firebase/firebase-tools/issues/1682

Internally this will allow the emulator suite to do this:
```js
const app = admin.initializeApp();
functions.app.setEmulatedAdminApp(app);
```

This way, things like `change.after.ref` will not point to production Firestore but will instead point to the emulator.

### Code sample

See above.