### PR TITLE
Defensively JSON.pase+JSON.stringify inputs into removeCircular to prevent NPEs

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -30,7 +30,7 @@ export interface LogEntry {
   [key: string]: any;
 }
 
-function removeCircular(obj: any, refs:any[] = []): any {
+function removeCircular(obj: any, refs: any[] = []): any {
   const cleanedObj = JSON.parse(JSON.stringify(obj));
   return removeCircularRecursive(cleanedObj, refs);
 }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -30,7 +30,12 @@ export interface LogEntry {
   [key: string]: any;
 }
 
-function removeCircular(obj: any, refs: any[] = []): any {
+function removeCircular(obj: any, refs:any[] = []): any {
+  const cleanedObj = JSON.parse(JSON.stringify(obj));
+  return removeCircularRecursive(cleanedObj, refs);
+}
+
+function removeCircularRecursive(obj: any, refs: any[] = []): any {
   if (typeof obj !== 'object' || !obj) {
     return obj;
   }
@@ -49,7 +54,7 @@ function removeCircular(obj: any, refs: any[] = []): any {
     if (refs.includes(obj[k])) {
       returnObj[k] = '[Circular]';
     } else {
-      returnObj[k] = removeCircular(obj[k], refs);
+      returnObj[k] = removeCircularRecursive(obj[k], refs);
     }
   }
   return returnObj;


### PR DESCRIPTION
### Description
Some complex objects that overwrote toJSON were breaking the structured logger. Specifically, calling removeCircular on some complex objects (for example, #907 ) could cause JSON.stringify to throw null pointer errors when called on those objects. This fix should ensure that any object can be safely logged.

### Testing
I tested out the case in #907, and I was able to successfully log `moment()` without errors:
``` {"structuredData":"2021-06-28T22:31:17.125Z","severity":"INFO","message":"Hello logs!"}```
