### PR TITLE
Construct the database instance from the application options for the DataSnapshot on events

### DIFF
--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -234,7 +234,7 @@ export class RefBuilder {
         raw.data.delta,
         path,
         this.apps.admin,
-        dbInstance
+        this.apps.admin.options?.databaseURL || dbInstance
       );
     };
     return this.onOperation(handler, 'ref.create', dataConstructor);
@@ -259,7 +259,12 @@ export class RefBuilder {
         raw.context.resource.name,
         raw.context.domain
       );
-      return new DataSnapshot(raw.data.data, path, this.apps.admin, dbInstance);
+      return new DataSnapshot(
+        raw.data.data,
+        path,
+        this.apps.admin,
+        this.apps.admin.options?.databaseURL || dbInstance
+      );
     };
     return this.onOperation(handler, 'ref.delete', dataConstructor);
   }


### PR DESCRIPTION
### Description

When wiring up to the local emulator suite we discovered that the database instance value for the `DataSnapshot` is constructed from the context's resource name and domain, building a URL that looks like `<projectId>.localhost`, which doesn't exist and surfaces the error:

```
Error: FIREBASE FATAL ERROR: Cannot parse Firebase url. Please use https://<YOUR FIREBASE>.firebaseio.com
```

Instead of constructing the domain from the context, using the `databaseURL` value from the application options, resolves this issue for us.  

Not sure if this is the correct approach, but here is a PR that addresses this and tests pass.
