### PR TITLE
Inline DecodedAppCheck definition

### DIFF
--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -1,9 +1,9 @@
+import { PubSub } from '@google-cloud/pubsub';
 import { Request, Response } from 'express';
 import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import * as fs from 'fs';
 import * as https from 'https';
-import { PubSub } from '@google-cloud/pubsub';
 
 export * from './pubsub-tests';
 export * from './database-tests';

--- a/integration_test/functions/src/testLab-tests.ts
+++ b/integration_test/functions/src/testLab-tests.ts
@@ -1,5 +1,5 @@
 import * as functions from 'firebase-functions';
-import { TestSuite, expectEq } from './testing';
+import { expectEq, TestSuite } from './testing';
 import TestMatrix = functions.testLab.TestMatrix;
 const REGION = process.env.FIREBASE_FUNCTIONS_TEST_REGION || 'us-central1';
 

--- a/integration_test/functions/src/testLab-utils.ts
+++ b/integration_test/functions/src/testLab-utils.ts
@@ -1,6 +1,6 @@
+import * as admin from 'firebase-admin';
 import * as http from 'http';
 import * as https from 'https';
-import * as admin from 'firebase-admin';
 import * as utils from './test-utils';
 
 interface AndroidDevice {
@@ -50,12 +50,12 @@ async function fetchDefaultDevice(
   const model = defaultModels[0];
   const versions = model.supportedVersionIds;
 
-  return <AndroidDevice>{
+  return {
     androidModelId: model.id,
     androidVersionId: versions[versions.length - 1],
     locale: 'en',
     orientation: 'portrait',
-  };
+  } as AndroidDevice;
 }
 
 function createTestMatrix(
@@ -70,7 +70,7 @@ function createTestMatrix(
     '/v1/projects/' + projectId + '/testMatrices'
   );
   const body = {
-    projectId: projectId,
+    projectId,
     testSpecification: {
       androidRoboTest: {
         appApk: {
@@ -105,9 +105,9 @@ function requestOptions(
   path: string
 ): https.RequestOptions {
   return {
-    method: method,
+    method,
     hostname: TESTING_API_SERVICE_NAME,
-    path: path,
+    path,
     headers: {
       Authorization: 'Bearer ' + accessToken.access_token,
       'Content-Type': 'application/json',

--- a/integration_test/functions/src/testing.ts
+++ b/integration_test/functions/src/testing.ts
@@ -92,7 +92,7 @@ function deepEq(left: any, right: any) {
     return false;
   }
 
-  for (let key in left) {
+  for (const key in left) {
     if (!right.hasOwnProperty(key)) {
       return false;
     }

--- a/spec/fixtures/mockrequest.ts
+++ b/spec/fixtures/mockrequest.ts
@@ -2,8 +2,8 @@ import * as jwt from 'jsonwebtoken';
 import * as jwkToPem from 'jwk-to-pem';
 import * as _ from 'lodash';
 import * as nock from 'nock';
-import * as mockKey from '../fixtures/credential/key.json';
 import * as mockJWK from '../fixtures/credential/jwk.json';
+import * as mockKey from '../fixtures/credential/key.json';
 
 // MockRequest mocks an https.Request.
 export class MockRequest {

--- a/spec/logger.spec.ts
+++ b/spec/logger.spec.ts
@@ -7,8 +7,8 @@ const SUPPORTS_STRUCTURED_LOGS =
 describe(`logger (${
   SUPPORTS_STRUCTURED_LOGS ? 'structured' : 'unstructured'
 })`, () => {
-  let stdoutWrite = process.stdout.write.bind(process.stdout);
-  let stderrWrite = process.stderr.write.bind(process.stderr);
+  const stdoutWrite = process.stdout.write.bind(process.stdout);
+  const stderrWrite = process.stderr.write.bind(process.stderr);
   let lastOut: string;
   let lastErr: string;
 
@@ -127,7 +127,7 @@ describe(`logger (${
 
         for (const severity of ['DEBUG', 'INFO', 'NOTICE']) {
           it(`should output ${severity} severity to stdout`, () => {
-            let entry: logger.LogEntry = {
+            const entry: logger.LogEntry = {
               severity: severity as logger.LogSeverity,
               message: 'test',
             };
@@ -144,7 +144,7 @@ describe(`logger (${
           'EMERGENCY',
         ]) {
           it(`should output ${severity} severity to stderr`, () => {
-            let entry: logger.LogEntry = {
+            const entry: logger.LogEntry = {
               severity: severity as logger.LogSeverity,
               message: 'test',
             };

--- a/spec/providers/testLab.spec.ts
+++ b/spec/providers/testLab.spec.ts
@@ -66,23 +66,23 @@ describe('Test Lab Functions', () => {
             resource: {},
           },
         };
-        const expected = <testLab.TestMatrix>{
+        const expected = {
           testMatrixId: 'matrix-375mfeu9mnw8t',
           state: 'INVALID',
           createTime: '2019-04-15T17:43:32.538Z',
           outcomeSummary: undefined,
           invalidMatrixDetails: 'INVALID_INPUT_APK',
-          resultStorage: <testLab.ResultStorage>{
+          resultStorage: {
             gcsPath: 'gs://test.appspot.com',
             resultsUrl: undefined,
             toolResultsHistoryId: undefined,
             toolResultsExecutionId: undefined,
-          },
-          clientInfo: <testLab.ClientInfo>{
+          } as testLab.ResultStorage,
+          clientInfo: {
             name: 'test',
             details: {},
-          },
-        };
+          } as testLab.ClientInfo,
+        } as testLab.TestMatrix;
         const func = testLab.testMatrix().onComplete((matrix) => matrix);
         return expect(func(event.data, event.context)).to.eventually.deep.equal(
           expected
@@ -119,23 +119,23 @@ describe('Test Lab Functions', () => {
             resource: {},
           },
         };
-        const expected = <testLab.TestMatrix>{
+        const expected = {
           testMatrixId: 'matrix-tsgjk8pnvxhya',
           state: 'FINISHED',
           createTime: '2019-04-15T18:03:11.115Z',
           outcomeSummary: 'FAILURE',
           invalidMatrixDetails: undefined,
-          resultStorage: <testLab.ResultStorage>{
+          resultStorage: {
             gcsPath: 'gs://test.appspot.com',
             toolResultsHistoryId: 'bh.9b6f4dac24d3049',
             toolResultsExecutionId: '6352915701487950333',
             resultsUrl: 'https://path/to/results',
-          },
-          clientInfo: <testLab.ClientInfo>{
+          } as testLab.ResultStorage,
+          clientInfo: {
             name: 'test',
             details: {},
-          },
-        };
+          } as testLab.ClientInfo,
+        } as testLab.TestMatrix;
         const func = testLab.testMatrix().onComplete((matrix) => matrix);
         return expect(func(event.data, event.context)).to.eventually.deep.equal(
           expected
@@ -161,7 +161,7 @@ describe('Test Lab Functions', () => {
   describe('TestMatrix', () => {
     describe('constructor', () => {
       it('should populate basic fields', () => {
-        const expected = <testLab.TestMatrix>{
+        const expected = {
           testMatrixId: 'id1',
           createTime: '2019-02-08T18:50:32.178Z',
           state: 'FINISHED',
@@ -169,7 +169,7 @@ describe('Test Lab Functions', () => {
           invalidMatrixDetails: 'DETAILS_UNAVAILABLE',
           resultStorage: new testLab.ResultStorage(),
           clientInfo: new testLab.ClientInfo(),
-        };
+        } as testLab.TestMatrix;
         const actual = new testLab.TestMatrix({
           testMatrixId: 'id1',
           timestamp: '2019-02-08T18:50:32.178Z',
@@ -185,10 +185,10 @@ describe('Test Lab Functions', () => {
   describe('ClientInfo', () => {
     describe('constructor', () => {
       it('should populate basic fields', () => {
-        const expected = <testLab.ClientInfo>{
+        const expected = {
           name: 'client',
           details: {},
-        };
+        } as testLab.ClientInfo;
         const actual = new testLab.ClientInfo({
           name: 'client',
         });
@@ -196,13 +196,13 @@ describe('Test Lab Functions', () => {
       });
 
       it('should populate key/value details', () => {
-        const expected = <testLab.ClientInfo>{
+        const expected = {
           name: 'client',
           details: {
             k0: 'v0',
             k1: '',
           },
-        };
+        } as testLab.ClientInfo;
         const actual = new testLab.ClientInfo({
           name: 'client',
           clientInfoDetails: [
@@ -223,12 +223,12 @@ describe('Test Lab Functions', () => {
   describe('ResultStorage', () => {
     describe('constructor', () => {
       it('should populate basic fields', () => {
-        const expected = <testLab.ResultStorage>{
+        const expected = {
           gcsPath: 'path',
           toolResultsHistoryId: 'h1',
           toolResultsExecutionId: 'e2',
           resultsUrl: 'http://example.com/',
-        };
+        } as testLab.ResultStorage;
         const actual = new testLab.ResultStorage({
           googleCloudStorage: {
             gcsPath: 'path',

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -22,13 +22,13 @@
 
 import { Request, Response } from 'express';
 import * as _ from 'lodash';
-import { warn } from './logger';
 import {
   DEFAULT_FAILURE_POLICY,
   DeploymentOptions,
   FailurePolicy,
   Schedule,
 } from './function-configuration';
+import { warn } from './logger';
 export { Request, Response };
 
 /** @hidden */

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -26,12 +26,12 @@ import * as _ from 'lodash';
 import { CloudFunction, EventContext } from './cloud-functions';
 import {
   DeploymentOptions,
+  INGRESS_SETTINGS_OPTIONS,
   MAX_TIMEOUT_SECONDS,
   RuntimeOptions,
   SUPPORTED_REGIONS,
   VALID_MEMORY_OPTIONS,
   VPC_EGRESS_SETTINGS_OPTIONS,
-  INGRESS_SETTINGS_OPTIONS,
 } from './function-configuration';
 import * as analytics from './providers/analytics';
 import * as auth from './providers/auth';

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -117,6 +117,13 @@ export interface RuntimeOptions {
   minInstances?: number;
 
   /**
+   * Which version of the internal contract between the CLI and the SDK are
+   * we using? For internal testing only.
+   * @hidden
+   */
+  apiVersion?: 1 | 2;
+
+  /**
    * Max number of actual instances allowed to be running in parallel
    */
   maxInstances?: number;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,8 +32,8 @@ import * as storage from './providers/storage';
 import * as testLab from './providers/testLab';
 
 import * as apps from './apps';
-import * as logger from './logger';
 import { handler } from './handler-builder';
+import * as logger from './logger';
 import { setup } from './setup';
 
 const app = apps.apps();

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,8 +1,8 @@
 import { format } from 'util';
 
 import {
-  SUPPORTS_STRUCTURED_LOGS,
   CONSOLE_SEVERITY,
+  SUPPORTS_STRUCTURED_LOGS,
   UNPATCHED_CONSOLE,
 } from './logger/common';
 

--- a/src/logger/compat.ts
+++ b/src/logger/compat.ts
@@ -1,9 +1,9 @@
+import { format } from 'util';
 import {
+  CONSOLE_SEVERITY,
   SUPPORTS_STRUCTURED_LOGS,
   UNPATCHED_CONSOLE,
-  CONSOLE_SEVERITY,
 } from './common';
-import { format } from 'util';
 
 /** @hidden */
 function patchedConsole(severity: string): (data: any, ...args: any[]) => void {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -140,7 +140,7 @@ export function _refWithOptions(
       );
     }
 
-    let instance = undefined;
+    let instance;
     const prodMatch = databaseURL.match(databaseURLRegex);
     if (prodMatch) {
       instance = prodMatch[1];

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -253,7 +253,60 @@ export interface CallableContext {
    */
   app?: {
     appId: string;
-    token: firebase.appCheck.DecodedAppCheckToken;
+
+    // This is actually a firebase.appCheck.DecodedAppCheckToken, but
+    // that type may not be available in some supported SDK versions.
+    // Declare as an inline type, which DecodedAppCheckToken will be
+    // able to merge with.
+    // TODO: Replace with the real type once we bump the min-version of
+    // the admin SDK
+    token: {
+      /**
+       * The issuer identifier for the issuer of the response.
+       *
+       * This value is a URL with the format
+       * `https://firebaseappcheck.googleapis.com/<PROJECT_NUMBER>`, where `<PROJECT_NUMBER>` is the
+       * same project number specified in the [`aud`](#aud) property.
+       */
+      iss: string;
+  
+      /**
+       * The Firebase App ID corresponding to the app the token belonged to.
+       *
+       * As a convenience, this value is copied over to the [`app_id`](#app_id) property.
+       */
+      sub: string;
+  
+      /**
+       * The audience for which this token is intended.
+       *
+       * This value is a JSON array of two strings, the first is the project number of your
+       * Firebase project, and the second is the project ID of the same project.
+       */
+      aud: string[];
+  
+      /**
+       * The App Check token's expiration time, in seconds since the Unix epoch. That is, the
+       * time at which this App Check token expires and should no longer be considered valid.
+       */
+      exp: number;
+  
+      /**
+       * The App Check token's issued-at time, in seconds since the Unix epoch. That is, the
+       * time at which this App Check token was issued and should start to be considered
+       * valid.
+       */
+      iat: number;
+  
+      /**
+       * The App ID corresponding to the App the App Check token belonged to.
+       *
+       * This value is not actually one of the JWT token claims. It is added as a
+       * convenience, and is set as the value of the [`sub`](#sub) property.
+       */
+      app_id: string;
+      [key: string]: any;
+    };
   };
 
   /**

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -269,14 +269,14 @@ export interface CallableContext {
        * same project number specified in the [`aud`](#aud) property.
        */
       iss: string;
-  
+
       /**
        * The Firebase App ID corresponding to the app the token belonged to.
        *
        * As a convenience, this value is copied over to the [`app_id`](#app_id) property.
        */
       sub: string;
-  
+
       /**
        * The audience for which this token is intended.
        *
@@ -284,20 +284,20 @@ export interface CallableContext {
        * Firebase project, and the second is the project ID of the same project.
        */
       aud: string[];
-  
+
       /**
        * The App Check token's expiration time, in seconds since the Unix epoch. That is, the
        * time at which this App Check token expires and should no longer be considered valid.
        */
       exp: number;
-  
+
       /**
        * The App Check token's issued-at time, in seconds since the Unix epoch. That is, the
        * time at which this App Check token was issued and should start to be considered
        * valid.
        */
       iat: number;
-  
+
       /**
        * The App ID corresponding to the App the App Check token belonged to.
        *


### PR DESCRIPTION
Previously, including the HTTP library caused failures if the customer had an old (but supported) version of firebase-admin. This now inlines a compatible interface definition to avoid the error.