### PR TITLE
Update tests to change region based on env variable FIREBASE_FUNCTIONS_TEST_REGION

### DIFF
--- a/integration_test/functions/src/auth-tests.ts
+++ b/integration_test/functions/src/auth-tests.ts
@@ -3,7 +3,9 @@ import * as functions from 'firebase-functions';
 import { expectEq, TestSuite } from './testing';
 import UserMetadata = admin.auth.UserRecord;
 
-export const createUserTests: any = functions.auth.user().onCreate((u, c) => {
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+
+export const createUserTests: any = functions.region(REGION).auth.user().onCreate((u, c) => {
   const testId: string = u.displayName;
   console.log(`testId is ${testId}`);
 
@@ -37,7 +39,7 @@ export const createUserTests: any = functions.auth.user().onCreate((u, c) => {
     .run(testId, u, c);
 });
 
-export const deleteUserTests: any = functions.auth.user().onDelete((u, c) => {
+export const deleteUserTests: any = functions.region(REGION).auth.user().onDelete((u, c) => {
   const testId: string = u.displayName;
   console.log(`testId is ${testId}`);
 

--- a/integration_test/functions/src/auth-tests.ts
+++ b/integration_test/functions/src/auth-tests.ts
@@ -3,70 +3,82 @@ import * as functions from 'firebase-functions';
 import { expectEq, TestSuite } from './testing';
 import UserMetadata = admin.auth.UserRecord;
 
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
-export const createUserTests: any = functions.region(REGION).auth.user().onCreate((u, c) => {
-  const testId: string = u.displayName;
-  console.log(`testId is ${testId}`);
+export const createUserTests: any = functions
+  .region(REGION)
+  .auth.user()
+  .onCreate((u, c) => {
+    const testId: string = u.displayName;
+    console.log(`testId is ${testId}`);
 
-  return new TestSuite<UserMetadata>('auth user onCreate')
-    .it('should have a project as resource', (user, context) =>
-      expectEq(context.resource.name, `projects/${process.env.GCLOUD_PROJECT}`)
-    )
+    return new TestSuite<UserMetadata>('auth user onCreate')
+      .it('should have a project as resource', (user, context) =>
+        expectEq(
+          context.resource.name,
+          `projects/${process.env.GCLOUD_PROJECT}`
+        )
+      )
 
-    .it('should not have a path', (user, context) =>
-      expectEq((context as any).path, undefined)
-    )
+      .it('should not have a path', (user, context) =>
+        expectEq((context as any).path, undefined)
+      )
 
-    .it('should have the correct eventType', (user, context) =>
-      expectEq(context.eventType, 'google.firebase.auth.user.create')
-    )
+      .it('should have the correct eventType', (user, context) =>
+        expectEq(context.eventType, 'google.firebase.auth.user.create')
+      )
 
-    .it('should have an eventId', (user, context) => context.eventId)
+      .it('should have an eventId', (user, context) => context.eventId)
 
-    .it('should have a timestamp', (user, context) => context.timestamp)
+      .it('should have a timestamp', (user, context) => context.timestamp)
 
-    .it('should not have auth', (user, context) =>
-      expectEq((context as any).auth, undefined)
-    )
+      .it('should not have auth', (user, context) =>
+        expectEq((context as any).auth, undefined)
+      )
 
-    .it('should not have action', (user, context) =>
-      expectEq((context as any).action, undefined)
-    )
+      .it('should not have action', (user, context) =>
+        expectEq((context as any).action, undefined)
+      )
 
-    .it('should have properly defined meta', (user, context) => user.metadata)
+      .it('should have properly defined meta', (user, context) => user.metadata)
 
-    .run(testId, u, c);
-});
+      .run(testId, u, c);
+  });
 
-export const deleteUserTests: any = functions.region(REGION).auth.user().onDelete((u, c) => {
-  const testId: string = u.displayName;
-  console.log(`testId is ${testId}`);
+export const deleteUserTests: any = functions
+  .region(REGION)
+  .auth.user()
+  .onDelete((u, c) => {
+    const testId: string = u.displayName;
+    console.log(`testId is ${testId}`);
 
-  return new TestSuite<UserMetadata>('auth user onDelete')
-    .it('should have a project as resource', (user, context) =>
-      expectEq(context.resource.name, `projects/${process.env.GCLOUD_PROJECT}`)
-    )
+    return new TestSuite<UserMetadata>('auth user onDelete')
+      .it('should have a project as resource', (user, context) =>
+        expectEq(
+          context.resource.name,
+          `projects/${process.env.GCLOUD_PROJECT}`
+        )
+      )
 
-    .it('should not have a path', (user, context) =>
-      expectEq((context as any).path, undefined)
-    )
+      .it('should not have a path', (user, context) =>
+        expectEq((context as any).path, undefined)
+      )
 
-    .it('should have the correct eventType', (user, context) =>
-      expectEq(context.eventType, 'google.firebase.auth.user.delete')
-    )
+      .it('should have the correct eventType', (user, context) =>
+        expectEq(context.eventType, 'google.firebase.auth.user.delete')
+      )
 
-    .it('should have an eventId', (user, context) => context.eventId)
+      .it('should have an eventId', (user, context) => context.eventId)
 
-    .it('should have a timestamp', (user, context) => context.timestamp)
+      .it('should have a timestamp', (user, context) => context.timestamp)
 
-    .it('should not have auth', (user, context) =>
-      expectEq((context as any).auth, undefined)
-    )
+      .it('should not have auth', (user, context) =>
+        expectEq((context as any).auth, undefined)
+      )
 
-    .it('should not have action', (user, context) =>
-      expectEq((context as any).action, undefined)
-    )
+      .it('should not have action', (user, context) =>
+        expectEq((context as any).action, undefined)
+      )
 
-    .run(testId, u, c);
-});
+      .run(testId, u, c);
+  });

--- a/integration_test/functions/src/database-tests.ts
+++ b/integration_test/functions/src/database-tests.ts
@@ -4,8 +4,9 @@ import { expectEq, expectMatches, TestSuite } from './testing';
 import DataSnapshot = admin.database.DataSnapshot;
 
 const testIdFieldName = 'testId';
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
 
-export const databaseTests: any = functions.database
+export const databaseTests: any = functions.region(REGION).database
   .ref('dbTests/{testId}/start')
   .onWrite((ch, ctx) => {
     if (ch.after.val() === null) {

--- a/integration_test/functions/src/database-tests.ts
+++ b/integration_test/functions/src/database-tests.ts
@@ -4,10 +4,11 @@ import { expectEq, expectMatches, TestSuite } from './testing';
 import DataSnapshot = admin.database.DataSnapshot;
 
 const testIdFieldName = 'testId';
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
-export const databaseTests: any = functions.region(REGION).database
-  .ref('dbTests/{testId}/start')
+export const databaseTests: any = functions
+  .region(REGION)
+  .database.ref('dbTests/{testId}/start')
   .onWrite((ch, ctx) => {
     if (ch.after.val() === null) {
       console.log(

--- a/integration_test/functions/src/firestore-tests.ts
+++ b/integration_test/functions/src/firestore-tests.ts
@@ -4,7 +4,7 @@ import { expectDeepEq, expectEq, TestSuite } from './testing';
 import DocumentSnapshot = admin.firestore.DocumentSnapshot;
 
 const testIdFieldName = 'documentId';
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
 export const firestoreTests: any = functions
   .runWith({

--- a/integration_test/functions/src/firestore-tests.ts
+++ b/integration_test/functions/src/firestore-tests.ts
@@ -4,11 +4,13 @@ import { expectDeepEq, expectEq, TestSuite } from './testing';
 import DocumentSnapshot = admin.firestore.DocumentSnapshot;
 
 const testIdFieldName = 'documentId';
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
 
 export const firestoreTests: any = functions
   .runWith({
     timeoutSeconds: 540,
   })
+  .region(REGION)
   .firestore.document('tests/{documentId}')
   .onCreate((s, c) => {
     return new TestSuite<DocumentSnapshot>('firestore document onWrite')

--- a/integration_test/functions/src/https-tests.ts
+++ b/integration_test/functions/src/https-tests.ts
@@ -2,7 +2,7 @@ import * as functions from 'firebase-functions';
 import * as _ from 'lodash';
 import { expectEq, TestSuite } from './testing';
 
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
 export const callableTests: any = functions.region(REGION).https.onCall((d) => {
   return new TestSuite('https onCall')

--- a/integration_test/functions/src/https-tests.ts
+++ b/integration_test/functions/src/https-tests.ts
@@ -2,7 +2,9 @@ import * as functions from 'firebase-functions';
 import * as _ from 'lodash';
 import { expectEq, TestSuite } from './testing';
 
-export const callableTests: any = functions.https.onCall((d) => {
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+
+export const callableTests: any = functions.region(REGION).https.onCall((d) => {
   return new TestSuite('https onCall')
     .it('should have the correct data', (data) =>
       expectEq(_.get(data, 'foo'), 'bar')

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -20,13 +20,14 @@ import * as testLab from './testLab-utils';
 import 'firebase-functions'; // temporary shim until process.env.FIREBASE_CONFIG available natively in GCF(BUG 63586213)
 const firebaseConfig = JSON.parse(process.env.FIREBASE_CONFIG);
 admin.initializeApp();
+const REGION = functions.config().functions.test_region
 
 // TODO(klimt): Get rid of this once the JS client SDK supports callable triggers.
 function callHttpsTrigger(name: string, data: any, baseUrl) {
   return utils.makeRequest(
     {
       method: 'POST',
-      host: 'us-central1-' + firebaseConfig.projectId + '.' + baseUrl,
+      host: REGION + '-' + firebaseConfig.projectId + '.' + baseUrl,
       path: '/' + name,
       headers: {
         'Content-Type': 'application/json',
@@ -62,6 +63,7 @@ function callScheduleTrigger(functionName: string, region: string) {
 }
 
 export const integrationTests: any = functions
+  .region(REGION)
   .runWith({
     timeoutSeconds: 540,
   })

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -20,7 +20,7 @@ import * as testLab from './testLab-utils';
 import 'firebase-functions'; // temporary shim until process.env.FIREBASE_CONFIG available natively in GCF(BUG 63586213)
 const firebaseConfig = JSON.parse(process.env.FIREBASE_CONFIG);
 admin.initializeApp();
-const REGION = functions.config().functions.test_region
+const REGION = functions.config().functions.test_region;
 
 // TODO(klimt): Get rid of this once the JS client SDK supports callable triggers.
 function callHttpsTrigger(name: string, data: any, baseUrl) {

--- a/integration_test/functions/src/pubsub-tests.ts
+++ b/integration_test/functions/src/pubsub-tests.ts
@@ -3,9 +3,11 @@ import * as functions from 'firebase-functions';
 import { evaluate, expectEq, success, TestSuite } from './testing';
 import PubsubMessage = functions.pubsub.Message;
 
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+
 // TODO(inlined) use multiple queues to run inline.
 // Expected message data: {"hello": "world"}
-export const pubsubTests: any = functions.pubsub
+export const pubsubTests: any = functions.region(REGION).pubsub
   .topic('pubsubTests')
   .onPublish((m, c) => {
     let testId: string;
@@ -59,7 +61,7 @@ export const pubsubTests: any = functions.pubsub
       .run(testId, m, c);
   });
 
-export const schedule: any = functions.pubsub
+export const schedule: any = functions.region(REGION).pubsub
   .schedule('every 10 hours') // This is a dummy schedule, since we need to put a valid one in.
   // For the test, the job is triggered by the jobs:run api
   .onRun((context) => {

--- a/integration_test/functions/src/pubsub-tests.ts
+++ b/integration_test/functions/src/pubsub-tests.ts
@@ -3,12 +3,13 @@ import * as functions from 'firebase-functions';
 import { evaluate, expectEq, success, TestSuite } from './testing';
 import PubsubMessage = functions.pubsub.Message;
 
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
 // TODO(inlined) use multiple queues to run inline.
 // Expected message data: {"hello": "world"}
-export const pubsubTests: any = functions.region(REGION).pubsub
-  .topic('pubsubTests')
+export const pubsubTests: any = functions
+  .region(REGION)
+  .pubsub.topic('pubsubTests')
   .onPublish((m, c) => {
     let testId: string;
     try {
@@ -61,8 +62,9 @@ export const pubsubTests: any = functions.region(REGION).pubsub
       .run(testId, m, c);
   });
 
-export const schedule: any = functions.region(REGION).pubsub
-  .schedule('every 10 hours') // This is a dummy schedule, since we need to put a valid one in.
+export const schedule: any = functions
+  .region(REGION)
+  .pubsub.schedule('every 10 hours') // This is a dummy schedule, since we need to put a valid one in.
   // For the test, the job is triggered by the jobs:run api
   .onRun((context) => {
     let testId;

--- a/integration_test/functions/src/remoteConfig-tests.ts
+++ b/integration_test/functions/src/remoteConfig-tests.ts
@@ -2,7 +2,9 @@ import * as functions from 'firebase-functions';
 import { expectEq, TestSuite } from './testing';
 import TemplateVersion = functions.remoteConfig.TemplateVersion;
 
-export const remoteConfigTests: any = functions.remoteConfig.onUpdate(
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+
+export const remoteConfigTests: any = functions.region(REGION).remoteConfig.onUpdate(
   (v, c) => {
     return new TestSuite<TemplateVersion>('remoteConfig onUpdate')
       .it('should have a project as resource', (version, context) =>

--- a/integration_test/functions/src/remoteConfig-tests.ts
+++ b/integration_test/functions/src/remoteConfig-tests.ts
@@ -2,10 +2,11 @@ import * as functions from 'firebase-functions';
 import { expectEq, TestSuite } from './testing';
 import TemplateVersion = functions.remoteConfig.TemplateVersion;
 
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
-export const remoteConfigTests: any = functions.region(REGION).remoteConfig.onUpdate(
-  (v, c) => {
+export const remoteConfigTests: any = functions
+  .region(REGION)
+  .remoteConfig.onUpdate((v, c) => {
     return new TestSuite<TemplateVersion>('remoteConfig onUpdate')
       .it('should have a project as resource', (version, context) =>
         expectEq(
@@ -27,5 +28,4 @@ export const remoteConfigTests: any = functions.region(REGION).remoteConfig.onUp
       )
 
       .run(v.description, v, c);
-  }
-);
+  });

--- a/integration_test/functions/src/storage-tests.ts
+++ b/integration_test/functions/src/storage-tests.ts
@@ -2,7 +2,7 @@ import * as functions from 'firebase-functions';
 import { expectEq, TestSuite } from './testing';
 import ObjectMetadata = functions.storage.ObjectMetadata;
 
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
 export const storageTests: any = functions
   .runWith({

--- a/integration_test/functions/src/storage-tests.ts
+++ b/integration_test/functions/src/storage-tests.ts
@@ -2,10 +2,13 @@ import * as functions from 'firebase-functions';
 import { expectEq, TestSuite } from './testing';
 import ObjectMetadata = functions.storage.ObjectMetadata;
 
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+
 export const storageTests: any = functions
   .runWith({
     timeoutSeconds: 540,
   })
+  .region(REGION)
   .storage.bucket()
   .object()
   .onFinalize((s, c) => {

--- a/integration_test/functions/src/testLab-tests.ts
+++ b/integration_test/functions/src/testLab-tests.ts
@@ -2,11 +2,13 @@ import * as functions from 'firebase-functions';
 import * as _ from 'lodash';
 import { TestSuite, expectEq } from './testing';
 import TestMatrix = functions.testLab.TestMatrix;
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
 
 export const testLabTests: any = functions
   .runWith({
     timeoutSeconds: 540,
   })
+  .region(REGION)
   .testLab.testMatrix()
   .onComplete((matrix, context) => {
     return new TestSuite<TestMatrix>('test matrix complete')

--- a/integration_test/functions/src/testLab-tests.ts
+++ b/integration_test/functions/src/testLab-tests.ts
@@ -2,7 +2,7 @@ import * as functions from 'firebase-functions';
 import * as _ from 'lodash';
 import { TestSuite, expectEq } from './testing';
 import TestMatrix = functions.testLab.TestMatrix;
-const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || "us-central1";
+const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 
 export const testLabTests: any = functions
   .runWith({


### PR DESCRIPTION
### Description
Updates integration tests to use the region specified in the environment variable FIREBASE_FUNCTIONS_TEST_REGION. If not set, defaults to 'us-central1'.

### Code sample
export FIREBASE_FUNCTIONS_TEST_REGION=europe-west1
./integration-test/run_tests.sh <project-name>

