### PR TITLE
fix: rawBody is optional type in funcs framework

### DIFF
--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -32,7 +32,7 @@ import { apps } from '../../apps';
 
 /** @hidden */
 export interface Request extends express.Request {
-  rawBody: Buffer;
+  rawBody?: Buffer;
 }
 
 /**


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

Working on the [Firebase Adapter](https://github.com/jthegedus/svelte-adapter-firebase) for [SvelteKit](kit.svelte.dev) I discovered the type here is different from that in the Functions Framework which I believe is an upstream of this?

https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/e76b9f6c49bcf8c12d8206212cae84cfb931a077/src/invoker.ts#L44

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
