### PR TITLE
Align DataSnapshot methods to @firebase/database DataSnapshot

### DIFF
--- a/spec/v1/providers/database.spec.ts
+++ b/spec/v1/providers/database.spec.ts
@@ -541,16 +541,51 @@ describe('Database Functions', () => {
         expect(subject.val()).to.equal(0);
         populate({ myKey: 0 });
         expect(subject.val()).to.deep.equal({ myKey: 0 });
-
-        // Null values are still reported as null.
-        populate({ myKey: null });
-        expect(subject.val()).to.deep.equal({ myKey: null });
       });
 
       // Regression test: .val() was returning array of nulls when there's a property called length (BUG#37683995)
       it('should return correct values when data has "length" property', () => {
         populate({ length: 3, foo: 'bar' });
         expect(subject.val()).to.deep.equal({ length: 3, foo: 'bar' });
+      });
+
+      it('should deal with null-values appropriately', () => {
+        populate(null);
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: null });
+        expect(subject.val()).to.be.null;
+      });
+
+      it('should deal with empty object values appropriately', () => {
+        populate({});
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: {} });
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: { child: null } });
+        expect(subject.val()).to.be.null;
+      });
+
+      it('should deal with empty array values appropriately', () => {
+        populate([]);
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: [] });
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: [null] });
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: [{}] });
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: [{ myKey: null }] });
+        expect(subject.val()).to.be.null;
+
+        populate({ myKey: [{ myKey: {} }] });
+        expect(subject.val()).to.be.null;
       });
     });
 
@@ -578,13 +613,36 @@ describe('Database Functions', () => {
       });
 
       it('should be false for a non-existent value', () => {
-        populate({ a: { b: 'c' } });
+        populate({ a: { b: 'c', nullChild: null } });
         expect(subject.child('d').exists()).to.be.false;
+        expect(subject.child('nullChild').exists()).to.be.false;
       });
 
       it('should be false for a value pathed beyond a leaf', () => {
         populate({ a: { b: 'c' } });
         expect(subject.child('a/b/c').exists()).to.be.false;
+      });
+
+      it('should be false for an empty object value', () => {
+        populate({ a: {} });
+        expect(subject.child('a').exists()).to.be.false;
+
+        populate({ a: { child: null } });
+        expect(subject.child('a').exists()).to.be.false;
+
+        populate({ a: { child: {} } });
+        expect(subject.child('a').exists()).to.be.false;
+      });
+
+      it('should be false for an empty array value', () => {
+        populate({ a: [] });
+        expect(subject.child('a').exists()).to.be.false;
+
+        populate({ a: [null] });
+        expect(subject.child('a').exists()).to.be.false;
+
+        populate({ a: [{}] });
+        expect(subject.child('a').exists()).to.be.false;
       });
     });
 
@@ -614,6 +672,17 @@ describe('Database Functions', () => {
 
         expect(subject.forEach(counter)).to.equal(false);
         expect(count).to.eq(0);
+
+        populate({
+          a: 'foo',
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
+        count = 0;
+
+        expect(subject.forEach(counter)).to.equal(false);
+        expect(count).to.eq(1);
       });
 
       it('should cancel further enumeration if callback returns true', () => {
@@ -653,13 +722,51 @@ describe('Database Functions', () => {
 
     describe('#numChildren()', () => {
       it('should be key count for objects', () => {
-        populate({ a: 'b', c: 'd' });
+        populate({
+          a: 'b',
+          c: 'd',
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
         expect(subject.numChildren()).to.eq(2);
       });
 
       it('should be 0 for non-objects', () => {
         populate(23);
         expect(subject.numChildren()).to.eq(0);
+
+        populate({
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
+        expect(subject.numChildren()).to.eq(0);
+      });
+    });
+
+    describe('#hasChildren()', () => {
+      it('should true for objects', () => {
+        populate({
+          a: 'b',
+          c: 'd',
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
+        expect(subject.hasChildren()).to.be.true;
+      });
+
+      it('should be false for non-objects', () => {
+        populate(23);
+        expect(subject.hasChildren()).to.be.false;
+
+        populate({
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
+        expect(subject.hasChildren()).to.be.false;
       });
     });
 
@@ -671,9 +778,17 @@ describe('Database Functions', () => {
       });
 
       it('should return false if a child is missing', () => {
-        populate({ a: 'b' });
+        populate({
+          a: 'b',
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
         expect(subject.hasChild('c')).to.be.false;
         expect(subject.hasChild('a/b')).to.be.false;
+        expect(subject.hasChild('nullChild')).to.be.false;
+        expect(subject.hasChild('emptyObjectChild')).to.be.false;
+        expect(subject.hasChild('emptyArrayChild')).to.be.false;
       });
     });
 
@@ -703,11 +818,21 @@ describe('Database Functions', () => {
 
     describe('#toJSON(): Object', () => {
       it('should return the current value', () => {
-        populate({ a: 'b' });
+        populate({
+          a: 'b',
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
         expect(subject.toJSON()).to.deep.equal(subject.val());
       });
       it('should be stringifyable', () => {
-        populate({ a: 'b' });
+        populate({
+          a: 'b',
+          nullChild: null,
+          emptyObjectChild: {},
+          emptyArrayChild: [],
+        });
         expect(JSON.stringify(subject)).to.deep.equal('{"a":"b"}');
       });
     });

--- a/src/v1/providers/database.ts
+++ b/src/v1/providers/database.ts
@@ -476,7 +476,7 @@ export class DataSnapshot {
       // Null value
       return false;
     }
-    if ((_.isObjectLike(val) || _.isArray(val)) && _.isEmpty(val)) {
+    if (_.isObjectLike(val) && _.isEmpty(val)) {
       // Empty object/array
       return false;
     }
@@ -521,7 +521,7 @@ export class DataSnapshot {
    */
   forEach(action: (a: DataSnapshot) => boolean | void): boolean {
     const val = this.val();
-    if (_.isObjectLike(val) || _.isArray(val)) {
+    if (_.isObjectLike(val)) {
       return _.some(
         val,
         (value, key: string) => action(this.child(key)) === true
@@ -555,7 +555,7 @@ export class DataSnapshot {
    */
   hasChildren(): boolean {
     const val = this.val();
-    return (_.isObjectLike(val) || _.isArray(val)) && !_.isEmpty(val);
+    return _.isObjectLike(val) && !_.isEmpty(val);
   }
 
   /**
@@ -565,7 +565,7 @@ export class DataSnapshot {
    */
   numChildren(): number {
     const val = this.val();
-    return _.isObjectLike(val) || _.isArray(val) ? _.keys(val).length : 0;
+    return _.isObjectLike(val) ? _.keys(val).length : 0;
   }
 
   /**


### PR DESCRIPTION
### Description

I've noticed[1] a difference between `DataSnapshot`s methods in this SDK compared to the [one used when fetching data](https://github.com/firebase/firebase-js-sdk/tree/master/packages/database) (when using the admin SDK).

When setting values that are (or contain) empty object/arrays and null values using the admin SDK, when fetching these values back, they're always `null` when calling `.val()`.
However when creating a `DataSnapshot` with these values and calling `.val()` the results don't match.
I'm only raising this as an issue because when the functions are being called, I'd expect the `DataSnapshot` provided to the function handler to match the `DataSnapshot` when fetched from the same location - currently this isn't the case.

### Code sample

Using the following data: `{ child: 'foo', nullChild: null, emptyChild: {}, emptyArray: [], child: { nullVal: null, key: 'bar' } }`

Setting and then getting this value using the admin SDK [2] results in `{ child1: 'foo', child2: { key: 'bar } }` when calling `.val()`, which is what you'd expect - all the empty/`null` nodes are dropped.

However using the `firebase-functions` `database.DataSnapshot` constructor the result includes these empty/`null` values `{ child: 'foo', nullChild: null, emptyChild: {}, emptyArray: {}, child: { nullVal: null, key: 'bar' } }` when calling `.val()`.

I think this is mostly due to the lack of [this](https://github.com/firebase/firebase-js-sdk/blob/8599d91416ae8ac5202742f11cee00666d3360ec/packages/database/src/core/snap/ChildrenNode.ts#L198-L200) check the `@firebase/database` does when calling `.val()`.

The discrepancies are mainly when using `.val()` but I've updated the other methods and their tests (`.exists()`, `.numChildren()`, `.hasChildren()`, etc.) for completeness... 

[1] noticed when using `firebase-functions-test` [`makeDataSnapshot`](https://github.com/firebase/firebase-functions-test/blob/5361ad3757529e8da0b5f0356657b3236fcadbe9/src/providers/database.ts#L29-L52) method (which calls this repos `database.DataSnapshot` constructor) for mocking parameters for testing a Firebase Function.

[2] By using:

```js
const firebase = require('firebase-admin')
firebase.initializeApp({ databaseURL: 'https://<databaseName>.firebaseio.com' })

const setAndGet = async val => {
   const ref = firebase.database().ref('node')
   
   await ref.set(val)
   return await ref.get()
}
```

