### PR TITLE
Update release script to build packages using Node 14

### DIFF
--- a/scripts/publish-container/Dockerfile
+++ b/scripts/publish-container/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:14
 
 # Install dependencies
 RUN apt-get update && \

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -87,7 +87,7 @@ npm run build:release
 echo "Ran publish build."
 
 echo "Making a $VERSION version..."
-npm version $VERSION
+npm version --no-git-tag-version $VERSION
 NEW_VERSION=$(jq -r ".version" package.json)
 echo "Made a $VERSION version."
 


### PR DESCRIPTION
https://github.com/firebase/firebase-functions/pull/885 changes typescript target to ES2018, and running `npm test` in Node 8 no longer works.

We update the release script to update to an environment that uses Node 14. As a side-effect, we have to update the publish.sh script where we use `npm version` - npm v7 requires the local git directory to be clean by default.