### PR TITLE
Add runtime option to associate secrets to functions

### DIFF
--- a/spec/v1/function-builder.spec.ts
+++ b/spec/v1/function-builder.spec.ts
@@ -472,10 +472,58 @@ describe('FunctionBuilder', () => {
     ).to.throw();
   });
 
-  it('', () => {
+  it('should throw an error if private identifier is in the invoker array', () => {
     expect(() =>
       functions.runWith({
         invoker: ['service-account1', 'private', 'service-account2'],
+      })
+    ).to.throw();
+  });
+
+  it('should allow valid secret config expressed using short form', () => {
+    const secrets = ['API_KEY', 'API_KEY@3', 'API_KEY@latest'];
+    const fn = functions
+      .runWith({ secrets })
+      .auth.user()
+      .onCreate((user) => user);
+
+    expect(fn.__trigger.secrets).to.deep.equal(secrets);
+  });
+
+  it('should allow valid secret config expressed with full resource name', () => {
+    const secrets = [
+      'projects/my-project/secrets/API_KEY',
+      'projects/my-project/secrets/API_KEY/versions/3',
+      'projects/my-project/secrets/API_KEY/versions/latest',
+    ];
+    const fn = functions
+      .runWith({ secrets })
+      .auth.user()
+      .onCreate((user) => user);
+
+    expect(fn.__trigger.secrets).to.deep.equal(secrets);
+  });
+
+  it('should throw error given invalid secret config', () => {
+    expect(() =>
+      functions.runWith({
+        secrets: ['ABC!@#$'],
+      })
+    ).to.throw();
+  });
+
+  it('should throw error given invalid secret version on short form', () => {
+    expect(() =>
+      functions.runWith({
+        secrets: ['ABC@live'],
+      })
+    ).to.throw();
+  });
+
+  it('should throw error given invalid secret version on long form', () => {
+    expect(() =>
+      functions.runWith({
+        secrets: ['projects/my-project/secrets/API_KEY/versions/live'],
       })
     ).to.throw();
   });

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -499,7 +499,8 @@ export function optionsToTrigger(options: DeploymentOptions) {
     'ingressSettings',
     'vpcConnectorEgressSettings',
     'vpcConnector',
-    'labels'
+    'labels',
+    'secrets'
   );
   convertIfPresent(
     trigger,

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -280,6 +280,7 @@ export interface TriggerAnnotated {
     vpcConnectorEgressSettings?: string;
     serviceAccountEmail?: string;
     ingressSettings?: string;
+    secrets?: string[];
   };
 }
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -229,6 +229,33 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
     }
   }
 
+  if (runtimeOptions.secrets !== undefined) {
+    // Secrets can be configured in few ways:
+    //   1. Shortform notation (with or without version)
+    //     e.g. MY_API_KEY[@VERSION]
+    //   2. Full resource name (with or without version)
+    //     e.g projects/my-project/secrets/MY_API_KEY[/versions/3]
+    const SECRET_SHORT_REGEX = /^[A-Za-z\d\-_]+(?:@[latest|\d]+)?$/
+    const SECRET_FULL_REGEX = new RegExp(
+      "^" +
+      "projects\\/" +
+      "((?:[0-9]+)|(?:[A-Za-z]+[A-Za-z\\d-]*[A-Za-z\\d]?))\\/" +
+      "secrets\\/" +
+      "([A-Za-z\\d\\-_]+)" +
+      "(?:\\/versions\\/" + "(latest|[0-9]+))?" +
+      "$"
+    );
+    const invalidSecrets = runtimeOptions.secrets.filter(s => !SECRET_SHORT_REGEX.test(s) && !SECRET_FULL_REGEX.test(s))
+    if (invalidSecrets.length > 0) {
+      throw new Error(
+        `Invalid secrets: ${invalidSecrets.join(',')}. ` +
+        "Secret must be configured using the short form (e.g. API_KEY@1) " +
+        "or with full resource name (e.g. projects/my-project/secrets/API_KEY)."
+      );
+    }
+  }
+
+
   return true;
 }
 

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -44,6 +44,22 @@ import * as remoteConfig from './providers/remoteConfig';
 import * as storage from './providers/storage';
 import * as testLab from './providers/testLab';
 
+// Secrets can be configured in 2 ways:
+//   1. Shortform notation (with or without version)
+//     e.g. MY_API_KEY[@VERSION]
+const SECRET_SHORT_REGEX = /^[A-Za-z\d\-_]+(?:@[latest|\d]+)?$/
+//   2. Full resource name (with or without version)
+//     e.g projects/my-project/secrets/MY_API_KEY[/versions/3]
+const SECRET_FULL_REGEX = new RegExp(
+  "^" +
+  "projects\\/" +
+  "((?:[0-9]+)|(?:[A-Za-z]+[A-Za-z\\d-]*[A-Za-z\\d]?))\\/" +
+  "secrets\\/" +
+  "([A-Za-z\\d\\-_]+)" +
+  "(?:\\/versions\\/" + "(latest|[0-9]+))?" +
+  "$"
+);
+
 /**
  * Assert that the runtime options passed in are valid.
  * @param runtimeOptions object containing memory and timeout information.
@@ -230,21 +246,6 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   }
 
   if (runtimeOptions.secrets !== undefined) {
-    // Secrets can be configured in few ways:
-    //   1. Shortform notation (with or without version)
-    //     e.g. MY_API_KEY[@VERSION]
-    //   2. Full resource name (with or without version)
-    //     e.g projects/my-project/secrets/MY_API_KEY[/versions/3]
-    const SECRET_SHORT_REGEX = /^[A-Za-z\d\-_]+(?:@[latest|\d]+)?$/
-    const SECRET_FULL_REGEX = new RegExp(
-      "^" +
-      "projects\\/" +
-      "((?:[0-9]+)|(?:[A-Za-z]+[A-Za-z\\d-]*[A-Za-z\\d]?))\\/" +
-      "secrets\\/" +
-      "([A-Za-z\\d\\-_]+)" +
-      "(?:\\/versions\\/" + "(latest|[0-9]+))?" +
-      "$"
-    );
     const invalidSecrets = runtimeOptions.secrets.filter(s => !SECRET_SHORT_REGEX.test(s) && !SECRET_FULL_REGEX.test(s))
     if (invalidSecrets.length > 0) {
       throw new Error(

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -47,17 +47,18 @@ import * as testLab from './providers/testLab';
 // Secrets can be configured in 2 ways:
 //   1. Shortform notation (with or without version)
 //     e.g. MY_API_KEY[@VERSION]
-const SECRET_SHORT_REGEX = /^[A-Za-z\d\-_]+(?:@[latest|\d]+)?$/
+const SECRET_SHORT_REGEX = /^[A-Za-z\d\-_]+(?:@[latest|\d]+)?$/;
 //   2. Full resource name (with or without version)
 //     e.g projects/my-project/secrets/MY_API_KEY[/versions/3]
 const SECRET_FULL_REGEX = new RegExp(
-  "^" +
-  "projects\\/" +
-  "((?:[0-9]+)|(?:[A-Za-z]+[A-Za-z\\d-]*[A-Za-z\\d]?))\\/" +
-  "secrets\\/" +
-  "([A-Za-z\\d\\-_]+)" +
-  "(?:\\/versions\\/" + "(latest|[0-9]+))?" +
-  "$"
+  '^' +
+    'projects\\/' +
+    '((?:[0-9]+)|(?:[A-Za-z]+[A-Za-z\\d-]*[A-Za-z\\d]?))\\/' +
+    'secrets\\/' +
+    '([A-Za-z\\d\\-_]+)' +
+    '(?:\\/versions\\/' +
+    '(latest|[0-9]+))?' +
+    '$'
 );
 
 /**
@@ -246,16 +247,17 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   }
 
   if (runtimeOptions.secrets !== undefined) {
-    const invalidSecrets = runtimeOptions.secrets.filter(s => !SECRET_SHORT_REGEX.test(s) && !SECRET_FULL_REGEX.test(s))
+    const invalidSecrets = runtimeOptions.secrets.filter(
+      (s) => !SECRET_SHORT_REGEX.test(s) && !SECRET_FULL_REGEX.test(s)
+    );
     if (invalidSecrets.length > 0) {
       throw new Error(
         `Invalid secrets: ${invalidSecrets.join(',')}. ` +
-        "Secret must be configured using the short form (e.g. API_KEY@1) " +
-        "or with full resource name (e.g. projects/my-project/secrets/API_KEY)."
+          'Secret must be configured using the short form (e.g. API_KEY@1) ' +
+          'or with full resource name (e.g. projects/my-project/secrets/API_KEY).'
       );
     }
   }
-
 
   return true;
 }

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -165,6 +165,11 @@ export interface RuntimeOptions {
    * Allow requests with invalid App Check tokens on callable functions.
    */
   allowInvalidAppCheckToken?: boolean;
+
+  /*
+   * Bind secrets in Secret Manager as environment variables.
+   */
+  secrets?: string[];
 }
 
 export interface DeploymentOptions extends RuntimeOptions {

--- a/src/function-configuration.ts
+++ b/src/function-configuration.ts
@@ -167,7 +167,7 @@ export interface RuntimeOptions {
   allowInvalidAppCheckToken?: boolean;
 
   /*
-   * Bind secrets in Secret Manager as environment variables.
+   * Secrets to bind to a function instance.
    */
   secrets?: string[];
 }


### PR DESCRIPTION
Google Cloud Functions (GCF) now have support for loading secrets stored in Secret Manager to securely access application secrets (e.g. Third party API keys) on function executions. See the [documentations(https://cloud.google.com/functions/docs/configuring/secrets) for more details.

We propose extending the function runtime option to associate secrets. Then, the secrets can be access as an environment once deployed to GCF:

```js
import * as functions from "firebase-functions";

const helloSecret = functions
  .runWith({ 
    // Loads secret
    //   projects/{PROJECT}/secrets/MY_SECRET/versions/{current latest secret version}
    secrets: ['MY_SECRET']
  })
  .https
  .onRequest((res, req) => {
    req.send(`Shhhhh. Our secret: ${process.env.MY_SECRET}`);
  });

const helloSecretVersion = functions
  .runWith({ 
    // Loads secret
    //   projects/{PROJECT}/secrets/MY_SECRET/versions/3
    secrets: ['MY_SECRET@3']
  })
  .https
  .onRequest((res, req) => {
    req.send(`Shhhhh. Our secret: ${process.env.MY_SECRET}`);
  });


// Optionally provide the full resource name.
const helloSecretFullName = functions
  .runWith({ 
    secrets: [
      'projects/my-project/secrets/MY_SECRET', // as secret resource name
      'projects/my-project/secrets/ANOTHER_SECRET/versions/3', // or secret version resource name
    ] 
  })
  .onRequest((res, req) => {
    // Environment variable name is still the secret id.
    req.send(`Shhhhh. Our secret: ${process.env.MY_SECRET}`);
  });
```

