### PR TITLE
v2 Callable now takes a single parameter

### DIFF
--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -233,7 +233,7 @@ describe('onCall', () => {
         region: ['us-west1', 'us-central1'],
         minInstances: 3,
       },
-      (data, context) => 42
+      (request) => 42
     );
 
     expect(result.__trigger).to.deep.equal({
@@ -252,19 +252,19 @@ describe('onCall', () => {
   });
 
   it('has a .run method', () => {
-    const cf = https.onCall((d, c) => {
-      return { data: d, context: c };
+    const cf = https.onCall((request) => {
+      return request;
     });
 
-    const data = 'data';
-    const context: any = {
+    const request: any = {
+      data: 'data',
       instanceIdToken: 'token',
       auth: {
         uid: 'abc',
         token: 'token',
       },
     };
-    expect(cf.run(data, context)).to.deep.equal({ data, context });
+    expect(cf.run(request)).to.deep.equal(request);
   });
 
   it('should be an express handler', async () => {

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -194,7 +194,7 @@ describe('onCall', () => {
   });
 
   it('should return a minimal trigger with appropriate values', () => {
-    const result = https.onCall((data, context) => 42);
+    const result = https.onCall((request) => 42);
     expect(result.__trigger).to.deep.equal({
       apiVersion: 2,
       platform: 'gcfv2',
@@ -208,7 +208,7 @@ describe('onCall', () => {
   });
 
   it('should create a complex trigger with appropriate values', () => {
-    const result = https.onCall(FULL_OPTIONS, (data, context) => 42);
+    const result = https.onCall(FULL_OPTIONS, (request) => 42);
     expect(result.__trigger).to.deep.equal({
       ...FULL_TRIGGER,
       httpsTrigger: {
@@ -268,7 +268,7 @@ describe('onCall', () => {
   });
 
   it('should be an express handler', async () => {
-    const func = https.onCall((data, context) => 42);
+    const func = https.onCall((request) => 42);
 
     const req = new MockRequest(
       {
@@ -286,7 +286,7 @@ describe('onCall', () => {
   });
 
   it('should enforce CORS options', async () => {
-    const func = https.onCall({ cors: 'example.com' }, (req, res) => {
+    const func = https.onCall({ cors: 'example.com' }, (request) => {
       throw new Error('Should not reach here for OPTIONS preflight');
     });
 
@@ -314,7 +314,7 @@ describe('onCall', () => {
   });
 
   it('adds CORS headers', async () => {
-    const func = https.onCall((data, context) => 42);
+    const func = https.onCall((request) => 42);
     const req = new MockRequest(
       {
         data: {},

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -44,7 +44,9 @@ export type HttpsHandler = (
   request: Request,
   response: express.Response
 ) => void | Promise<void>;
-export type CallableHandler<T, Return> = (request: CallableRequest<T>) => Return;
+export type CallableHandler<T, Return> = (
+  request: CallableRequest<T>
+) => Return;
 
 export type HttpsFunction = HttpsHandler & { __trigger: unknown };
 export interface CallableFunction<T, Return> extends HttpsHandler {

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -28,7 +28,7 @@ import * as options from '../options';
 
 export type Request = common.Request;
 
-export type CallableContext = common.CallableContext;
+export type CallableRequest<T> = common.CallableRequest<T>;
 export type FunctionsErrorCode = common.FunctionsErrorCode;
 export type HttpsError = common.HttpsError;
 
@@ -44,15 +44,12 @@ export type HttpsHandler = (
   request: Request,
   response: express.Response
 ) => void | Promise<void>;
-export type CallableHandler<T, Ret> = (
-  data: T,
-  context: CallableContext
-) => Ret;
+export type CallableHandler<T, Return> = (request: CallableRequest<T>) => Return;
 
 export type HttpsFunction = HttpsHandler & { __trigger: unknown };
-export interface CallableFunction<T, Ret> extends HttpsHandler {
+export interface CallableFunction<T, Return> extends HttpsHandler {
   __trigger: unknown;
-  run(data: T, context: CallableContext): Ret;
+  run(data: CallableRequest<T>): Return;
 }
 
 export function onRequest(
@@ -110,21 +107,21 @@ export function onRequest(
   return handler as HttpsFunction;
 }
 
-export function onCall<T = unknown, Ret = any | Promise<any>>(
+export function onCall<T = any, Return = any | Promise<any>>(
   opts: HttpsOptions,
-  handler: CallableHandler<T, Ret>
-): CallableFunction<T, Ret>;
-export function onCall<T = unknown, Ret = any | Promise<any>>(
-  handler: CallableHandler<T, Ret>
-): CallableFunction<T, Ret>;
-export function onCall<T = unknown, Ret = any | Promise<any>>(
-  optsOrHandler: HttpsOptions | CallableHandler<T, Ret>,
-  handler?: CallableHandler<T, Ret>
-): CallableFunction<T, Ret> {
+  handler: CallableHandler<T, Return>
+): CallableFunction<T, Return>;
+export function onCall<T = any, Return = any | Promise<any>>(
+  handler: CallableHandler<T, Return>
+): CallableFunction<T, Return>;
+export function onCall<T = any, Return = any | Promise<any>>(
+  optsOrHandler: HttpsOptions | CallableHandler<T, Return>,
+  handler?: CallableHandler<T, Return>
+): CallableFunction<T, Return> {
   let opts: HttpsOptions;
   if (arguments.length == 1) {
     opts = {};
-    handler = optsOrHandler as CallableHandler<T, Ret>;
+    handler = optsOrHandler as CallableHandler<T, Return>;
   } else {
     opts = optsOrHandler as HttpsOptions;
   }


### PR DESCRIPTION
Per pending design review, `(data: T, CallableContext)` is now replaced with `(request: CallableRequest<T>)` where `CallableRequest<T>` is `CallableContext & { data: T}`