### PR TITLE
Updating TOC source with Testlab paths.

### DIFF
--- a/docgen/content-sources/toc.yaml
+++ b/docgen/content-sources/toc.yaml
@@ -116,3 +116,15 @@ toc:
         path: /docs/reference/functions/providers_storage_.objectbuilder.html
       - title: 'ObjectMetadata'
         path: /docs/reference/functions/providers_storage_.objectmetadata.html
+
+  - title: 'functions.testLab'
+    path: /docs/reference/functions/providers_testlab_.html
+    section:
+      - title: 'testLab.clientInfo'
+        path: /docs/reference/functions/providers_testlab_.clientinfo.html
+      - title: 'testLab.resultStorage'
+        path: /docs/reference/functions/providers_testlab_.resultstorage.html
+      - title: 'testLab.testMatrix'
+        path: /docs/reference/functions/providers_testlab_.testmatrix.html
+      - title: 'testLab.testMatrixBuilder'
+        path: /docs/reference/functions/providers_testlab_.testmatrixbuilder.html


### PR DESCRIPTION
Probably due to my own user error, the TOC source is out of sync with the published version.

Adding these up-to-date Testlab paths resolves that.

Thanks!