### PR TITLE
Updates logging in https callable functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ const notifyUsers = require('./notify-users');
 exports.newPost = functions.database
   .ref('/posts/{postId}')
   .onCreate((snapshot, context) => {
-    console.log('Received new post with ID:', context.params.postId);
+    functions.logger.info('Received new post with ID:', context.params.postId);
     return notifyUsers(snapshot.val());
   });
 ```

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -23,6 +23,7 @@
 import { Request, Response } from 'express';
 import * as _ from 'lodash';
 import { DeploymentOptions, Schedule } from './function-configuration';
+import { warn } from './logger';
 export { Request, Response };
 
 /** @hidden */
@@ -379,7 +380,7 @@ export function makeCloudFunction<EventData>({
       promise = handler(dataOrChange, context);
     }
     if (typeof promise === 'undefined') {
-      console.warn('Function returned undefined, expected Promise or value');
+      warn('Function returned undefined, expected Promise or value');
     }
     return Promise.resolve(promise)
       .then((result) => {

--- a/src/providers/crashlytics.ts
+++ b/src/providers/crashlytics.ts
@@ -77,7 +77,7 @@ export class IssueBuilder {
    *   const slackMessage = ` There's a new issue (${issueId}) ` +
    *       `in your app - ${issueTitle}`;
    *   return notifySlack(slackMessage).then(() => {
-   *     console.log(`Posted new issue ${issueId} successfully to Slack`);
+   *     functions.logger.info(`Posted new issue ${issueId} successfully to Slack`);
    *   });
    * });
    * ```

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -22,6 +22,7 @@
 
 /** @hidden */
 import { firebaseConfig } from './config';
+import { warn } from './logger';
 
 // Set up for config and vars
 export function setup() {
@@ -45,7 +46,7 @@ export function setup() {
   // If FIREBASE_CONFIG is still not found, try using GCLOUD_PROJECT to estimate
   if (!process.env.FIREBASE_CONFIG) {
     if (process.env.GCLOUD_PROJECT) {
-      console.warn(
+      warn(
         'Warning, estimating Firebase Config based on GCLOUD_PROJECT. Initializing firebase-admin may fail'
       );
       process.env.FIREBASE_CONFIG = JSON.stringify({
@@ -58,7 +59,7 @@ export function setup() {
         projectId: process.env.GCLOUD_PROJECT,
       });
     } else {
-      console.warn(
+      warn(
         'Warning, FIREBASE_CONFIG and GCLOUD_PROJECT environment variables are missing. Initializing firebase-admin will fail'
       );
     }


### PR DESCRIPTION
#744 brought to my attention that we need to update our internal logging for HTTPS callable functions to be compatible with the new Node 10+ logging style.

I've taken a pass to update any instance of `console.*` to the appropriate logger method, and also taken the suggestion to remove logging the full request body on invalid argument.