### PR TITLE
Add an option to disable rejection of requests with invalid App Check token for callable functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - GCS Enhancement
+- Add option to allow callable functions to ignore invalid App Check tokens.

--- a/spec/common/providers/https.spec.ts
+++ b/spec/common/providers/https.spec.ts
@@ -40,6 +40,8 @@ interface CallTest {
 
   callableFunction2: (request: https.CallableRequest<any>) => any;
 
+  callableOption?: https.CallableOptions;
+
   // The expected shape of the http response returned to the callable SDK.
   expectedHttpResponse: RunHandlerResult;
 }
@@ -104,7 +106,10 @@ function runHandler(
 
 // Runs a CallTest test.
 async function runTest(test: CallTest): Promise<any> {
-  const opts = { origin: true, methods: 'POST' };
+  const opts = {
+    cors: { origin: true, methods: 'POST' },
+    ...test.callableOption,
+  };
   const callableFunctionV1 = https.onCallHandler(opts, (data, context) => {
     expect(data).to.deep.equal(test.expectedData);
     return test.callableFunction(data, context);
@@ -466,6 +471,30 @@ describe('onCallHandler', () => {
             message: 'Unauthenticated',
           },
         },
+      },
+    });
+  });
+
+  it('should handle bad AppCheck token with callable option', async () => {
+    await runTest({
+      httpRequest: mockRequest(null, 'application/json', {
+        appCheckToken: 'FAKE',
+      }),
+      expectedData: null,
+      callableFunction: (data, context) => {
+        return;
+      },
+      callableFunction2: (request) => {
+        return;
+      },
+      callableOption: {
+        cors: { origin: true, methods: 'POST' },
+        allowInvalidAppCheckToken: true,
+      },
+      expectedHttpResponse: {
+        status: 200,
+        headers: expectedResponseHeaders,
+        body: { result: null },
       },
     });
   });

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -592,16 +592,22 @@ async function checkTokens(
 type v1Handler = (data: any, context: CallableContext) => any | Promise<any>;
 type v2Handler<Req, Res> = (request: CallableRequest<Req>) => Res;
 
+/** @hidden **/
+export interface CallableOptions {
+  cors: cors.CorsOptions;
+  allowInvalidAppCheckToken?: boolean;
+}
+
 /** @hidden */
 export function onCallHandler<Req = any, Res = any>(
-  options: cors.CorsOptions,
+  options: CallableOptions,
   handler: v1Handler | v2Handler<Req, Res>
 ): (req: Request, res: express.Response) => Promise<void> {
-  const wrapped = wrapOnCallHandler(handler);
+  const wrapped = wrapOnCallHandler(options, handler);
   return (req: Request, res: express.Response) => {
     return new Promise((resolve) => {
       res.on('finish', resolve);
-      cors(options)(req, res, () => {
+      cors(options.cors)(req, res, () => {
         resolve(wrapped(req, res));
       });
     });
@@ -610,6 +616,7 @@ export function onCallHandler<Req = any, Res = any>(
 
 /** @internal */
 function wrapOnCallHandler<Req = any, Res = any>(
+  options: CallableOptions,
   handler: v1Handler | v2Handler<Req, Res>
 ): (req: Request, res: express.Response) => Promise<void> {
   return async (req: Request, res: express.Response): Promise<void> => {
@@ -621,7 +628,10 @@ function wrapOnCallHandler<Req = any, Res = any>(
 
       const context: CallableContext = { rawRequest: req };
       const tokenStatus = await checkTokens(req, context);
-      if (tokenStatus.app === 'INVALID' || tokenStatus.auth === 'INVALID') {
+      if (tokenStatus.auth === 'INVALID') {
+        throw new HttpsError('unauthenticated', 'Unauthenticated');
+      }
+      if (tokenStatus.app === 'INVALID' && !options.allowInvalidAppCheckToken) {
         throw new HttpsError('unauthenticated', 'Unauthenticated');
       }
 

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -160,6 +160,11 @@ export interface RuntimeOptions {
    * Invoker to set access control on https functions.
    */
   invoker?: 'public' | 'private' | string | string[];
+
+  /*
+   * Allow requests with invalid App Check tokens on callable functions.
+   */
+  allowInvalidAppCheckToken?: boolean;
 }
 
 export interface DeploymentOptions extends RuntimeOptions {

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -90,7 +90,10 @@ export function _onCallWithOptions(
   // in another handler to avoid accidentally triggering the v2 API
   const fixedLen = (data: any, context: CallableContext) =>
     handler(data, context);
-  const func: any = onCallHandler({ origin: true, methods: 'POST' }, fixedLen);
+  const func: any = onCallHandler(
+    { cors: { origin: true, methods: 'POST' } },
+    fixedLen
+  );
 
   func.__trigger = {
     labels: {},

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -91,7 +91,10 @@ export function _onCallWithOptions(
   const fixedLen = (data: any, context: CallableContext) =>
     handler(data, context);
   const func: any = onCallHandler(
-    { cors: { origin: true, methods: 'POST' } },
+    {
+      allowInvalidAppCheckToken: options.allowInvalidAppCheckToken,
+      cors: { origin: true, methods: 'POST' },
+    },
     fixedLen
   );
 

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -43,10 +43,6 @@ export interface HttpsOptions extends Omit<options.GlobalOptions, 'region'> {
   cors?: string | boolean | RegExp | Array<string | RegExp>;
 }
 
-export interface CallableOptions extends HttpsOptions {
-  allowInvalidAppCheckToken?: boolean;
-}
-
 export type HttpsFunction = ((
   req: Request,
   res: express.Response
@@ -138,22 +134,22 @@ export function onRequest(
 }
 
 export function onCall<T = any, Return = any | Promise<any>>(
-  opts: CallableOptions,
+  opts: HttpsOptions,
   handler: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return>;
 export function onCall<T = any, Return = any | Promise<any>>(
   handler: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return>;
 export function onCall<T = any, Return = any | Promise<any>>(
-  optsOrHandler: CallableOptions | ((request: CallableRequest<T>) => Return),
+  optsOrHandler: HttpsOptions | ((request: CallableRequest<T>) => Return),
   handler?: (request: CallableRequest<T>) => Return
 ): CallableFunction<T, Return> {
-  let opts: CallableOptions;
+  let opts: HttpsOptions;
   if (arguments.length == 1) {
     opts = {};
     handler = optsOrHandler as (request: CallableRequest<T>) => Return;
   } else {
-    opts = optsOrHandler as CallableOptions;
+    opts = optsOrHandler as HttpsOptions;
   }
 
   const origin = 'cors' in opts ? opts.cors : true;
@@ -162,7 +158,7 @@ export function onCall<T = any, Return = any | Promise<any>>(
   // fix the length to prevent api versions from being mismatched.
   const fixedLen = (req: CallableRequest<T>) => handler(req);
   const func: any = onCallHandler(
-    { ...opts, cors: { origin, methods: 'POST' } },
+    { cors: { origin, methods: 'POST' } },
     fixedLen
   );
 


### PR DESCRIPTION
Since releasing App Check integration for Callable Functions, we've received several requests from our users to make it possible turn  App Check enforcement off. By default, if a request includes an App Check token, callable functions will verify the token, and - if the token is invalid - reject the request. This makes it hard for developers to onboard to App Check, especially for developers that want to "soft launch" App Check integration to measure the App Check enforcement would have on its users.

The change here adds a `runWith` option to allow requests with invalid App check token to continue to user code execution, e.g.

```js
exports.yourCallableFunction = functions.
  .runWith({
    allowInvalidAppCheckToken: true  // Opt-out: Invalid App Check token cont. to user code.
  }).
  .https.onCall(
  (data, context) => {
    // Requests with an invalid App Check token are not rejected.
    //
    // context.app will be undefined if the request:
    //   1) Does not include an App Check token
    //   2) Includes an invalid App Check token
    if (context.app == undefined) {
      // Users can manually inspect raw request header to check whether an App Check
      // token was provided in the request.
      const rawToken = context.rawRequest.header['X-Firebase-AppCheck'];
      if (rawToken == undefined) {
        throw new functions.https.HttpsError(
            'failed-precondition',
            'The function must be called from an App Check verified app.'
        );
      } else {
        throw new functions.https.HttpsError(
            'unauthenticated',
            'Provided App Check token failed to validate.'
        );
      }
    },
  }
);
```

