### PR TITLE
Fix bug where v1 HTTP used v2 API if callback had len 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where the <data> arg of https onCall functions sometimes deviates from the documented format.

--- a/spec/v1/providers/https.spec.ts
+++ b/spec/v1/providers/https.spec.ts
@@ -179,20 +179,23 @@ describe('#onCall', () => {
   // Regression test for firebase-functions#947
   it('should lock to the v1 API even with function.length == 1', async () => {
     let gotData: Record<string, any>;
-    const func = https.onCall(data => {
+    const func = https.onCall((data) => {
       gotData = data;
     });
 
-    const req = new MockRequest({
-      data: {"foo": "bar"},
-    }, {
-      "content-type": "application/json",
-    });
-    req.method = "POST";
+    const req = new MockRequest(
+      {
+        data: { foo: 'bar' },
+      },
+      {
+        'content-type': 'application/json',
+      }
+    );
+    req.method = 'POST';
 
     const response = await runHandler(func, req as any);
     expect(response.status).to.equal(200);
-    expect(gotData).to.deep.equal({"foo": "bar"});
+    expect(gotData).to.deep.equal({ foo: 'bar' });
   });
 });
 

--- a/spec/v1/providers/https.spec.ts
+++ b/spec/v1/providers/https.spec.ts
@@ -175,6 +175,25 @@ describe('#onCall', () => {
     };
     expect(cf.run(data, context)).to.deep.equal({ data, context });
   });
+
+  // Regression test for firebase-functions#947
+  it('should lock to the v1 API even with function.length == 1', async () => {
+    let gotData: Record<string, any>;
+    const func = https.onCall(data => {
+      gotData = data;
+    });
+
+    const req = new MockRequest({
+      data: {"foo": "bar"},
+    }, {
+      "content-type": "application/json",
+    });
+    req.method = "POST";
+
+    const response = await runHandler(func, req as any);
+    expect(response.status).to.equal(200);
+    expect(gotData).to.deep.equal({"foo": "bar"});
+  });
 });
 
 describe('callable CORS', () => {

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -80,7 +80,8 @@ export function _onCallWithOptions(
   // onCallHandler sniffs the function length of the passed-in callback
   // and the user could have only tried to listen to data. Wrap their handler
   // in another handler to avoid accidentally triggering the v2 API
-  const fixedLen = (data: any, context: CallableContext) => handler(data, context);
+  const fixedLen = (data: any, context: CallableContext) =>
+    handler(data, context);
   const func: any = onCallHandler({ origin: true, methods: 'POST' }, fixedLen);
 
   func.__trigger = {

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -77,7 +77,11 @@ export function _onCallWithOptions(
   handler: (data: any, context: CallableContext) => any | Promise<any>,
   options: DeploymentOptions
 ): HttpsFunction & Runnable<any> {
-  const func: any = onCallHandler({ origin: true, methods: 'POST' }, handler);
+  // onCallHandler sniffs the function length of the passed-in callback
+  // and the user could have only tried to listen to data. Wrap their handler
+  // in another handler to avoid accidentally triggering the v2 API
+  const fixedLen = (data: any, context: CallableContext) => handler(data, context);
+  const func: any = onCallHandler({ origin: true, methods: 'POST' }, fixedLen);
 
   func.__trigger = {
     labels: {},

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -144,7 +144,11 @@ export function onCall<T = any, Return = any | Promise<any>>(
   }
 
   const origin = 'cors' in opts ? opts.cors : true;
-  const func: any = onCallHandler({ origin, methods: 'POST' }, handler);
+
+  // onCallHandler sniffs the function length to determine which API to present.
+  // fix the length to prevent api versions from being mismatched.
+  const fixedLen = (req: CallableRequest<T>) => handler(req);
+  const func: any = onCallHandler({ origin, methods: 'POST' }, fixedLen);
 
   Object.defineProperty(func, '__trigger', {
     get: () => {


### PR DESCRIPTION
The Callable API is complex enough that we share code between the v1 and v2 SDKs. The shared code sniffed the callback length to determine which API to surface, but this is a mistake because the callback is customer controlled and they may drop parameters they don't care about. By wrapping the customer-provided handler with a known-sized handler we can fix the sniffing behavior.

Fixes #947 