### PR TITLE
Improve types for Runnable

### DIFF
--- a/spec/v1/providers/database.spec.ts
+++ b/spec/v1/providers/database.spec.ts
@@ -83,7 +83,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -131,7 +131,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -180,7 +180,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -229,7 +229,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: { foo: 'bar' },
             delta: null,
@@ -269,7 +269,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -307,7 +307,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -344,7 +344,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: null,
             delta: { foo: 'bar' },
@@ -381,7 +381,7 @@ describe('Database Functions', () => {
       });
 
       it('should return a handler that emits events with a proper DataSnapshot', () => {
-        const event = {
+        const event: any = {
           data: {
             data: { foo: 'bar' },
             delta: null,

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -287,8 +287,8 @@ export interface TriggerAnnotated {
  * A Runnable has a `run` method which directly invokes the user-defined
  * function - useful for unit testing.
  */
-export interface Runnable<T> {
-  run: (data: T, context: any) => PromiseLike<any> | any;
+export interface Runnable<Data, Return = any> {
+  run: (data: Data, context: any) => PromiseLike<Return> | Return;
 }
 
 /**
@@ -310,9 +310,9 @@ export type HttpsFunction = TriggerAnnotated &
  * This type is a special JavaScript function which takes a templated
  * `Event` object as its only argument.
  */
-export type CloudFunction<T> = Runnable<T> &
+export type CloudFunction<Data, Return = any> = Runnable<Data, Return> &
   TriggerAnnotated &
-  ((input: any, context?: any) => PromiseLike<any> | any);
+  ((input: Data, context?: any) => PromiseLike<Return> | Return);
 
 /** @hidden */
 export interface MakeCloudFunctionArgs<EventData> {

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -50,9 +50,9 @@ export function onRequest(
  * Declares a callable method for clients to call using a Firebase SDK.
  * @param handler A method that takes a data and context and returns a value.
  */
-export function onCall(
-  handler: (data: any, context: CallableContext) => any | Promise<any>
-): HttpsFunction & Runnable<any> {
+export function onCall<Data, Return>(
+  handler: (data: Data, context: CallableContext) => Return | Promise<Return>
+): HttpsFunction & Runnable<Data, Return> {
   return _onCallWithOptions(handler, {});
 }
 
@@ -81,10 +81,10 @@ export function _onRequestWithOptions(
 }
 
 /** @hidden */
-export function _onCallWithOptions(
-  handler: (data: any, context: CallableContext) => any | Promise<any>,
+export function _onCallWithOptions<Data, Return>(
+  handler: (data: Data, context: CallableContext) => Return | Promise<Return>,
   options: DeploymentOptions
-): HttpsFunction & Runnable<any> {
+): HttpsFunction & Runnable<Data, Return> {
   // onCallHandler sniffs the function length of the passed-in callback
   // and the user could have only tried to listen to data. Wrap their handler
   // in another handler to avoid accidentally triggering the v2 API


### PR DESCRIPTION
Swaps `Runnable<T>` for `Runnable<Data, Return>` to preserve inferred types when using the `Runnable` interface (or it's derivative `CloudFunction`).

This helps with writing tests that call functions, because their return type will be preserved.

```ts
import * as functions from "firebase-functions";

const double = https.onCall((n: number) => n * 2);
const four: number = await double.run(2, {});
```

However, the main motivation for this change is to help with writing type-safe client/server interactions. The runnable interface gives the client a chance to infer the function's signature.

### Functions
<details open>

<summary><code>functions/index.ts</code></summary>

```ts
import * as functions from "firebase-functions";

// double is Runnable<number, number>
export const double = functions.https.onCall((n: number) => n * 2);
```
</details>

### Client
<details open>

<summary><code>client/index.ts</code></summary>

```ts
import { getFunctions } from "firebase/functions";
import { httpsCallables } from "./https-callables";

// ...
let functions = getFunctions(app);
let callable = httpsCallables<typeof import("../functions")>(functions);

let double = callable("double");

let result: string = await double("hello");
//          ^^^^^^                ^^^^^^^
// Compiler knows that return type and parameter are wrong!
```
</details>

<details>

<summary><code>client/https-callables.ts</code></summary>

```ts
import { Functions, httpsCallable } from "firebase/functions";

interface Runnable<Data = any, Return = any> {
  run(data: Data): Return | PromiseLike<Return>;
}

type GetCallableFunctions<ImportedFunctions> = {
  [Name in keyof ImportedFunctions as ImportedFunctions[Name] extends Runnable ? Name : never]:
    ImportedFunctions[Name] extends Runnable<infer Data, infer Return> ? (data: Data) => Promise<Return>;
};

export function httpsCallables<ImportedFunctions>(functions: Functions) {
  type CallableFunctions = GetCallableFunctions<ImportedFunctions>;
  
  return <Name extends keyof CallableFunctions>(name: Name):
    CallableFunctions[Name] extends (data: infer Data) => infer Return ? HttpsCallable<Data, Return> : never = 
    httpsCallable(functions, name);
}
```

It would be nice if there was a slightly less hacky way to do this, ideally one where you didn't need to bring in your own helper for creating the callable functions, but that's out of scope for this repo/PR.
</details>

I'm currently hacking my way around this by overloading the `https.onCall` function with a type declaration, but it would be much nicer if I could get the data/return type directly without it. 

## No Breaking Changes
I added a default value for the `Return` type parameter, which should mean that this isn't a breaking change for anyone currently using `Runnable`.

## Broken Tests
The changes here surfaced some type errors in some tests, and I went with a quick and dirty fix as it wasn't immediately obvious whether the tests are wrong, or whether they're just taking some type system shortcuts.

The `data` and `resource` fields on the event objects in `spec/v1/providers/database.spec.ts` don't match up with the definition of `Event` (from `src/cloud-functions.ts`).

Specifically, the `data` property should be an instance of `DataSnapshot`. I tried using `const event: Event = {` but then the `context.resource` field errors instead, expecting it to be a `Resource` (`src/cloud-functions.ts`) rather than a `string`.

Let me know if there's a better fix than `any` here and I'll happily amend the PR.

Thanks!
