### PR TITLE
Fix issues with .ref in Database functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Fixes error when last argument to logger methods is `null`. (#716)
 - Adds newly available locations `us-west3`, `europe-west6`, `northamerica-northeast1`, and `australia-southeast1`.
 - No longer throw errors for unrecognized regions (deploy will error instead).
+- Fixes error where `snap.ref` in database functions did not work when using the Emulator Suite (#726)

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -142,11 +142,13 @@ export function _refWithOptions(
 
     let instance = undefined;
     const prodMatch = databaseURL.match(databaseURLRegex);
-    const emulatorMatch = databaseURL.match(emulatorDatabaseURLRegex);
     if (prodMatch) {
       instance = prodMatch[1];
-    } else if (emulatorMatch) {
-      instance = emulatorMatch[1];
+    } else {
+      const emulatorMatch = databaseURL.match(emulatorDatabaseURLRegex);
+      if (emulatorMatch) {
+        instance = emulatorMatch[1];
+      }
     }
 
     if (!instance) {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -41,7 +41,7 @@ export const provider = 'google.firebase.database';
 export const service = 'firebaseio.com';
 
 const databaseURLRegex = new RegExp('^https://([^.]+).');
-const emulatorDatabaseURLRegex = new RegExp('^http://.*ns=([^\&]+)');
+const emulatorDatabaseURLRegex = new RegExp('^http://.*ns=([^&]+)');
 
 /**
  * Registers a function that triggers on events from a specific
@@ -360,7 +360,7 @@ export class DataSnapshot {
     private app?: firebase.app.App,
     instance?: string
   ) {
-    if (app && app.options.databaseURL.startsWith("http:")) {
+    if (app && app.options.databaseURL.startsWith('http:')) {
       // In this case we're dealing with an emulator
       this.instance = app.options.databaseURL;
     } else if (instance) {


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

Partial fix for #726

**Note** for this to work we also need to merge this PR on `firebase-tools`: https://github.com/firebase/firebase-tools/pull/2434

### Code sample

```js
const functions = require('firebase-functions');

exports.helloDb = functions.database.ref('/foo').onCreate(async (snap, ctx) => {
  console.log("snap.ref", snap.ref.toString());
  await snap.ref.update({
    'fromFunction': new Date().toISOString()
  });
});
```