### PR TITLE
Set Access Control for HTTP Functions (v2)

### DIFF
--- a/spec/common/encoding.spec.ts
+++ b/spec/common/encoding.spec.ts
@@ -1,0 +1,36 @@
+import { expect } from 'chai';
+import { convertInvoker } from '../../src/common/encoding';
+
+describe('convertInvoker', () => {
+  it('should raise an error on mixing public and service accounts', () => {
+    expect(() => convertInvoker(['public', 'service-account@'])).to.throw;
+  });
+
+  it('should raise an error on mixing private and service accounts', () => {
+    expect(() => convertInvoker(['private', 'service-account@'])).to.throw;
+  });
+
+  it('should return the correct public invoker', () => {
+    const invoker = convertInvoker('public');
+
+    expect(invoker).to.deep.equal(['public']);
+  });
+
+  it('should return the correct private invoker', () => {
+    const invoker = convertInvoker('private');
+
+    expect(invoker).to.deep.equal(['private']);
+  });
+
+  it('should return the correct scalar invoker', () => {
+    const invoker = convertInvoker('service-account@');
+
+    expect(invoker).to.deep.equal(['service-account@']);
+  });
+
+  it('should return the correct array invoker', () => {
+    const invoker = convertInvoker(['service-account1@', 'service-account2@']);
+
+    expect(invoker).to.deep.equal(['service-account1@', 'service-account2@']);
+  });
+});

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -82,7 +82,6 @@ describe('onRequest', () => {
         allowInsecure: false,
       },
       labels: {},
-      invoker: 'public',
     });
   });
 
@@ -91,7 +90,7 @@ describe('onRequest', () => {
       {
         ...FULL_OPTIONS,
         region: ['us-west1', 'us-central1'],
-        invoker: ['service-account1', 'service-account2'],
+        invoker: ['service-account1@', 'service-account2@'],
       },
       (req, res) => {
         res.send(200);
@@ -103,7 +102,7 @@ describe('onRequest', () => {
         allowInsecure: false,
       },
       regions: ['us-west1', 'us-central1'],
-      invoker: ['service-account1', 'service-account2'],
+      invoker: ['service-account1@', 'service-account2@'],
     });
   });
 
@@ -112,6 +111,7 @@ describe('onRequest', () => {
       concurrency: 20,
       region: 'europe-west1',
       minInstances: 1,
+      invoker: 'public',
     });
 
     const result = https.onRequest(
@@ -135,7 +135,7 @@ describe('onRequest', () => {
       minInstances: 3,
       regions: ['us-west1', 'us-central1'],
       labels: {},
-      invoker: 'private',
+      invoker: ['private'],
     });
   });
 

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -82,6 +82,7 @@ describe('onRequest', () => {
         allowInsecure: false,
       },
       labels: {},
+      invoker: 'public',
     });
   });
 
@@ -90,6 +91,7 @@ describe('onRequest', () => {
       {
         ...FULL_OPTIONS,
         region: ['us-west1', 'us-central1'],
+        invoker: ['service-account1', 'service-account2'],
       },
       (req, res) => {
         res.send(200);
@@ -101,6 +103,7 @@ describe('onRequest', () => {
         allowInsecure: false,
       },
       regions: ['us-west1', 'us-central1'],
+      invoker: ['service-account1', 'service-account2'],
     });
   });
 
@@ -115,6 +118,7 @@ describe('onRequest', () => {
       {
         region: ['us-west1', 'us-central1'],
         minInstances: 3,
+        invoker: 'private',
       },
       (req, res) => {
         res.send(200);
@@ -131,6 +135,7 @@ describe('onRequest', () => {
       minInstances: 3,
       regions: ['us-west1', 'us-central1'],
       labels: {},
+      invoker: 'private',
     });
   });
 

--- a/src/common/encoding.ts
+++ b/src/common/encoding.ts
@@ -64,3 +64,20 @@ export function serviceAccountFromShorthand(
     );
   }
 }
+
+export function convertInvoker(invoker: string | string[]): string[] {
+  if (typeof invoker === 'string') {
+    invoker = [invoker];
+  }
+
+  if (
+    invoker.length > 1 &&
+    invoker.find((inv) => inv === 'public' || inv === 'private')
+  ) {
+    throw new Error(
+      "Invalid option for invoker. Cannot have 'public' or 'private' in an array of service accounts"
+    );
+  }
+
+  return invoker;
+}

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -37,6 +37,7 @@ import {
   Duration,
   durationFromSeconds,
   serviceAccountFromShorthand,
+  convertInvoker,
 } from '../common/encoding';
 
 /** @hidden */
@@ -279,7 +280,7 @@ export interface TriggerAnnotated {
     vpcConnectorEgressSettings?: string;
     serviceAccountEmail?: string;
     ingressSettings?: string;
-    invoker?: Invoker | Invoker[];
+    invoker?: Invoker[];
   };
 }
 
@@ -499,8 +500,7 @@ export function optionsToTrigger(options: DeploymentOptions) {
     'ingressSettings',
     'vpcConnectorEgressSettings',
     'vpcConnector',
-    'labels',
-    'invoker'
+    'labels'
   );
   convertIfPresent(
     trigger,
@@ -543,6 +543,7 @@ export function optionsToTrigger(options: DeploymentOptions) {
     'serviceAccount',
     serviceAccountFromShorthand
   );
+  convertIfPresent(trigger, options, 'invoker', 'invoker', convertInvoker);
 
   return trigger;
 }

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -27,7 +27,6 @@ import {
   DEFAULT_FAILURE_POLICY,
   DeploymentOptions,
   FailurePolicy,
-  Invoker,
   Schedule,
 } from './function-configuration';
 export { Request, Response };
@@ -280,7 +279,7 @@ export interface TriggerAnnotated {
     vpcConnectorEgressSettings?: string;
     serviceAccountEmail?: string;
     ingressSettings?: string;
-    invoker?: Invoker[];
+    invoker?: string[];
   };
 }
 

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -98,11 +98,6 @@ export const DEFAULT_FAILURE_POLICY: FailurePolicy = {
 
 export const MAX_NUMBER_USER_LABELS = 58;
 
-/**
- * Invoker access control type for https functions.
- */
-export type Invoker = 'public' | 'private' | string;
-
 export interface RuntimeOptions {
   /**
    * Which platform should host the backend. Valid options are "gcfv1"
@@ -165,7 +160,7 @@ export interface RuntimeOptions {
   /**
    * Invoker to set access control on https functions.
    */
-  invoker?: Invoker | Invoker[];
+  invoker?: 'public' | 'private' | string | string[];
 }
 
 export interface DeploymentOptions extends RuntimeOptions {

--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -40,7 +40,7 @@ export interface TriggerAnnotation {
   vpcConnectorEgressSettings?: string;
   serviceAccountEmail?: string;
   ingressSettings?: string;
-  invoker?: string | string[];
+  invoker?: string[];
 
   // TODO: schedule
 }

--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -40,6 +40,7 @@ export interface TriggerAnnotation {
   vpcConnectorEgressSettings?: string;
   serviceAccountEmail?: string;
   ingressSettings?: string;
+  invoker?: string | string[];
 
   // TODO: schedule
 }

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -112,11 +112,6 @@ export const SUPPORTED_INGRESS_SETTINGS = [
 export type IngressSetting = typeof SUPPORTED_INGRESS_SETTINGS[number];
 
 /**
- * Invoker access control type for https functions.
- */
-export type Invoker = 'public' | 'private' | string;
-
-/**
  * GlobalOptions are options that can be set across an entire project.
  * These options are common to HTTPS and Event handling functions.
  */
@@ -192,7 +187,7 @@ export interface GlobalOptions {
   /**
    * Invoker to set access control on https functions.
    */
-  invoker?: Invoker | Invoker[];
+  invoker?: 'public' | 'private' | string | string[];
 }
 
 let globalOptions: GlobalOptions | undefined;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -23,6 +23,7 @@
 import {
   durationFromSeconds,
   serviceAccountFromShorthand,
+  convertInvoker,
 } from '../common/encoding';
 import { convertIfPresent, copyIfPresent } from '../common/encoding';
 import * as logger from '../logger';
@@ -111,6 +112,11 @@ export const SUPPORTED_INGRESS_SETTINGS = [
 export type IngressSetting = typeof SUPPORTED_INGRESS_SETTINGS[number];
 
 /**
+ * Invoker access control type for https functions.
+ */
+export type Invoker = 'public' | 'private' | string;
+
+/**
  * GlobalOptions are options that can be set across an entire project.
  * These options are common to HTTPS and Event handling functions.
  */
@@ -182,6 +188,11 @@ export interface GlobalOptions {
    * User labels to set on the function.
    */
   labels?: Record<string, string>;
+
+  /**
+   * Invoker to set access control on https functions.
+   */
+  invoker?: Invoker | Invoker[];
 }
 
 let globalOptions: GlobalOptions | undefined;
@@ -270,6 +281,7 @@ export function optionsToTriggerAnnotations(
       return retry ? { retry: true } : null;
     }
   );
+  convertIfPresent(annotation, opts, 'invoker', 'invoker', convertInvoker);
 
   return annotation;
 }

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -32,18 +32,12 @@ export type CallableRequest<T = any> = common.CallableRequest<T>;
 export type FunctionsErrorCode = common.FunctionsErrorCode;
 export type HttpsError = common.HttpsError;
 
-/**
- * Invoker access control type for https functions.
- */
-export type Invoker = 'public' | 'private' | string;
-
 export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   region?:
     | options.SupportedRegion
     | string
     | Array<options.SupportedRegion | string>;
   cors?: string | boolean;
-  invoker?: Invoker | Invoker[];
 }
 
 export type HttpsFunction = ((
@@ -87,7 +81,6 @@ export function onRequest(
     opts = optsOrHandler as HttpsOptions;
   }
 
-  const invoker = 'invoker' in opts ? opts.invoker : 'public';
   if ('cors' in opts) {
     const userProvidedHandler = handler;
     handler = (req: Request, res: express.Response) => {
@@ -120,7 +113,6 @@ export function onRequest(
         httpsTrigger: {
           allowInsecure: false,
         },
-        invoker,
       };
     },
   });

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -35,7 +35,7 @@ export type HttpsError = common.HttpsError;
 /**
  * Invoker access control type for https functions.
  */
- export type Invoker = 'public' | 'private' | string;
+export type Invoker = 'public' | 'private' | string;
 
 export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   region?:

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -32,12 +32,18 @@ export type CallableRequest<T = any> = common.CallableRequest<T>;
 export type FunctionsErrorCode = common.FunctionsErrorCode;
 export type HttpsError = common.HttpsError;
 
+/**
+ * Invoker access control type for https functions.
+ */
+ export type Invoker = 'public' | 'private' | string;
+
 export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   region?:
     | options.SupportedRegion
     | string
     | Array<options.SupportedRegion | string>;
   cors?: string | boolean;
+  invoker?: Invoker | Invoker[];
 }
 
 export type HttpsFunction = ((
@@ -81,6 +87,7 @@ export function onRequest(
     opts = optsOrHandler as HttpsOptions;
   }
 
+  const invoker = 'invoker' in opts ? opts.invoker : 'public';
   if ('cors' in opts) {
     const userProvidedHandler = handler;
     handler = (req: Request, res: express.Response) => {
@@ -113,6 +120,7 @@ export function onRequest(
         httpsTrigger: {
           allowInsecure: false,
         },
+        invoker,
       };
     },
   });


### PR DESCRIPTION
### Description

Creating a way for customers to explicitly set the access control on v2 HTTP functions. The access control is set at the function level, so different functions can have different access policies. The customer can choose to set access control to `public`, `private`, or a custom service account. Access control is set in the `onRequest({})` options object, by setting the invoker property. To handle multiple service accounts, invoker can accept an array of strings.

### Code sample

`export const myFunction = v2.https.onRequest({ invoker: 'private' }, (req, res) => { res.send("Done"); });`
