### PR TITLE
Use npm ci on publish scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   "scripts": {
     "apidocs": "node docgen/generate-docs.js",
     "build:pack": "rm -rf lib && npm install && tsc -p tsconfig.release.json && npm pack",
-    "build:release": "npm install --production && npm install --no-save typescript firebase-admin && tsc -p tsconfig.release.json",
+    "build:release": "npm ci --production && npm install --no-save typescript firebase-admin && tsc -p tsconfig.release.json",
     "build": "tsc -p tsconfig.release.json",
     "build:watch": "npm run build -- -w",
     "format": "prettier --check '**/*.{json,md,ts,yml,yaml}'",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -74,9 +74,9 @@ if [ ! -s CHANGELOG.md ]; then
 fi
 echo "Made sure there is a changelog."
 
-echo "Running npm install..."
-npm install
-echo "Ran npm install."
+echo "Running npm ci..."
+npm ci
+echo "Ran npm ci."
 
 echo "Running tests..."
 npm test


### PR DESCRIPTION
I kept seeing error on the `npm version` command claiming that the directory was dirty.

I believe this is because version of the `npm` used in our builder image is >v7 which uses lockfileversion 2 instead of 1. I'm suggesting that we use `npm ci` instead, but we should also think about updating the package-lock.json to lockfileversion 2.
