### PR TITLE
missing provider type in auth variable

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -315,6 +315,7 @@ export interface CallableContext {
   auth?: {
     uid: string;
     token: firebase.auth.DecodedIdToken;
+    provider: string;
   };
 
   /**


### PR DESCRIPTION
As specified in the docs auth object should have a provider property

<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
