### PR TITLE
Add support for VPC connectors in `functions.runWith`

### DIFF
--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -168,4 +168,43 @@ describe('FunctionBuilder', () => {
       } as any);
     }).to.throw(Error, 'at least one region');
   });
+
+  it('should allow a vpcConnector to be set', () => {
+    const fn = functions
+      .runWith({
+        vpcConnector: 'test-connector',
+      })
+      .auth.user()
+      .onCreate((user) => user);
+
+    expect(fn.__trigger.vpcConnector).to.equal('test-connector');
+  });
+
+  it('should allow a vpcConnectorEgressSettings to be set', () => {
+    const fn = functions
+      .runWith({
+        vpcConnector: 'test-connector',
+        vpcConnectorEgressSettings: 'PRIVATE_RANGES_ONLY',
+      })
+      .auth.user()
+      .onCreate((user) => user);
+
+    expect(fn.__trigger.vpcConnectorEgressSettings).to.equal(
+      'PRIVATE_RANGES_ONLY'
+    );
+  });
+
+  it('should throw an error if user chooses an invalid vpcConnectorEgressSettings', () => {
+    expect(() => {
+      return functions.runWith({
+        vpcConnector: 'test-connector',
+        vpcConnectorEgressSettings: 'INCORRECT_OPTION',
+      } as any);
+    }).to.throw(
+      Error,
+      `The only valid vpcConnectorEgressSettings values are: ${functions.VPC_EGRESS_SETTINGS_OPTIONS.join(
+        ','
+      )}`
+    );
+  });
 });

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -261,6 +261,8 @@ export interface TriggerAnnotated {
     regions?: string[];
     schedule?: Schedule;
     timeout?: string;
+    vpcConnector?: string;
+    vpcConnectorEgressSettings?: string;
   };
 }
 
@@ -493,5 +495,14 @@ export function optionsToTrigger(options: DeploymentOptions) {
   if (options.maxInstances) {
     trigger.maxInstances = options.maxInstances;
   }
+
+  if (options.vpcConnector) {
+    trigger.vpcConnector = options.vpcConnector;
+  }
+
+  if (options.vpcConnectorEgressSettings) {
+    trigger.vpcConnectorEgressSettings = options.vpcConnectorEgressSettings;
+  }
+
   return trigger;
 }

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -30,6 +30,7 @@ import {
   RuntimeOptions,
   SUPPORTED_REGIONS,
   VALID_MEMORY_OPTIONS,
+  VPC_EGRESS_SETTINGS_OPTIONS,
 } from './function-configuration';
 import * as analytics from './providers/analytics';
 import * as auth from './providers/auth';
@@ -64,6 +65,19 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   ) {
     throw new Error(
       `TimeoutSeconds must be between 0 and ${MAX_TIMEOUT_SECONDS}`
+    );
+  }
+  if (
+    runtimeOptions.vpcConnectorEgressSettings &&
+    !_.includes(
+      VPC_EGRESS_SETTINGS_OPTIONS,
+      runtimeOptions.vpcConnectorEgressSettings
+    )
+  ) {
+    throw new Error(
+      `The only valid vpcConnectorEgressSettings values are: ${VPC_EGRESS_SETTINGS_OPTIONS.join(
+        ','
+      )}`
     );
   }
   return true;
@@ -104,6 +118,7 @@ export function region(
  *    are: '128MB', '256MB', '512MB', '1GB', and '2GB'.
  * 2. timeoutSeconds: timeout for the function in seconds, possible values are
  *    0 to 540.
+ * 3. vpcConnector and vpcConnectorEgressSettings.
  */
 export function runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
   if (assertRuntimeOptionsValid(runtimeOptions)) {

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -67,7 +67,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
       `TimeoutSeconds must be between 0 and ${MAX_TIMEOUT_SECONDS}`
     );
   }
-  
+
   if (
     runtimeOptions.vpcConnectorEgressSettings &&
     !_.includes(
@@ -81,7 +81,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
       )}`
     );
   }
-  
+
   if (runtimeOptions.failurePolicy !== undefined) {
     if (
       _.isBoolean(runtimeOptions.failurePolicy) === false &&

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -45,6 +45,15 @@ export const VALID_MEMORY_OPTIONS = [
 ] as const;
 
 /**
+ * List of available options for VpcConnectorEgressSettings.
+ */
+export const VPC_EGRESS_SETTINGS_OPTIONS = [
+  'VPC_CONNECTOR_EGRESS_SETTINGS_UNSPECIFIED',
+  'PRIVATE_RANGES_ONLY',
+  'ALL_TRAFFIC',
+] as const;
+
+/**
  * Scheduler retry options. Applies only to scheduled functions.
  */
 export interface ScheduleRetryConfig {
@@ -78,6 +87,16 @@ export interface RuntimeOptions {
    * Max number of actual instances allowed to be running in parallel
    */
   maxInstances?: number;
+
+  /**
+   * Connect cloud function to specified VPC connector
+   */
+  vpcConnector?: string;
+
+  /**
+   * Egress settings for VPC connector
+   */
+  vpcConnectorEgressSettings?: typeof VPC_EGRESS_SETTINGS_OPTIONS[number];
 }
 
 export interface DeploymentOptions extends RuntimeOptions {


### PR DESCRIPTION
### Description

This PR adds support for vpcConnectors inside runWith.
Refers to #552  and my corresponding PR in firebase-tools: [#2525](https://github.com/firebase/firebase-tools/pull/2525)

### Code sample

```
functions
      .runWith({
        vpcConnector: 'test-connector',
        vpcConnectorEgressSettings: 'PRIVATE_RANGES_ONLY'
      })
      .auth.user()
      .onCreate((user) => user);
```