### PR TITLE
Rename enqueue to dispatch to match API proposal

### DIFF
--- a/spec/common/providers/https.spec.ts
+++ b/spec/common/providers/https.spec.ts
@@ -166,7 +166,7 @@ interface TaskTest {
 
 // Runs a TaskTest test.
 async function runTaskTest(test: TaskTest): Promise<any> {
-  const taskQueueFunctionV1 = https.onEnqueueHandler((data, context) => {
+  const taskQueueFunctionV1 = https.onDispatchHandler((data, context) => {
     expect(data).to.deep.equal(test.expectedData);
     if (test.taskFunction) {
       test.taskFunction(data, context);
@@ -176,7 +176,7 @@ async function runTaskTest(test: TaskTest): Promise<any> {
   const responseV1 = await runHandler(taskQueueFunctionV1, test.httpRequest);
   expect(responseV1.status).to.equal(test.expectedStatus);
 
-  const taskQueueFunctionV2 = https.onEnqueueHandler((request) => {
+  const taskQueueFunctionV2 = https.onDispatchHandler((request) => {
     expect(request.data).to.deep.equal(test.expectedData);
     if (test.taskFunction2) {
       test.taskFunction2(request);

--- a/spec/v1/providers/https.spec.ts
+++ b/spec/v1/providers/https.spec.ts
@@ -225,7 +225,7 @@ describe('#onEnqueue', () => {
         },
         invoker: 'private',
       })
-      .onEnqueue(() => {});
+      .onDispatch(() => {});
     expect(result.__trigger).to.deep.equal({
       taskQueueTrigger: {
         rateLimits: {
@@ -252,7 +252,7 @@ describe('#onEnqueue', () => {
         memory: '256MB',
       })
       .https.taskQueue({ retryConfig: { maxAttempts: 5 } })
-      .onEnqueue(() => null);
+      .onDispatch(() => null);
 
     expect(fn.__trigger).to.deep.equal({
       regions: ['us-east1'],
@@ -275,7 +275,7 @@ describe('#onEnqueue', () => {
       },
     };
     let done = false;
-    const cf = https.taskQueue().onEnqueue((d, c) => {
+    const cf = https.taskQueue().onDispatch((d, c) => {
       expect(d).to.equal(data);
       expect(c).to.deep.equal(context);
       done = true;
@@ -288,7 +288,7 @@ describe('#onEnqueue', () => {
   // Regression test for firebase-functions#947
   it('should lock to the v1 API even with function.length == 1', async () => {
     let gotData: Record<string, any>;
-    const func = https.taskQueue().onEnqueue((data) => {
+    const func = https.taskQueue().onDispatch((data) => {
       gotData = data;
     });
 

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -378,7 +378,7 @@ describe('onTaskEnqueue', () => {
   });
 
   it('should return a minimal trigger with appropriate values', () => {
-    const result = https.onTaskEnqueue(() => {});
+    const result = https.onTaskDispatched(() => {});
     expect(result.__trigger).to.deep.equal({
       apiVersion: 2,
       platform: 'gcfv2',
@@ -388,7 +388,7 @@ describe('onTaskEnqueue', () => {
   });
 
   it('should create a complex trigger with appropriate values', () => {
-    const result = https.onTaskEnqueue(
+    const result = https.onTaskDispatched(
       {
         ...FULL_OPTIONS,
         retryConfig: {
@@ -432,7 +432,7 @@ describe('onTaskEnqueue', () => {
       minInstances: 1,
     });
 
-    const result = https.onTaskEnqueue(
+    const result = https.onTaskDispatched(
       {
         region: 'us-west1',
         minInstances: 3,
@@ -459,7 +459,7 @@ describe('onTaskEnqueue', () => {
         token: 'token',
       },
     };
-    const cf = https.onTaskEnqueue((r) => {
+    const cf = https.onTaskDispatched((r) => {
       expect(r.data).to.deep.equal(request.data);
       expect(r.auth).to.deep.equal(request.auth);
     });
@@ -468,7 +468,7 @@ describe('onTaskEnqueue', () => {
   });
 
   it('should be an express handler', async () => {
-    const func = https.onTaskEnqueue((request) => {});
+    const func = https.onTaskDispatched((request) => {});
 
     const req = new MockRequest(
       {
@@ -487,17 +487,17 @@ describe('onTaskEnqueue', () => {
 
   // These tests pass if the code transpiles
   it('allows desirable syntax', () => {
-    https.onTaskEnqueue<string>((request: https.TaskRequest<string>) => {
+    https.onTaskDispatched<string>((request: https.TaskRequest<string>) => {
       // There should be no lint warnings that data is not a string.
       console.log(`hello, ${request.data}`);
     });
-    https.onTaskEnqueue((request: https.TaskRequest<string>) => {
+    https.onTaskDispatched((request: https.TaskRequest<string>) => {
       console.log(`hello, ${request.data}`);
     });
-    https.onTaskEnqueue<string>((request: https.TaskRequest) => {
+    https.onTaskDispatched<string>((request: https.TaskRequest) => {
       console.log(`hello, ${request.data}`);
     });
-    https.onTaskEnqueue((request: https.TaskRequest) => {
+    https.onTaskDispatched((request: https.TaskRequest) => {
       console.log(`Hello, ${request.data}`);
     });
   });

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -171,16 +171,28 @@ export interface CallableRequest<T = any> {
 
 /** How a task should be retried in the event of a non-2xx return. */
 export interface TaskRetryConfig {
-  // If left unspecified, will default to 3
+  /**
+   * Maximum number of times a request should be attempted
+   * If left unspecified, will default to 3.
+   */
   maxAttempts?: number;
 
-  // If left unspecified will default to 1hr
+  /**
+   * The maximum amount of time to wait between attempts.
+   * If left unspecified will default to 1hr.
+   */
   maxBackoffSeconds?: number;
 
-  // If left unspecified will default to 16
+  /**
+   * The maximum number of times to double the backoff between
+   * retries. If left unspecified will default to 16.
+   */
   maxDoublings?: number;
 
-  // If left unspecified will default to 100ms
+  /**
+   * The minimum time to wait between attempts. If left unspecified
+   * will default to 100ms.
+   */
   minBackoffSeconds?: number;
 }
 
@@ -818,7 +830,7 @@ function wrapOnCallHandler<Req = any, Res = any>(
 }
 
 /** @internal */
-export function onEnqueueHandler<Req = any>(
+export function onDispatchHandler<Req = any>(
   handler: v1TaskHandler | v2TaskHandler<Req>
 ): (req: Request, res: express.Response) => Promise<void> {
   return async (req: Request, res: express.Response): Promise<void> => {

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -172,7 +172,7 @@ export interface CallableRequest<T = any> {
 /** How a task should be retried in the event of a non-2xx return. */
 export interface TaskRetryConfig {
   /**
-   * Maximum number of times a request should be attempted
+   * Maximum number of times a request should be attempted.
    * If left unspecified, will default to 3.
    */
   maxAttempts?: number;

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -358,7 +358,7 @@ export class FunctionBuilder {
 
       /**
        * Declares a task queue function for clients to call using a Firebase Admin SDK.
-       * @param handler A method that takes a data and context and returns void or Promise<void>.
+       * @param options Configuratins for the task queue function.
        */
       /** @hidden */
       taskQueue: (options?: https.TaskQueueOptions) => {

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -358,7 +358,7 @@ export class FunctionBuilder {
 
       /**
        * Declares a task queue function for clients to call using a Firebase Admin SDK.
-       * @param options Configuratins for the task queue function.
+       * @param options Configurations for the task queue function.
        */
       /** @hidden */
       taskQueue: (options?: https.TaskQueueOptions) => {

--- a/src/handler-builder.ts
+++ b/src/handler-builder.ts
@@ -92,7 +92,7 @@ export class HandlerBuilder {
             ) => void | Promise<void>
           ) {
             const builder = new https.TaskQueueBuilder();
-            const func = builder.onEnqueue(handler);
+            const func = builder.onDispatch(handler);
             func.__trigger = {};
             return func;
           },

--- a/src/providers/https.ts
+++ b/src/providers/https.ts
@@ -33,7 +33,7 @@ import {
   FunctionsErrorCode,
   HttpsError,
   onCallHandler,
-  onEnqueueHandler,
+  onDispatchHandler,
   Request,
   TaskContext,
   TaskRateLimits,
@@ -107,7 +107,7 @@ export class TaskQueueBuilder {
     private readonly depOpts?: DeploymentOptions
   ) {}
 
-  onEnqueue(
+  onDispatch(
     handler: (data: any, context: TaskContext) => void | Promise<void>
   ): TaskQueueFunction {
     // onEnqueueHandler sniffs the function length of the passed-in callback
@@ -115,7 +115,7 @@ export class TaskQueueBuilder {
     // in another handler to avoid accidentally triggering the v2 API
     const fixedLen = (data: any, context: TaskContext) =>
       handler(data, context);
-    const func: any = onEnqueueHandler(fixedLen);
+    const func: any = onDispatchHandler(fixedLen);
 
     func.__trigger = {
       ...optionsToTrigger(this.depOpts || {}),

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -33,7 +33,7 @@ import {
   FunctionsErrorCode,
   HttpsError,
   onCallHandler,
-  onEnqueueHandler,
+  onDispatchHandler,
   Request,
   TaskRateLimits,
   TaskRequest,
@@ -227,17 +227,17 @@ export function onCall<T = any, Return = any | Promise<any>>(
 }
 
 /** Handle a request sent to a Cloud Tasks queue. */
-export function onTaskEnqueue<Args = any>(
+export function onTaskDispatched<Args = any>(
   handler: (request: TaskRequest<Args>) => void | Promise<void>
 ): TaskQueueFunction<Args>;
 
 /** Handle a request sent to a Cloud Tasks queue. */
-export function onTaskEnqueue<Args = any>(
+export function onTaskDispatched<Args = any>(
   options: TaskQueueOptions,
   handler: (request: TaskRequest<Args>) => void | Promise<void>
 ): TaskQueueFunction<Args>;
 
-export function onTaskEnqueue<Args = any>(
+export function onTaskDispatched<Args = any>(
   optsOrHandler:
     | TaskQueueOptions
     | ((request: TaskRequest<Args>) => void | Promise<void>),
@@ -256,7 +256,7 @@ export function onTaskEnqueue<Args = any>(
   // onEnqueueHandler sniffs the function length to determine which API to present.
   // fix the length to prevent api versions from being mismatched.
   const fixedLen = (req: TaskRequest<Args>) => handler(req);
-  const func: any = onEnqueueHandler(fixedLen);
+  const func: any = onDispatchHandler(fixedLen);
 
   Object.defineProperty(func, '__trigger', {
     get: () => {


### PR DESCRIPTION
Shoot! Not only did I rush and make the v2 API present tense instead of past tense, but I used enqueue vs dispatch in the naming conventions! Should now match go/task-functions