### PR TITLE
Fix "functions.https.HttpsError is not a constructor"

### DIFF
--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -23,10 +23,16 @@
 import * as express from 'express';
 
 import { HttpsFunction, optionsToTrigger, Runnable } from '../cloud-functions';
-import { Request, CallableContext, FunctionsErrorCode, HttpsError, onCallHandler } from '../common/providers/https';
+import {
+  CallableContext,
+  FunctionsErrorCode,
+  HttpsError,
+  onCallHandler,
+  Request,
+} from '../common/providers/https';
 import { DeploymentOptions } from '../function-configuration';
 
-export { Request, CallableContext, FunctionsErrorCode, HttpsError }
+export { Request, CallableContext, FunctionsErrorCode, HttpsError };
 
 /**
  * Handle HTTP requests.
@@ -71,10 +77,7 @@ export function _onCallWithOptions(
   handler: (data: any, context: CallableContext) => any | Promise<any>,
   options: DeploymentOptions
 ): HttpsFunction & Runnable<any> {
-  const func: any = onCallHandler(
-    { origin: true, methods: 'POST' },
-    handler
-  );
+  const func: any = onCallHandler({ origin: true, methods: 'POST' }, handler);
 
   func.__trigger = {
     labels: {},

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -23,13 +23,10 @@
 import * as express from 'express';
 
 import { HttpsFunction, optionsToTrigger, Runnable } from '../cloud-functions';
-import * as common from '../common/providers/https';
+import { Request, CallableContext, FunctionsErrorCode, HttpsError, onCallHandler } from '../common/providers/https';
 import { DeploymentOptions } from '../function-configuration';
 
-export type Request = common.Request;
-export type CallableContext = common.CallableContext;
-export type FunctionsErrorCode = common.FunctionsErrorCode;
-export type HttpsError = common.HttpsError;
+export { Request, CallableContext, FunctionsErrorCode, HttpsError }
 
 /**
  * Handle HTTP requests.
@@ -74,7 +71,7 @@ export function _onCallWithOptions(
   handler: (data: any, context: CallableContext) => any | Promise<any>,
   options: DeploymentOptions
 ): HttpsFunction & Runnable<any> {
-  const func: any = common.onCallHandler(
+  const func: any = onCallHandler(
     { origin: true, methods: 'POST' },
     handler
   );

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -23,14 +23,10 @@
 import * as cors from 'cors';
 import * as express from 'express';
 
-import * as common from '../../common/providers/https';
+import { Request, CallableRequest, FunctionsErrorCode, HttpsError, onCallHandler } from '../../common/providers/https';
 import * as options from '../options';
 
-export type Request = common.Request;
-
-export type CallableRequest<T = any> = common.CallableRequest<T>;
-export type FunctionsErrorCode = common.FunctionsErrorCode;
-export type HttpsError = common.HttpsError;
+export { Request, CallableRequest, FunctionsErrorCode, HttpsError }
 
 export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   region?:
@@ -142,7 +138,7 @@ export function onCall<T = any, Return = any | Promise<any>>(
   }
 
   const origin = 'cors' in opts ? opts.cors : true;
-  const func: any = common.onCallHandler({ origin, methods: 'POST' }, handler);
+  const func: any = onCallHandler({ origin, methods: 'POST' }, handler);
 
   Object.defineProperty(func, '__trigger', {
     get: () => {

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -23,10 +23,16 @@
 import * as cors from 'cors';
 import * as express from 'express';
 
-import { Request, CallableRequest, FunctionsErrorCode, HttpsError, onCallHandler } from '../../common/providers/https';
+import {
+  CallableRequest,
+  FunctionsErrorCode,
+  HttpsError,
+  onCallHandler,
+  Request,
+} from '../../common/providers/https';
 import * as options from '../options';
 
-export { Request, CallableRequest, FunctionsErrorCode, HttpsError }
+export { Request, CallableRequest, FunctionsErrorCode, HttpsError };
 
 export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   region?:


### PR DESCRIPTION
It turns out that type aliases in TypeScript don't copy constructors.
Replacing "export type Foo = common.Foo" with "import { Foo } from
common; export { Foo }" is lossless and fixes the bug.
