### PR TITLE
Fix onRequest handler return type to allow promises (async)

### DIFF
--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -157,7 +157,10 @@ export class FunctionBuilder {
        * same signature as an Express app.
        */
       onRequest: (
-        handler: (req: https.Request, resp: express.Response) => void
+        handler: (
+          req: https.Request,
+          resp: express.Response
+        ) => void | Promise<void>
       ) => https._onRequestWithOptions(handler, this.options),
       /**
        * Declares a callable method for clients to call using a Firebase SDK.


### PR DESCRIPTION
### Description

Fixes the types for onRequest so that it allows for async function handlers (returning a Promise)