### PR TITLE
Cleaning up docgen

### DIFF
--- a/docgen/content-sources/toc.yaml
+++ b/docgen/content-sources/toc.yaml
@@ -69,18 +69,6 @@ toc:
       - title: 'UserRecord'
         path: /docs/reference/functions/providers_auth_.html#userrecord
 
-  - title: 'functions.crashlytics'
-    path: /docs/reference/functions/providers_crashlytics_.html
-    section:
-      - title: 'Issue'
-        path: /docs/reference/functions/providers_crashlytics_.issue.html
-      - title: 'IssueBuilder'
-        path: /docs/reference/functions/providers_crashlytics_.issuebuilder.html
-      - title: 'AppInfo'
-        path: /docs/reference/functions/providers_crashlytics_.appinfo.html
-      - title: 'VelocityAlert'
-        path: /docs/reference/functions/providers_crashlytics_.velocityalert.html
-
   - title: 'functions.firestore'
     path: /docs/reference/functions/providers_firestore_.html
     section:

--- a/docgen/generate-docs.js
+++ b/docgen/generate-docs.js
@@ -323,7 +323,9 @@ Promise.all([
     // Clean up temp home markdown file. (Nothing needs to wait for this.)
     fs.unlink(tempHomePath);
     // Devsite doesn't like css.map files.
-    return fs.unlink(`${docPath}/assets/css/main.css.map`);
+    if (fs.existsSync(`${docPath}/assets/css/main.css.map`)) { 
+      return fs.unlink(`${docPath}/assets/css/main.css.map`);
+    }
   })
   // Write out TOC file.  Do this after Typedoc step to prevent Typedoc
   // erroring when it finds an unexpected file in the target dir.


### PR DESCRIPTION
### Description
Cleaning up our docgen script:
- Removes crashlytics from toc.yaml
- Stops trying to delete css.map files if they don't exist
