### PR TITLE
Allow users to specify options for callable functions.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -496,9 +496,9 @@
       "optional": true
     },
     "@types/body-parser": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
-      "integrity": "sha512-W98JrE0j2K78swW4ukqMleo8R7h/pFETjM2DQ90MF6XK2i4LO4W3gQ71Lt4w3bfm2EvVSyWHplECvB5sK22yFQ==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.1.tgz",
+      "integrity": "sha512-a6bTJ21vFOGIkwM0kzh9Yr89ziVxq4vYH2fQ6N8AeipEzai/cFK6aGMArIkUeIdRIgpwQa+2bXiLuUJCpSf2Cg==",
       "requires": {
         "@types/connect": "*",
         "@types/node": "*"
@@ -526,9 +526,9 @@
       "dev": true
     },
     "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.35",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz",
+      "integrity": "sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==",
       "requires": {
         "@types/node": "*"
       }
@@ -542,12 +542,13 @@
       }
     },
     "@types/express": {
-      "version": "4.17.3",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.3.tgz",
-      "integrity": "sha512-I8cGRJj3pyOLs/HndoP+25vOqhqWkAZsWMEmq1qXy/b/M3ppufecUwaK2/TVDVxcV61/iSdhykUjQQ2DLSrTdg==",
+      "version": "4.17.13",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz",
+      "integrity": "sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==",
       "requires": {
         "@types/body-parser": "*",
-        "@types/express-serve-static-core": "*",
+        "@types/express-serve-static-core": "^4.17.18",
+        "@types/qs": "*",
         "@types/serve-static": "*"
       }
     },
@@ -562,9 +563,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.12",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
-      "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -603,9 +604,9 @@
       "optional": true
     },
     "@types/mime": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz",
-      "integrity": "sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q=="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz",
+      "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -637,22 +638,22 @@
       "integrity": "sha512-g+nSkeHFDd2WOQChfmy9SAXLywT47WZBrGS/NC5ym5PJ8c8RC6l4pbGaUW/X0+eZJnXw6/AVNEouXWhV4iz72Q=="
     },
     "@types/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw=="
     },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha1-fuMwunyq+5gJC+zoal7kQRWQTCw="
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw=="
     },
     "@types/serve-static": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-      "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+      "version": "1.13.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz",
+      "integrity": "sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==",
       "requires": {
-        "@types/express-serve-static-core": "*",
-        "@types/mime": "*"
+        "@types/mime": "^1",
+        "@types/node": "*"
       }
     },
     "@types/sinon": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -537,7 +537,6 @@
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.5.tgz",
       "integrity": "sha512-GmK8AKu8i+s+EChK/uZ5IbrXPcPaQKWaNSGevDT/7o3gFObwSUQwqb1jMqxuo+YPvj0ckGzINI+EO7EHcmJjKg==",
-      "dev": true,
       "requires": {
         "@types/express": "*"
       }

--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
   },
   "dependencies": {
     "@types/cors": "^2.8.5",
-    "@types/express": "4.17.3",
+    "@types/express": "^4.17.13",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "lodash": "^4.17.14"

--- a/spec/common/providers/https.spec.ts
+++ b/spec/common/providers/https.spec.ts
@@ -104,7 +104,7 @@ function runHandler(
 
 // Runs a CallTest test.
 async function runTest(test: CallTest): Promise<any> {
-  const opts = { cors: { origin: true, methods: 'POST' }};
+  const opts = { cors: { origin: true, methods: 'POST' } };
   const callableFunctionV1 = https.onCallHandler(opts, (data, context) => {
     expect(data).to.deep.equal(test.expectedData);
     return test.callableFunction(data, context);

--- a/spec/common/providers/https.spec.ts
+++ b/spec/common/providers/https.spec.ts
@@ -104,7 +104,7 @@ function runHandler(
 
 // Runs a CallTest test.
 async function runTest(test: CallTest): Promise<any> {
-  const opts = { origin: true, methods: 'POST' };
+  const opts = { cors: { origin: true, methods: 'POST' }};
   const callableFunctionV1 = https.onCallHandler(opts, (data, context) => {
     expect(data).to.deep.equal(test.expectedData);
     return test.callableFunction(data, context);

--- a/spec/v1/providers/https.spec.ts
+++ b/spec/v1/providers/https.spec.ts
@@ -260,19 +260,22 @@ describe('callable CORS', () => {
   });
 
   it('handles OPTIONS preflight with CORS options', async () => {
-    const func = https.onCall({ cors: ['example1.com', 'example2.com'] }, (data, context) => {
-      throw new Error(
+    const func = https.onCall(
+      { cors: ['example1.com', 'example2.com'] },
+      (data, context) => {
+        throw new Error(
           `This shouldn't have gotten called for an OPTIONS preflight.`
-      );
-    });
+        );
+      }
+    );
 
     const req = new MockRequest(
-        {},
-        {
-          'Access-Control-Request-Method': 'POST',
-          'Access-Control-Request-Headers': 'origin',
-          Origin: 'example.com',
-        }
+      {},
+      {
+        'Access-Control-Request-Method': 'POST',
+        'Access-Control-Request-Headers': 'origin',
+        Origin: 'example.com',
+      }
     );
     req.method = 'OPTIONS';
 
@@ -311,13 +314,13 @@ describe('callable CORS', () => {
   it('adds CORS headers with CORS options', async () => {
     const func = https.onCall({ cors: 'example.com' }, (data, context) => 42);
     const req = new MockRequest(
-        {
-          data: {},
-        },
-        {
-          'content-type': 'application/json',
-          origin: 'example1.com',
-        }
+      {
+        data: {},
+      },
+      {
+        'content-type': 'application/json',
+        origin: 'example1.com',
+      }
     );
     req.method = 'POST';
 

--- a/spec/v1/providers/https.spec.ts
+++ b/spec/v1/providers/https.spec.ts
@@ -230,7 +230,7 @@ describe('callable CORS', () => {
     });
   });
 
-  it('handles OPTIONS preflight with CORS options', async () => {
+  it('handles OPTIONS preflight with CORS options w/ single origin', async () => {
     const func = https.onCall({ cors: 'example1.com' }, (data, context) => {
       throw new Error(
         `This shouldn't have gotten called for an OPTIONS preflight.`
@@ -259,7 +259,7 @@ describe('callable CORS', () => {
     });
   });
 
-  it('handles OPTIONS preflight with CORS options', async () => {
+  it('handles OPTIONS preflight with CORS options w/ multiple origins', async () => {
     const func = https.onCall(
       { cors: ['example1.com', 'example2.com'] },
       (data, context) => {
@@ -285,7 +285,7 @@ describe('callable CORS', () => {
     expect(response.body).to.be.undefined;
     expect(response.headers).to.deep.equal({
       'Access-Control-Allow-Methods': 'POST',
-      // Missing 'Access-Control-Allow-Origin' b/c example.com is not part of configured origin.
+      // Missing 'Access-Control-Allow-Origin' b/c example.com is not in configured origins.
       'Content-Length': '0',
       Vary: 'Origin, Access-Control-Request-Headers',
     });

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -594,7 +594,7 @@ type v2Handler<Req, Res> = (request: CallableRequest<Req>) => Res;
 
 interface CallableOptions {
   cors: cors.CorsOptions;
-  allowInvalidAppCheckToken?: boolean,
+  allowInvalidAppCheckToken?: boolean;
 }
 
 /** @hidden */

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -23,7 +23,12 @@
 import * as express from 'express';
 import * as _ from 'lodash';
 
-import { CloudFunction, EventContext, HttpsFunction, Runnable } from './cloud-functions';
+import {
+  CloudFunction,
+  EventContext,
+  HttpsFunction,
+  Runnable,
+} from './cloud-functions';
 import {
   DeploymentOptions,
   INGRESS_SETTINGS_OPTIONS,
@@ -44,7 +49,6 @@ import * as pubsub from './providers/pubsub';
 import * as remoteConfig from './providers/remoteConfig';
 import * as storage from './providers/storage';
 import * as testLab from './providers/testLab';
-
 
 /**
  * Assert that the runtime options passed in are valid.

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -306,7 +306,7 @@ function _onCall<T = any, Return = any | Promise<any>>(
   } else {
     opts = optsOrHandler as CallableV1Options;
   }
-  return https._onCallWithOptions(opts, handler, {});
+  return https._onCallWithOptions(opts, handler, this.options);
 }
 
 export class FunctionBuilder {
@@ -375,7 +375,7 @@ export class FunctionBuilder {
        * @param opts Configuration options for a callable function.
        * @param handler A method that takes a data and context and returns a value.
        */
-      onCall: _onCall,
+      onCall: _onCall.bind(this),
     };
   }
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -34,6 +34,7 @@ import {
   VALID_MEMORY_OPTIONS,
   VPC_EGRESS_SETTINGS_OPTIONS,
 } from './function-configuration';
+import { CallableContext, CallableV1Options } from './providers/https';
 import * as analytics from './providers/analytics';
 import * as auth from './providers/auth';
 import * as database from './providers/database';
@@ -44,7 +45,6 @@ import * as remoteConfig from './providers/remoteConfig';
 import * as storage from './providers/storage';
 import * as testLab from './providers/testLab';
 
-import type { CallableContext, CallableV1Options } from './providers/https';
 
 /**
  * Assert that the runtime options passed in are valid.

--- a/src/handler-builder.ts
+++ b/src/handler-builder.ts
@@ -78,7 +78,7 @@ export class HandlerBuilder {
           context: https.CallableContext
         ) => any | Promise<any>
       ): HttpsFunction => {
-        const func = https._onCallWithOptions(handler, {});
+        const func = https._onCallWithOptions({}, handler, {});
         func.__trigger = {};
         return func;
       },

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -43,6 +43,10 @@ export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   cors?: string | boolean | RegExp | Array<string | RegExp>;
 }
 
+export interface CallableV2Options extends HttpsOptions {
+  allowInvalidAppCheckToken?: boolean;
+}
+
 export type HttpsFunction = ((
   req: Request,
   res: express.Response
@@ -134,22 +138,22 @@ export function onRequest(
 }
 
 export function onCall<T = any, Return = any | Promise<any>>(
-  opts: HttpsOptions,
+  opts: CallableV2Options,
   handler: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return>;
 export function onCall<T = any, Return = any | Promise<any>>(
   handler: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return>;
 export function onCall<T = any, Return = any | Promise<any>>(
-  optsOrHandler: HttpsOptions | ((request: CallableRequest<T>) => Return),
+  optsOrHandler: CallableV2Options | ((request: CallableRequest<T>) => Return),
   handler?: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return> {
-  let opts: HttpsOptions;
+  let opts: CallableV2Options;
   if (arguments.length == 1) {
     opts = {};
     handler = optsOrHandler as (request: CallableRequest<T>) => Return;
   } else {
-    opts = optsOrHandler as HttpsOptions;
+    opts = optsOrHandler as CallableV2Options;
   }
 
   const origin = 'cors' in opts ? opts.cors : true;
@@ -157,7 +161,10 @@ export function onCall<T = any, Return = any | Promise<any>>(
   // onCallHandler sniffs the function length to determine which API to present.
   // fix the length to prevent api versions from being mismatched.
   const fixedLen = (req: CallableRequest<T>) => handler(req);
-  const func: any = onCallHandler({ origin, methods: 'POST' }, fixedLen);
+  const func: any = onCallHandler(
+    { ...opts, cors: { origin, methods: 'POST' } },
+    fixedLen
+  );
 
   Object.defineProperty(func, '__trigger', {
     get: () => {


### PR DESCRIPTION
We extend `functions.https.onCall` function builder to accept an (optional) options object that expose users more control over callable function's behaviors.

2 options are exposed:

1. `cors`: Allows users to control `Access-Control-Allow-Origin` to override default behavior (`cors: { origin: true }`).
2. `allowInvalidAppCheckToken`: Allows users to control behavior of callable function when given invalid App Check tokens. By default, requests with invalid App Check tokens are rejected prior to executing user code.

e.g.

```js
import * as functions from "firebase-functions";

export const helloWorld = functions
    .https
    .onCall({allowInvalidAppCheckToken: true}, (data, context) => {
      // context.app will be undefined if the request doesn't include a valid
      // App Check token.
      if (context.app == undefined) {
        throw new functions.https.HttpsError(
            "failed-precondition",
            "The function must be called from an App Check verified app.");
      }
      return `Hello ${data.name}`;
    });
```
