### PR TITLE
fix: onRequest type definitions

### DIFF
--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -280,7 +280,7 @@ export interface Runnable<T> {
  * arguments.
  */
 export type HttpsFunction = TriggerAnnotated &
-  ((req: Request, resp: Response) => void);
+  ((req: Request, resp: Response) => void | Promise<void>);
 
 /**
  * The Cloud Function type for all non-HTTPS triggers. This should be exported

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -39,7 +39,7 @@ export interface Request extends express.Request {
  * same signature as an Express app.
  */
 export function onRequest(
-  handler: (req: Request, resp: express.Response) => void
+  handler: (req: Request, resp: express.Response) => void | Promise<void>
 ): HttpsFunction {
   return _onRequestWithOptions(handler, {});
 }
@@ -56,7 +56,7 @@ export function onCall(
 
 /** @hidden */
 export function _onRequestWithOptions(
-  handler: (req: Request, resp: express.Response) => void,
+  handler: (req: Request, resp: express.Response) => void | Promise<void>,
   options: DeploymentOptions
 ): HttpsFunction {
   // lets us add __trigger without altering handler:


### PR DESCRIPTION
onRequest basically defines a handler for express routes, which allow async handlers. However at the moment the types only allowed to have non-async definitions.

Note that async support does work today in production.

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
