### PR TITLE
Correcting UserRecord falsey values to match types in admin sdk (#875)

### DIFF
--- a/spec/providers/auth.spec.ts
+++ b/spec/providers/auth.spec.ts
@@ -131,17 +131,10 @@ describe('Auth Functions', () => {
       const record = auth.userRecordConstructor({ uid: '123' });
       expect(record.toJSON()).to.deep.equal({
         uid: '123',
-        email: null,
         emailVerified: false,
-        displayName: null,
-        photoURL: null,
-        phoneNumber: null,
         disabled: false,
         providerData: [],
         customClaims: {},
-        passwordSalt: null,
-        passwordHash: null,
-        tokensValidAfterTime: null,
         metadata: {
           creationTime: null,
           lastSignInTime: null,

--- a/src/providers/auth.ts
+++ b/src/providers/auth.ts
@@ -126,17 +126,10 @@ export function userRecordConstructor(
 ): firebase.auth.UserRecord {
   // Falsey values from the wire format proto get lost when converted to JSON, this adds them back.
   const falseyValues: any = {
-    email: null,
     emailVerified: false,
-    displayName: null,
-    photoURL: null,
-    phoneNumber: null,
     disabled: false,
     providerData: [],
     customClaims: {},
-    passwordSalt: null,
-    passwordHash: null,
-    tokensValidAfterTime: null,
   };
   const record = _.assign({}, falseyValues, wireData);
 


### PR DESCRIPTION
### Description
Stop setting these fields in UserRecord to null when they are not present - they should be undefined in that case. Fixes #875, though I am a little worried that this breaks users who were specifically checking `if (userRecord.field == null)`.
