### PR TITLE
Fix publish script to commit changes to version info in package{-lock}.json.

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -89,6 +89,7 @@ echo "Ran publish build."
 echo "Making a $VERSION version..."
 # TODO: Remove the following command.
 #   npm version command had previously failed claiming unclean git repo, and we don't know why.
+echo "DEBUG: Running git status to show dirty files..."
 git status
 npm version $VERSION
 NEW_VERSION=$(jq -r ".version" package.json)

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -87,7 +87,10 @@ npm run build:release
 echo "Ran publish build."
 
 echo "Making a $VERSION version..."
-npm version --no-git-tag-version $VERSION
+# TODO: Remove the following command.
+#   npm version command had previously failed claiming unclean git repo, and we don't know why.
+git status
+npm version $VERSION
 NEW_VERSION=$(jq -r ".version" package.json)
 echo "Made a $VERSION version."
 


### PR DESCRIPTION
While migrating publish script to run on Node.js 14 in https://github.com/firebase/firebase-functions/pull/889, we accidentally  removed mechanism to commit and push changes to the `version` attribute in `package.json` and `package-lock.json`. This broke the publishing pipeline by pushing out wrong versions of the release.

We revert the changes made in the faulty PR. I still don't know why the release script failed with error messages like below when we migrated the publisher container to use nodejs14:

```
Step #11: Making a minor version...
Step #11: npm ERR! Git working directory not clean.
Step #11:
Step #11: npm ERR! A complete log of this run can be found in:
Step #11: npm ERR!     /builder/home/.npm/_logs/2021-05-12T18_47_59_428Z-debug.log
Finished Step #11
```

I'm adding a `git status` command before `npm version` command to help us more easily diagnose the issue if it happens again on our next release.