### PR TITLE
Use process.env.PWD for finding .runtimeconfig.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+**IMPORTANT: Please update to this version of `firebase-functions` if you are using Node.js 10 functions, otherwise your functions will break in production.** 
+* Prevents deployment and runtime issues caused by upcoming changes to Cloud Functions infrastructure for Node.js 10 functions. (Issue #630)
+* Add support for writing scheduled functions under handler namespace.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
-**IMPORTANT: Please update to this version of `firebase-functions` if you are using Node.js 10 functions, otherwise your functions will break in production.** 
-* Prevents deployment and runtime issues caused by upcoming changes to Cloud Functions infrastructure for Node.js 10 functions. (Issue #630)
-* Add support for writing scheduled functions under handler namespace.
+**IMPORTANT: Please update to this version of `firebase-functions` if you are using Node.js 10 functions, otherwise your functions will break in production.**
+
+- Prevents deployment and runtime issues caused by upcoming changes to Cloud Functions infrastructure for Node.js 10 functions. (Issue #630)
+- Add support for writing scheduled functions under handler namespace.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,2 @@
-**IMPORTANT: Please update to this version of firebase-functions if you are using Node.js 10 functions, otherwise your functions will break in production.** 
+**IMPORTANT: Please update to this version of `firebase-functions` if you are using Node.js 10 functions, otherwise your functions will break in production.** 
 Prevents deployment and runtime issue for Node.js 10 functions, due to `process.env.FIREBASE_CONFIG` and `functions.config()` being empty. (Issue #630)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,2 @@
 **IMPORTANT: Please update to this version of `firebase-functions` if you are using Node.js 10 functions, otherwise your functions will break in production.** 
-Prevents deployment and runtime issue for Node.js 10 functions, due to `process.env.FIREBASE_CONFIG` and `functions.config()` being empty. (Issue #630)
+**Fixed:** Prevents deployment and runtime issues caused by upcoming changes to Cloud Functions infrastructure for Node.js 10 functions. (Issue #630)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,2 @@
+**IMPORTANT: Please update to this version of firebase-functions if you are using Node.js 10 functions, otherwise your functions will break in production.** 
+Prevents deployment and runtime issue for Node.js 10 functions, due to `process.env.FIREBASE_CONFIG` and `functions.config()` being empty. (Issue #630)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,2 +1,0 @@
-**IMPORTANT: Please update to this version of `firebase-functions` if you are using Node.js 10 functions, otherwise your functions will break in production.** 
-**Fixed:** Prevents deployment and runtime issues caused by upcoming changes to Cloud Functions infrastructure for Node.js 10 functions. (Issue #630)

--- a/spec/config.spec.ts
+++ b/spec/config.spec.ts
@@ -25,6 +25,12 @@ import * as mockRequire from 'mock-require';
 import { config, firebaseConfig } from '../src/config';
 
 describe('config()', () => {
+  before(() => {
+    process.env.PWD = '/srv';
+  });
+  after(() => {
+    delete process.env.PWD;
+  });
   afterEach(() => {
     mockRequire.stopAll();
     delete config.singleton;
@@ -33,19 +39,19 @@ describe('config()', () => {
   });
 
   it('loads config values from .runtimeconfig.json', () => {
-    mockRequire('../../../.runtimeconfig.json', { foo: 'bar', firebase: {} });
+    mockRequire('/srv/.runtimeconfig.json', { foo: 'bar', firebase: {} });
     const loaded = config();
     expect(loaded).to.not.have.property('firebase');
     expect(loaded).to.have.property('foo', 'bar');
   });
 
   it('does not provide firebase config if .runtimeconfig.json not invalid', () => {
-    mockRequire('../../../.runtimeconfig.json', 'does-not-exist');
+    mockRequire('/srv/.runtimeconfig.json', 'does-not-exist');
     expect(firebaseConfig()).to.be.null;
   });
 
   it('does not provide firebase config if .ruuntimeconfig.json has no firebase property', () => {
-    mockRequire('../../../.runtimeconfig.json', {});
+    mockRequire('/srv/.runtimeconfig.json', {});
     expect(firebaseConfig()).to.be.null;
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import * as firebase from 'firebase-admin';
+import * as path from 'path';
 
 export function config(): config.Config {
   if (typeof config.singleton === 'undefined') {
@@ -68,9 +69,10 @@ export function firebaseConfig(): firebase.AppOptions | null {
 
   // Could have Runtime Config with Firebase in it as an ENV location or default.
   try {
-    const path =
-      process.env.CLOUD_RUNTIME_CONFIG || '../../../.runtimeconfig.json';
-    const config = require(path);
+    const configPath =
+      process.env.CLOUD_RUNTIME_CONFIG ||
+      path.join(process.env.PWD, '.runtimeconfig.json');
+    const config = require(configPath);
     if (config.firebase) {
       return config.firebase;
     }
@@ -92,9 +94,10 @@ function init() {
   }
 
   try {
-    const path =
-      process.env.CLOUD_RUNTIME_CONFIG || '../../../.runtimeconfig.json';
-    const parsed = require(path);
+    const configPath =
+      process.env.CLOUD_RUNTIME_CONFIG ||
+      path.join(process.env.PWD, '.runtimeconfig.json');
+    const parsed = require(configPath);
     delete parsed.firebase;
     config.singleton = parsed;
     return;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

Fixes https://github.com/firebase/firebase-functions/issues/630

I've verified this with a project that's white listed for build packs, and I was able to successfully deploy to both Node 8 and Node 10, and make use of `functions.config()` and `admin.initializeApp()`

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
