### PR TITLE
Adds support for setting user labels on functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Adds support for setting user labels on functions via `runWith()`.

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -319,4 +319,62 @@ describe('FunctionBuilder', () => {
 
     expect(fn.__trigger.availableMemoryMb).to.deep.equal(4096);
   });
+
+  it('should allow labels to be set', () => {
+    const fn = functions
+      .runWith({
+        labels: {
+          'valid-key': 'valid-value',
+        },
+      })
+      .auth.user()
+      .onCreate((user) => user);
+
+    expect(fn.__trigger.labels).to.deep.equal({
+      'valid-key': 'valid-value',
+    });
+  });
+
+  it('should throw an error if more than 58 labels are set', () => {
+    const labels = {};
+    for (let i = 0; i < 59; i++) {
+      labels[`label${i}`] = 'value';
+    }
+
+    expect(() =>
+      functions.runWith({
+        labels,
+      })
+    ).to.throw();
+  });
+
+  it('should throw an error if labels has a key that is too long', () => {
+    expect(() =>
+      functions.runWith({
+        labels: {
+          'a-very-long-key-that-is-more-than-the-maximum-allowed-length-for-keys':
+            'value',
+        },
+      })
+    ).to.throw();
+  });
+
+  it('should throw an error if labels has key that is too short', () => {
+    expect(() =>
+      functions.runWith({
+        labels: { '': 'value' },
+      })
+    ).to.throw();
+  });
+
+  it('should throw an error if labels has a value that is too long', () => {
+    expect(() =>
+      functions.runWith({
+        labels: {
+          key:
+            'a-very-long-value-that-is-more-than-the-maximum-allowed-length-for-values',
+        },
+      })
+    ).to.throw();
+  });
 });

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -377,4 +377,48 @@ describe('FunctionBuilder', () => {
       })
     ).to.throw();
   });
+
+  it('should throw an error if labels has a key that contains invalid characters', () => {
+    expect(() =>
+      functions.runWith({
+        labels: {
+          Key: 'value',
+        },
+      })
+    ).to.throw();
+
+    expect(() =>
+      functions.runWith({
+        labels: {
+          'key ': 'value',
+        },
+      })
+    ).to.throw();
+
+    expect(() =>
+      functions.runWith({
+        labels: {
+          '1key': 'value',
+        },
+      })
+    ).to.throw();
+  });
+
+  it('should throw an error if labels has a value that contains invalid characters', () => {
+    expect(() =>
+      functions.runWith({
+        labels: {
+          key: 'Value',
+        },
+      })
+    ).to.throw();
+
+    expect(() =>
+      functions.runWith({
+        labels: {
+          'key ': 'va lue',
+        },
+      })
+    ).to.throw();
+  });
 });

--- a/spec/function-builder.spec.ts
+++ b/spec/function-builder.spec.ts
@@ -421,4 +421,22 @@ describe('FunctionBuilder', () => {
       })
     ).to.throw();
   });
+
+  it('should throw an error if a label key starts with a reserved namespace', () => {
+    expect(() =>
+      functions.runWith({
+        labels: {
+          'firebase-foo': 'value',
+        },
+      })
+    ).to.throw();
+
+    expect(() =>
+      functions.runWith({
+        labels: {
+          'deployment-bar': 'value',
+        },
+      })
+    ).to.throw();
+  });
 });

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -417,7 +417,7 @@ export function makeCloudFunction<EventData>({
         },
       });
       if (!_.isEmpty(labels)) {
-        trigger.labels = labels;
+        trigger.labels = Object.assign(labels, trigger.labels);
       }
       return trigger;
     },
@@ -551,6 +551,10 @@ export function optionsToTrigger(options: DeploymentOptions) {
         `Invalid option for serviceAccount: '${options.serviceAccount}'. Valid options are 'default', a service account email, or '{serviceAccountName}@'`
       );
     }
+  }
+
+  if (options.labels) {
+    trigger.labels = options.labels;
   }
 
   return trigger;

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -417,7 +417,7 @@ export function makeCloudFunction<EventData>({
         },
       });
       if (!_.isEmpty(labels)) {
-        trigger.labels = Object.assign(labels, trigger.labels);
+        trigger.labels = { ...labels, ...trigger.labels };
       }
       return trigger;
     },

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -417,7 +417,7 @@ export function makeCloudFunction<EventData>({
         },
       });
       if (!_.isEmpty(labels)) {
-        trigger.labels = { ...labels, ...trigger.labels };
+        trigger.labels = { ...trigger.labels, ...labels };
       }
       return trigger;
     },

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -27,6 +27,7 @@ import { CloudFunction, EventContext } from './cloud-functions';
 import {
   DeploymentOptions,
   INGRESS_SETTINGS_OPTIONS,
+  MAX_NUMBER_USER_LABELS,
   MAX_TIMEOUT_SECONDS,
   RuntimeOptions,
   SUPPORTED_REGIONS,
@@ -119,6 +120,36 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
     throw new Error(
       `serviceAccount must be set to 'default', a service account email, or '{serviceAccountName}@'`
     );
+  }
+
+  if (runtimeOptions.labels) {
+    if (Object.keys(runtimeOptions.labels).length > MAX_NUMBER_USER_LABELS) {
+      throw new Error(
+        `A function must not have more than 58 user-defined labels`
+      );
+    }
+
+    const invalidLengthKeys = Object.keys(runtimeOptions.labels).filter(
+      (label) => label.length < 1 || label.length > 63
+    );
+    if (invalidLengthKeys.length) {
+      throw new Error(
+        `Invalid label - ${invalidLengthKeys.join(
+          ', '
+        )} must be between 1 and 63 characters in length.`
+      );
+    }
+
+    const invalidLengthValues = Object.values(runtimeOptions.labels).filter(
+      (value) => value.length > 63
+    );
+    if (invalidLengthValues.length) {
+      throw new Error(
+        `Invalid label value - ${invalidLengthValues.join(
+          ', '
+        )} must be less than 64 charcters`
+      );
+    }
   }
   return true;
 }

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -132,7 +132,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
       );
     }
 
-    // We reserve the 'deployment-' and 'firebase-' namespaces for future feature development.
+    // We reserve the 'deployment' and 'firebase' namespaces for future feature development.
     const reservedKeys = Object.keys(runtimeOptions.labels).filter(
       (key) => key.startsWith('deployment') || key.startsWith('firebase')
     );

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -123,14 +123,29 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   }
 
   if (runtimeOptions.labels) {
+    // Labels must follow the rules listed in
+    // https://cloud.google.com/resource-manager/docs/creating-managing-labels#requirements
+
     if (Object.keys(runtimeOptions.labels).length > MAX_NUMBER_USER_LABELS) {
       throw new Error(
         `A function must not have more than ${MAX_NUMBER_USER_LABELS} user-defined labels.`
       );
     }
 
+    // We reserve the 'deployment-' and 'firebase-' namespaces for future feature development.
+    const reservedKeys = Object.keys(runtimeOptions.labels).filter(
+      (key) => key.startsWith('deployment') || key.startsWith('firebase')
+    );
+    if (reservedKeys.length) {
+      throw new Error(
+        `Invalid labels: ${reservedKeys.join(
+          ', '
+        )}. Labels may not start with reserved names 'deployment' or 'firebase'`
+      );
+    }
+
     const invalidLengthKeys = Object.keys(runtimeOptions.labels).filter(
-      (label) => label.length < 1 || label.length > 63
+      (key) => key.length < 1 || key.length > 63
     );
     if (invalidLengthKeys.length > 0) {
       throw new Error(
@@ -163,6 +178,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
         )}. Label keys can only contain lowercase letters, international characters, numbers, _ or -, and must start with a letter.`
       );
     }
+
     // Values can contain lowercase letters, foreign characters, numbers, _ or -.
     const validValuePattern = /^[\p{Ll}\p{Lo}\p{N}_-]{0,63}$/u;
     const invalidValues = Object.values(runtimeOptions.labels).filter(

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -125,7 +125,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   if (runtimeOptions.labels) {
     if (Object.keys(runtimeOptions.labels).length > MAX_NUMBER_USER_LABELS) {
       throw new Error(
-        `A function must not have more than 58 user-defined labels`
+        `A function must not have more than ${MAX_NUMBER_USER_LABELS} user-defined labels.`
       );
     }
 
@@ -147,7 +147,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
       throw new Error(
         `Invalid labels: ${invalidLengthValues.join(
           ', '
-        )}. Label values must be less than 64 charcters`
+        )}. Label values must be less than 64 charcters.`
       );
     }
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -132,22 +132,47 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
     const invalidLengthKeys = Object.keys(runtimeOptions.labels).filter(
       (label) => label.length < 1 || label.length > 63
     );
-    if (invalidLengthKeys.length) {
+    if (invalidLengthKeys.length > 0) {
       throw new Error(
-        `Invalid label - ${invalidLengthKeys.join(
+        `Invalid labels: ${invalidLengthKeys.join(
           ', '
-        )} must be between 1 and 63 characters in length.`
+        )}. Label keys must be between 1 and 63 characters in length.`
       );
     }
 
     const invalidLengthValues = Object.values(runtimeOptions.labels).filter(
       (value) => value.length > 63
     );
-    if (invalidLengthValues.length) {
+    if (invalidLengthValues.length > 0) {
       throw new Error(
-        `Invalid label value - ${invalidLengthValues.join(
+        `Invalid labels: ${invalidLengthValues.join(
           ', '
-        )} must be less than 64 charcters`
+        )}. Label values must be less than 64 charcters`
+      );
+    }
+
+    // Keys can contain lowercase letters, foreign characters, numbers, _ or -. They must start with a letter.
+    const validKeyPattern = /^[\p{Ll}\p{Lo}][\p{Ll}\p{Lo}\p{N}_-]{0,62}$/u;
+    const invalidKeys = Object.keys(runtimeOptions.labels).filter(
+      (key) => !validKeyPattern.test(key)
+    );
+    if (invalidKeys.length > 0) {
+      throw new Error(
+        `Invalid labels: ${invalidKeys.join(
+          ', '
+        )}. Label keys can only contain lowercase letters, international characters, numbers, _ or -, and must start with a letter.`
+      );
+    }
+    // Values can contain lowercase letters, foreign characters, numbers, _ or -.
+    const validValuePattern = /^[\p{Ll}\p{Lo}\p{N}_-]{0,63}$/u;
+    const invalidValues = Object.values(runtimeOptions.labels).filter(
+      (value) => !validValuePattern.test(value)
+    );
+    if (invalidValues.length > 0) {
+      throw new Error(
+        `Invalid labels: ${invalidValues.join(
+          ', '
+        )}. Label values can only contain lowercase letters, international characters, numbers, _ or -.`
       );
     }
   }

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -126,32 +126,32 @@ export interface RuntimeOptions {
   apiVersion?: 1 | 2;
 
   /**
-   * Max number of actual instances allowed to be running in parallel
+   * Max number of actual instances allowed to be running in parallel.
    */
   maxInstances?: number;
 
   /**
-   * Connect cloud function to specified VPC connector
+   * Connect cloud function to specified VPC connector.
    */
   vpcConnector?: string;
 
   /**
-   * Egress settings for VPC connector
+   * Egress settings for VPC connector.
    */
   vpcConnectorEgressSettings?: typeof VPC_EGRESS_SETTINGS_OPTIONS[number];
 
   /**
-   * Specific service account for the function to run as
+   * Specific service account for the function to run as.
    */
   serviceAccount?: 'default' | string;
 
   /**
-   * Ingress settings
+   * Ingress settings which control where this function can be called from.
    */
   ingressSettings?: typeof INGRESS_SETTINGS_OPTIONS[number];
 
   /**
-   *
+   * User labels to set on the function.
    */
   labels?: Record<string, string>;
 }

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -94,6 +94,8 @@ export const DEFAULT_FAILURE_POLICY: FailurePolicy = {
   retry: {},
 };
 
+export const MAX_NUMBER_USER_LABELS = 58;
+
 export interface RuntimeOptions {
   /**
    * Failure policy of the function, with boolean `true` being equivalent to
@@ -147,6 +149,11 @@ export interface RuntimeOptions {
    * Ingress settings
    */
   ingressSettings?: typeof INGRESS_SETTINGS_OPTIONS[number];
+
+  /**
+   *
+   */
+  labels?: Record<string, string>;
 }
 
 export interface DeploymentOptions extends RuntimeOptions {


### PR DESCRIPTION
### Description
Adds 'labels' to runtimeOptions, per go/firebase-functions-labels. This lets you set user labels on functions!

Note: I did make one minor change to the behavior described in go/firebase-functions-labels - if the labels option is not set in runWith(), we still overwrite labels. Originally, I proposed this behavior to support users who already manually set labels. However, the existing behavior of Firebase Functions is to overwrite labels. We also avoid the awkward case where removing 'labels' from 'runtimeOptions' doesn't cause labels to be removed. 


### Code sample
```
functions.runWith({
  labels: {
    "my-label": "my-value",
  }
})...
```

### Testing
I tested the following cases and confirmed that labels were set correctly via the Equivalent REST button in GCP console.
- Setting labels on normal functions.
- Setting labels on scheduled functions.
- Updating a function to change the labels.
- Setting too many labels throws an error before deployment
- Setting invalid labels throws an error before deployment 