### PR TITLE
RemoteConfig can be loaded in windows CMD.exe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Adds support for setting user labels on functions via `runWith()`.
 - Adds support for FIREBASE_CONFIG env as the name of a JSON file
 - Formalize module exports. Loggers can now be accessed at 'firebase-functions/logger' and 'firebase-functions/logger/compat'
+- Fixes an issue where Remote Config coiuld not be emulated in Windows machines on the classic Command Prompt.

--- a/src/v1/config.ts
+++ b/src/v1/config.ts
@@ -89,8 +89,9 @@ export function firebaseConfig(): firebase.AppOptions | null {
   try {
     const configPath =
       process.env.CLOUD_RUNTIME_CONFIG ||
-      path.join(process.env.PWD, '.runtimeconfig.json');
-    const config = require(configPath);
+      path.join(process.cwd(), '.runtimeconfig.json');
+    const contents = fs.readFileSync(configPath);
+    const config = JSON.parse(contents.toString('utf8'));
     if (config.firebase) {
       firebaseConfigCache = config.firebase;
       return firebaseConfigCache;
@@ -115,8 +116,9 @@ function init() {
   try {
     const configPath =
       process.env.CLOUD_RUNTIME_CONFIG ||
-      path.join(process.env.PWD, '.runtimeconfig.json');
-    const parsed = require(configPath);
+      path.join(process.cwd(), '.runtimeconfig.json');
+    const contents = fs.readFileSync(configPath);
+    const parsed = JSON.parse(contents.toString('utf8'));
     delete parsed.firebase;
     config.singleton = parsed;
     return;


### PR DESCRIPTION
Fixes #877

Favors using `process.cwd` over `process.env.PWD` as the latter is POSIX only (I might need to go check some of my code in firebase-tools!). While I was at it, I fixed a probably useless but nasty vulnerability where a malformed .runtimeconfig.json file would allow arbitrary code execution.