### PR TITLE
Fixes typo sending `error` logger function as err.

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -469,7 +469,7 @@ export function _onCallWithOptions(
     } catch (err) {
       if (!(err instanceof HttpsError)) {
         // This doesn't count as an 'explicit' error.
-        error('Unhandled error', error);
+        error('Unhandled error', err);
         err = new HttpsError('internal', 'INTERNAL');
       }
 


### PR DESCRIPTION
Likely addresses #757 but I need to do a little more investigation.