### PR TITLE
Check for missing options / databaseURL on emulator start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 - Parallelizes network calls that occur when validating authorization for onCall handlers.
 - Adds new regions to V2 API
-- Bug Fix - Check for missing options / databaseURL on emulator start
+- Fixes bug where the emulator crashed when given app without an `options` property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 - Parallelizes network calls that occur when validating authorization for onCall handlers.
 - Adds new regions to V2 API
+- Bug Fix - Check for missing options / databaseURL on emulator start

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -369,7 +369,7 @@ export class DataSnapshot {
     private app?: firebase.app.App,
     instance?: string
   ) {
-    if ( app?.options?.databaseURL?.startsWith('http:') ) {
+    if (app?.options?.databaseURL?.startsWith('http:')) {
       // In this case we're dealing with an emulator
       this.instance = app.options.databaseURL;
     } else if (instance) {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -369,7 +369,7 @@ export class DataSnapshot {
     private app?: firebase.app.App,
     instance?: string
   ) {
-    if ( app && app.options && app.options.databaseURL && app.options.databaseURL.startsWith('http:') ) {
+    if ( app?.options?.databaseURL?.startsWith('http:') ) {
       // In this case we're dealing with an emulator
       this.instance = app.options.databaseURL;
     } else if (instance) {

--- a/src/providers/database.ts
+++ b/src/providers/database.ts
@@ -369,7 +369,7 @@ export class DataSnapshot {
     private app?: firebase.app.App,
     instance?: string
   ) {
-    if (app && app.options.databaseURL.startsWith('http:')) {
+    if ( app && app.options && app.options.databaseURL && app.options.databaseURL.startsWith('http:') ) {
       // In this case we're dealing with an emulator
       this.instance = app.options.databaseURL;
     } else if (instance) {


### PR DESCRIPTION
### Description

Bug Fix
When using firebase emulators Realtime Database throws an error due to app.options not existing.
I've found adding an extra check to the database constructor stops this error, and results in the emulator starting up correctly.

### Code sample

Instead of 
`if (app && app.options.databaseURL.startsWith('http:'))`
I've added
`if ( app && app.options && app.options.databaseURL && app.options.databaseURL.startsWith('http:') )`


Note: I've deliberately not used the modern ES6 optional chaining.
This syntax would be much cleaner, but is not supported by your lowest node version.
`app?.options?.databaseURL?.startsWith('http:')`