### PR TITLE
Add proper generic types

### DIFF
--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -41,8 +41,9 @@ export const service = 'firestore.googleapis.com';
 /** @hidden */
 export const defaultDatabase = '(default)';
 let firestoreInstance: any;
-export type DocumentSnapshot = firebase.firestore.DocumentSnapshot;
-export type QueryDocumentSnapshot = firebase.firestore.QueryDocumentSnapshot;
+export type DocumentData = firebase.firestore.DocumentData;
+export type DocumentSnapshot<T = DocumentData> = firebase.firestore.DocumentSnapshot<T>;
+export type QueryDocumentSnapshot<T = DocumentData> = firebase.firestore.QueryDocumentSnapshot<T>;
 
 /**
  * Select the Firestore document to listen to for events.
@@ -146,7 +147,7 @@ function _getValueProto(data: any, resource: string, valueFieldName: string) {
 }
 
 /** @hidden */
-export function snapshotConstructor(event: Event): DocumentSnapshot {
+export function snapshotConstructor<T>(event: Event): DocumentSnapshot<T> {
   if (!firestoreInstance) {
     firestoreInstance = firebase.firestore(apps().admin);
   }
@@ -161,7 +162,7 @@ export function snapshotConstructor(event: Event): DocumentSnapshot {
 
 /** @hidden */
 // TODO remove this function when wire format changes to new format
-export function beforeSnapshotConstructor(event: Event): DocumentSnapshot {
+export function beforeSnapshotConstructor<T>(event: Event): DocumentSnapshot<T> {
   if (!firestoreInstance) {
     firestoreInstance = firebase.firestore(apps().admin);
   }
@@ -193,42 +194,42 @@ export class DocumentBuilder {
   }
 
   /** Respond to all document writes (creates, updates, or deletes). */
-  onWrite(
+  onWrite<T>(
     handler: (
-      change: Change<DocumentSnapshot>,
+      change: Change<DocumentSnapshot<T>>,
       context: EventContext
     ) => PromiseLike<any> | any
-  ): CloudFunction<Change<DocumentSnapshot>> {
+  ): CloudFunction<Change<DocumentSnapshot<T>>> {
     return this.onOperation(handler, 'document.write', changeConstructor);
   }
 
   /** Respond only to document updates. */
-  onUpdate(
+  onUpdate<T>(
     handler: (
-      change: Change<QueryDocumentSnapshot>,
+      change: Change<QueryDocumentSnapshot<T>>,
       context: EventContext
     ) => PromiseLike<any> | any
-  ): CloudFunction<Change<QueryDocumentSnapshot>> {
+  ): CloudFunction<Change<QueryDocumentSnapshot<T>>> {
     return this.onOperation(handler, 'document.update', changeConstructor);
   }
 
   /** Respond only to document creations. */
-  onCreate(
+  onCreate<T>(
     handler: (
-      snapshot: QueryDocumentSnapshot,
+      snapshot: QueryDocumentSnapshot<T>,
       context: EventContext
     ) => PromiseLike<any> | any
-  ): CloudFunction<QueryDocumentSnapshot> {
+  ): CloudFunction<QueryDocumentSnapshot<T>> {
     return this.onOperation(handler, 'document.create', snapshotConstructor);
   }
 
   /** Respond only to document deletions. */
-  onDelete(
+  onDelete<T>(
     handler: (
-      snapshot: QueryDocumentSnapshot,
+      snapshot: QueryDocumentSnapshot<T>,
       context: EventContext
     ) => PromiseLike<any> | any
-  ): CloudFunction<QueryDocumentSnapshot> {
+  ): CloudFunction<QueryDocumentSnapshot<T>> {
     return this.onOperation(
       handler,
       'document.delete',

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -147,7 +147,7 @@ function _getValueProto(data: any, resource: string, valueFieldName: string) {
 }
 
 /** @hidden */
-export function snapshotConstructor<T>(event: Event): DocumentSnapshot<T> {
+export function snapshotConstructor<T = DocumentData>(event: Event): DocumentSnapshot<T> {
   if (!firestoreInstance) {
     firestoreInstance = firebase.firestore(apps().admin);
   }
@@ -162,7 +162,7 @@ export function snapshotConstructor<T>(event: Event): DocumentSnapshot<T> {
 
 /** @hidden */
 // TODO remove this function when wire format changes to new format
-export function beforeSnapshotConstructor<T>(event: Event): DocumentSnapshot<T> {
+export function beforeSnapshotConstructor<T = DocumentData>(event: Event): DocumentSnapshot<T> {
   if (!firestoreInstance) {
     firestoreInstance = firebase.firestore(apps().admin);
   }
@@ -194,7 +194,7 @@ export class DocumentBuilder {
   }
 
   /** Respond to all document writes (creates, updates, or deletes). */
-  onWrite<T>(
+  onWrite<T = DocumentData>(
     handler: (
       change: Change<DocumentSnapshot<T>>,
       context: EventContext
@@ -204,7 +204,7 @@ export class DocumentBuilder {
   }
 
   /** Respond only to document updates. */
-  onUpdate<T>(
+  onUpdate<T = DocumentData>(
     handler: (
       change: Change<QueryDocumentSnapshot<T>>,
       context: EventContext
@@ -214,7 +214,7 @@ export class DocumentBuilder {
   }
 
   /** Respond only to document creations. */
-  onCreate<T>(
+  onCreate<T = DocumentData>(
     handler: (
       snapshot: QueryDocumentSnapshot<T>,
       context: EventContext
@@ -224,7 +224,7 @@ export class DocumentBuilder {
   }
 
   /** Respond only to document deletions. */
-  onDelete<T>(
+  onDelete<T = DocumentData>(
     handler: (
       snapshot: QueryDocumentSnapshot<T>,
       context: EventContext

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -42,8 +42,12 @@ export const service = 'firestore.googleapis.com';
 export const defaultDatabase = '(default)';
 let firestoreInstance: any;
 export type DocumentData = firebase.firestore.DocumentData;
-export type DocumentSnapshot<T = DocumentData> = firebase.firestore.DocumentSnapshot<T>;
-export type QueryDocumentSnapshot<T = DocumentData> = firebase.firestore.QueryDocumentSnapshot<T>;
+export type DocumentSnapshot<
+  T = DocumentData
+> = firebase.firestore.DocumentSnapshot<T>;
+export type QueryDocumentSnapshot<
+  T = DocumentData
+> = firebase.firestore.QueryDocumentSnapshot<T>;
 
 /**
  * Select the Firestore document to listen to for events.
@@ -147,7 +151,9 @@ function _getValueProto(data: any, resource: string, valueFieldName: string) {
 }
 
 /** @hidden */
-export function snapshotConstructor<T = DocumentData>(event: Event): DocumentSnapshot<T> {
+export function snapshotConstructor<T = DocumentData>(
+  event: Event
+): DocumentSnapshot<T> {
   if (!firestoreInstance) {
     firestoreInstance = firebase.firestore(apps().admin);
   }
@@ -162,7 +168,9 @@ export function snapshotConstructor<T = DocumentData>(event: Event): DocumentSna
 
 /** @hidden */
 // TODO remove this function when wire format changes to new format
-export function beforeSnapshotConstructor<T = DocumentData>(event: Event): DocumentSnapshot<T> {
+export function beforeSnapshotConstructor<T = DocumentData>(
+  event: Event
+): DocumentSnapshot<T> {
   if (!firestoreInstance) {
     firestoreInstance = firebase.firestore(apps().admin);
   }


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description
Currently, `firebase-admin` offers support for generics in the `DocumentSnapshot` and `QueryDocumentSnapshot` classes, but `firebase-function` does not make use of these generics. As such this PR attempts to extend generic support for the firestore provider.

### Code sample

Now users can do the following:
```ts
interface Doc {
  prop1: number;
}

functions.firestore.document('/messages/{documentId}').onCreate<Doc>((snap, context) => {
  console.log(snap.data().prop1)
});
```
And get autocomplete on `snap.data()` to the `Doc` interface.

As noted in https://github.com/googleapis/nodejs-firestore/issues/109. With this PR, the user has the option to not provide a type, thus keeping the use case of not having compile time type safety (unrelated with whether or not firestore provides run time type safety).

This follows the principal used in `nodejs-firestore`'s `Transaction` class https://github.com/googleapis/nodejs-firestore/blob/master/types/firestore.d.ts#L309, which allows the user to provide a type that describes a Document.