### PR TITLE
Added missing export: 'lib/function-configuration'

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "./lib/logger": "./lib/logger/index.js",
     "./lib/providers/auth": "./lib/providers/auth.js",
     "./lib/providers/analytics": "./lib/providers/analytics.js",
+    "./lib/function-configuration": "./lib/function-configuration.js",
     "./lib/providers/database": "./lib/providers/database.js",
     "./lib/providers/firestore": "./lib/providers/firestore.js",
     "./lib/providers/https": "./lib/providers/https.js",


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

When I upgraded from `firebase-functions@3.14.1` to `3.15.4`, I could no longer deploy function with this command:

```sh
$ firebase deploy --only functions:myFunction
```

The errors are:

```
i  deploying functions
i  functions: ensuring required API cloudfunctions.googleapis.com is enabled...
i  functions: ensuring required API cloudbuild.googleapis.com is enabled...
v  functions: required API cloudbuild.googleapis.com is enabled
v  functions: required API cloudfunctions.googleapis.com is enabled

Error: Error occurred while parsing your function triggers.

Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './lib/function-configuration' is not defined by "exports" in /home/ben/repos/my-project/src/functions/node_modules/firebase-functions/package.json

    at throwExportsNotFound (internal/modules/esm/resolve.js:299:9)
    at packageExportsResolve (internal/modules/esm/resolve.js:522:3)
    ...
```

### Code sample

N/A