### PR TITLE
Improve typings in HTTPS and Pub/Sub functions.

### DIFF
--- a/spec/v2/params.spec.ts
+++ b/spec/v2/params.spec.ts
@@ -17,16 +17,16 @@ describe('params', () => {
     delete process.env[TEST_PARAM];
   });
 
-  const VALUE_TESTS: {
+  const VALUE_TESTS: Array<{
     method: (name: string, options: ParamOptions<any>) => Param;
-    tests: {
+    tests: Array<{
       title: string;
       env?: string;
       options?: ParamOptions;
       expect?: any;
       throws?: boolean;
-    }[];
-  }[] = [
+    }>;
+  }> = [
     {
       method: defineString,
       tests: [

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -334,11 +334,19 @@ describe('onCall', () => {
   });
 
   // These tests pass if the code transpiles
-  it("allows desirable syntax", () => {
-    https.onCall<string, string>((request: https.CallableRequest<string>) => `hello, ${request.data}!`);
-    https.onCall<string>((request: https.CallableRequest<string>) => `hello, ${request.data}!`);
-    https.onCall<string>((request: https.CallableRequest) => `hello, ${request.data}!`);
-    https.onCall((request: https.CallableRequest<string>) => `Hello, ${request.data}`);
+  it('allows desirable syntax', () => {
+    https.onCall<string, string>(
+      (request: https.CallableRequest<string>) => `hello, ${request.data}!`
+    );
+    https.onCall<string>(
+      (request: https.CallableRequest<string>) => `hello, ${request.data}!`
+    );
+    https.onCall<string>(
+      (request: https.CallableRequest) => `hello, ${request.data}!`
+    );
+    https.onCall(
+      (request: https.CallableRequest<string>) => `Hello, ${request.data}`
+    );
     https.onCall((request: https.CallableRequest) => `Hello, ${request.data}`);
   });
 });

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -332,4 +332,13 @@ describe('onCall', () => {
     expect(response.body).to.be.deep.equal({ result: 42 });
     expect(response.headers).to.deep.equal(expectedResponseHeaders);
   });
+
+  // These tests pass if the code transpiles
+  it("allows desirable syntax", () => {
+    https.onCall<string, string>((request: https.CallableRequest<string>) => `hello, ${request.data}!`);
+    https.onCall<string>((request: https.CallableRequest<string>) => `hello, ${request.data}!`);
+    https.onCall<string>((request: https.CallableRequest) => `hello, ${request.data}!`);
+    https.onCall((request: https.CallableRequest<string>) => `Hello, ${request.data}`);
+    https.onCall((request: https.CallableRequest) => `Hello, ${request.data}`);
+  });
 });

--- a/spec/v2/providers/pubsub.spec.ts
+++ b/spec/v2/providers/pubsub.spec.ts
@@ -111,4 +111,24 @@ describe('onMessagePublished', () => {
 
     expect(json).to.deep.equal({ hello: 'world' });
   });
+
+  // These tests pass if the transpiler works
+  it('allows desirable syntax', () => {
+    pubsub.onMessagePublished<string>(
+      'topic',
+      (event: CloudEvent<pubsub.MessagePublishedData<string>>) => {}
+    );
+    pubsub.onMessagePublished<string>(
+      'topic',
+      (event: CloudEvent<pubsub.MessagePublishedData>) => {}
+    );
+    pubsub.onMessagePublished(
+      'topic',
+      (event: CloudEvent<pubsub.MessagePublishedData<string>>) => {}
+    );
+    pubsub.onMessagePublished(
+      'topic',
+      (event: CloudEvent<pubsub.MessagePublishedData>) => {}
+    );
+  });
 });

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -138,7 +138,7 @@ export interface CallableContext {
 /**
  * The request used to call a callable function.
  */
-export interface CallableRequest<T> {
+export interface CallableRequest<T = any> {
   /**
    * The parameters used by a client when calling this function.
    */

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -21,9 +21,9 @@
 // SOFTWARE.
 
 import * as logger from '../logger';
+import * as params from './params';
 import * as https from './providers/https';
 import * as pubsub from './providers/pubsub';
-import * as params from './params';
 
 export { https, pubsub, logger, params };
 

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -24,11 +24,11 @@ import {
   durationFromSeconds,
   serviceAccountFromShorthand,
 } from '../common/encoding';
+import { convertIfPresent, copyIfPresent } from '../common/encoding';
 import * as logger from '../logger';
-import { copyIfPresent, convertIfPresent } from '../common/encoding';
-import { ParamSpec } from './params/types';
-import { declaredParams } from './params';
 import { TriggerAnnotation } from './core';
+import { declaredParams } from './params';
+import { ParamSpec } from './params/types';
 
 /**
  * List of all regions supported by Cloud Functions v2

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -28,7 +28,7 @@ import * as options from '../options';
 
 export type Request = common.Request;
 
-export type CallableRequest<T> = common.CallableRequest<T>;
+export type CallableRequest<T = any> = common.CallableRequest<T>;
 export type FunctionsErrorCode = common.FunctionsErrorCode;
 export type HttpsError = common.HttpsError;
 
@@ -40,33 +40,24 @@ export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   cors?: string | boolean;
 }
 
-export type HttpsHandler = (
-  request: Request,
-  response: express.Response
-) => void | Promise<void>;
-export type CallableHandler<T, Return> = (
-  request: CallableRequest<T>
-) => Return;
-
-export type HttpsFunction = HttpsHandler & { __trigger: unknown };
-export interface CallableFunction<T, Return> extends HttpsHandler {
-  __trigger: unknown;
+export type HttpsFunction = (req: Request, res: express.Response) => void | Promise<void> & { __trigger: unknown };
+export interface CallableFunction<T, Return> extends HttpsFunction {
   run(data: CallableRequest<T>): Return;
 }
 
 export function onRequest(
   opts: HttpsOptions,
-  handler: HttpsHandler
+  handler: (request: Request, response: express.Response) => void | Promise<void>
 ): HttpsFunction;
-export function onRequest(handler: HttpsHandler): HttpsFunction;
+export function onRequest(handler: (request: Request, response: express.Response) => void | Promise<void>): HttpsFunction;
 export function onRequest(
-  optsOrHandler: HttpsOptions | HttpsHandler,
-  handler?: HttpsHandler
+  optsOrHandler: HttpsOptions | ((request: Request, response: express.Response) => void | Promise<void>),
+  handler?: (request: Request, response: express.Response) => void | Promise<void>
 ): HttpsFunction {
   let opts: HttpsOptions;
   if (arguments.length === 1) {
     opts = {};
-    handler = optsOrHandler as HttpsHandler;
+    handler = optsOrHandler as (request: Request, response: express.Response) => void | Promise<void>;
   } else {
     opts = optsOrHandler as HttpsOptions;
   }
@@ -111,19 +102,19 @@ export function onRequest(
 
 export function onCall<T = any, Return = any | Promise<any>>(
   opts: HttpsOptions,
-  handler: CallableHandler<T, Return>
+  handler: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return>;
 export function onCall<T = any, Return = any | Promise<any>>(
-  handler: CallableHandler<T, Return>
+  handler: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return>;
 export function onCall<T = any, Return = any | Promise<any>>(
-  optsOrHandler: HttpsOptions | CallableHandler<T, Return>,
-  handler?: CallableHandler<T, Return>
+  optsOrHandler: HttpsOptions | ((request: CallableRequest<T>) => Return),
+  handler?: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return> {
   let opts: HttpsOptions;
   if (arguments.length == 1) {
     opts = {};
-    handler = optsOrHandler as CallableHandler<T, Return>;
+    handler = optsOrHandler as (request: CallableRequest<T>) => Return;
   } else {
     opts = optsOrHandler as HttpsOptions;
   }

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -40,24 +40,43 @@ export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   cors?: string | boolean;
 }
 
-export type HttpsFunction = (req: Request, res: express.Response) => void | Promise<void> & { __trigger: unknown };
+export type HttpsFunction = ((
+  req: Request,
+  res: express.Response
+) => void | Promise<void>) & { __trigger: unknown };
 export interface CallableFunction<T, Return> extends HttpsFunction {
   run(data: CallableRequest<T>): Return;
 }
 
 export function onRequest(
   opts: HttpsOptions,
-  handler: (request: Request, response: express.Response) => void | Promise<void>
+  handler: (
+    request: Request,
+    response: express.Response
+  ) => void | Promise<void>
 ): HttpsFunction;
-export function onRequest(handler: (request: Request, response: express.Response) => void | Promise<void>): HttpsFunction;
 export function onRequest(
-  optsOrHandler: HttpsOptions | ((request: Request, response: express.Response) => void | Promise<void>),
-  handler?: (request: Request, response: express.Response) => void | Promise<void>
+  handler: (
+    request: Request,
+    response: express.Response
+  ) => void | Promise<void>
+): HttpsFunction;
+export function onRequest(
+  optsOrHandler:
+    | HttpsOptions
+    | ((request: Request, response: express.Response) => void | Promise<void>),
+  handler?: (
+    request: Request,
+    response: express.Response
+  ) => void | Promise<void>
 ): HttpsFunction {
   let opts: HttpsOptions;
   if (arguments.length === 1) {
     opts = {};
-    handler = optsOrHandler as (request: Request, response: express.Response) => void | Promise<void>;
+    handler = optsOrHandler as (
+      request: Request,
+      response: express.Response
+    ) => void | Promise<void>;
   } else {
     opts = optsOrHandler as HttpsOptions;
   }

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -85,7 +85,7 @@ export class Message<T> {
 }
 
 /** The interface published in a Pub/Sub publish subscription. */
-export interface MessagePublishedData<T> {
+export interface MessagePublishedData<T = any> {
   readonly message: Message<T>;
   readonly subscription: string;
 }
@@ -96,18 +96,18 @@ export interface PubSubOptions extends options.EventHandlerOptions {
 }
 
 /** Handle a message being published to a Pub/Sub topic. */
-export function onMessagePublished<T = unknown>(
+export function onMessagePublished<T = any>(
   topic: string,
   handler: (event: CloudEvent<MessagePublishedData<T>>) => any | Promise<any>
 ): CloudFunction<MessagePublishedData<T>>;
 
 /** Handle a message being published to a Pub/Sub topic. */
-export function onMessagePublished<T = unknown>(
+export function onMessagePublished<T = any>(
   options: PubSubOptions,
   handler: (event: CloudEvent<MessagePublishedData<T>>) => any | Promise<any>
 ): CloudFunction<MessagePublishedData<T>>;
 
-export function onMessagePublished<T = unknown>(
+export function onMessagePublished<T = any>(
   topicOrOptions: string | PubSubOptions,
   handler: (event: CloudEvent<MessagePublishedData<T>>) => any | Promise<any>
 ): CloudFunction<MessagePublishedData<T>> {


### PR DESCRIPTION
1. Defaulted all generic arguments for functions and types to `any`
2. Inlined handler arguments in HTTPS functions to improve code complete