### PR TITLE
Add RTDB service provider override

### DIFF
--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -38,7 +38,12 @@ import { applyChange } from '../utils';
 /** @hidden */
 export const provider = 'google.firebase.database';
 /** @hidden */
-export const service = 'firebaseio.com';
+function service(): string {
+ if (process.env.REALTIME_DATABASE_EVEENTFLOW_SERVICE) {
+   return process.env.REALTIME_DATABASE_EVEENTFLOW_SERVICE;
+ }
+ return 'firebaseio.com';
+}
 
 // NOTE(inlined): Should we relax this a bit to allow staging or alternate implementations of our API?
 const databaseURLRegex = new RegExp('https://([^.]+).firebaseio.com');
@@ -259,7 +264,7 @@ export class RefBuilder {
     return makeCloudFunction({
       handler,
       provider,
-      service,
+      service: service(),
       eventType,
       legacyEventType: `providers/${provider}/eventTypes/${eventType}`,
       triggerResource: this.triggerResource,

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -39,10 +39,10 @@ import { applyChange } from '../utils';
 export const provider = 'google.firebase.database';
 /** @hidden */
 function service(): string {
- if (process.env.REALTIME_DATABASE_PROVIDER_SERVICE) {
-   return process.env.REALTIME_DATABASE_PROVIDER_SERVICE;
- }
- return 'firebaseio.com';
+  if (process.env.REALTIME_DATABASE_PROVIDER_SERVICE) {
+    return process.env.REALTIME_DATABASE_PROVIDER_SERVICE;
+  }
+  return 'firebaseio.com';
 }
 
 // NOTE(inlined): Should we relax this a bit to allow staging or alternate implementations of our API?

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -39,8 +39,8 @@ import { applyChange } from '../utils';
 export const provider = 'google.firebase.database';
 /** @hidden */
 function service(): string {
- if (process.env.REALTIME_DATABASE_EVEENTFLOW_SERVICE) {
-   return process.env.REALTIME_DATABASE_EVEENTFLOW_SERVICE;
+ if (process.env.REALTIME_DATABASE_PROVIDER_SERVICE) {
+   return process.env.REALTIME_DATABASE_PROVIDER_SERVICE;
  }
  return 'firebaseio.com';
 }


### PR DESCRIPTION
This will allow us to override the service provider name to `firebaseio-staging.com` so that we can use it test environments.

FWIW, only two service names make sense: `firebaseio.com` or `firebaseio-staging.com`
They will work even for multi-region databases after we migrate FlowUpdate to integrate with metadata service instead: go/multi-region-function.