### PR TITLE
Fix compat path in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,4 +17,4 @@
 
   In newer runtimes, requiring this will emit text logs with multi-line support and appropriate severity. In the Node.js 8 runtime, the `compat` module has no effect.
 
-- Fixes `https.onRequest` type to allow Promises for `async` functions.
+- Fixes `https.onRequest` type signature to allow Promises for `async` functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,9 @@
 - Adds a special require that mimics Node.js 8 runtime logging in Node.js 10 and later runtimes:
 
   ```js
-  require('firebase-functions/logger/compat');
+  require('firebase-functions/lib/logger/compat');
   ```
 
   In newer runtimes, requiring this will emit text logs with multi-line support and appropriate severity. In the Node.js 8 runtime, the `compat` module has no effect.
+
+- Fixes `https.onRequest` type to allow Promises for `async` functions.


### PR DESCRIPTION
Unfortunately I didn't realize that due to the structure of the library the require path for `compat` is actually going to be `firebase-functions/lib/logger/compat`. It would be very non-trivial to make it otherwise so I'm just going to be okay with it.