### PR TITLE
Do not log the full request object on invalid onCall invocation

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -420,7 +420,7 @@ export function _onCallWithOptions(
   const func = async (req: Request, res: express.Response) => {
     try {
       if (!isValidRequest(req)) {
-        console.error('Invalid request', req);
+        console.error('Invalid request');
         throw new HttpsError('invalid-argument', 'Bad Request');
       }
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

When a malformed JSON body is sent to an `onCall` function, the entire request object will be logged. This is undesirable for the following reasons:

1. The object might contain sensitive data, which could be non-compliant with internal or regulatory privacy rules.
1. Each line in the output console, results in a structure log write which makes it easy to hit logging quota's. There are hundreds of logs per invalid request (picture below for just the first few lines).
1. Hitting logging quota's can be quite easily used for malicious purposes.
1. The output logs can become cluttered.

<img width="492" alt="Screenshot 2020-07-22 at 10 46 10" src="https://user-images.githubusercontent.com/451164/88156355-9b453f00-cc09-11ea-86d2-7bea573efddc.png">
