### PR TITLE
Specific interface for provider enhancement (2/3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "./v2/params": "./lib/v2/params/index.js",
     "./v2/pubsub": "./lib/v2/providers/pubsub.js",
     "./v2/storage": "./lib/v2/providers/storage.js",
-    "./v2/alerts": "./lib/v2/providers/alerts/index.js"
+    "./v2/alerts": "./lib/v2/providers/alerts/index.js",
+    "./v2/alerts/billing": "./lib/v2/providers/alerts/billing.js"
   },
   "typesVersions": {
     "*": {
@@ -118,6 +119,9 @@
       ],
       "v2/alerts": [
         "lib/v2/providers/alerts"
+      ],
+      "v2/alerts/billing": [
+        "lib/v2/providers/alerts/billing"
       ]
     }
   },

--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as alerts from '../../../../src/v2/providers/alerts';
 import * as billing from '../../../../src/v2/providers/alerts/billing';
-import { BASIC_ENDPOINT, BASIC_OPTIONS } from '../helpers';
+import { FULL_ENDPOINT, FULL_OPTIONS } from '../helpers';
 
 const ALERT_TYPE = 'new-alert-type';
 const myHandler = () => 42;
@@ -26,12 +26,12 @@ describe('billing', () => {
 
     it('should create a function with opts & handler', () => {
       const func = billing.onPlanUpdatePublished(
-        { ...BASIC_OPTIONS },
+        { ...FULL_OPTIONS },
         myHandler
       );
 
       expect(func.__endpoint).to.deep.equal({
-        ...BASIC_ENDPOINT,
+        ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
           eventFilters: {
@@ -62,12 +62,12 @@ describe('billing', () => {
 
     it('should create a function with opts & handler', () => {
       const func = billing.onAutomatedPlanUpdatePublished(
-        { ...BASIC_OPTIONS },
+        { ...FULL_OPTIONS },
         myHandler
       );
 
       expect(func.__endpoint).to.deep.equal({
-        ...BASIC_ENDPOINT,
+        ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
           eventFilters: {
@@ -99,12 +99,12 @@ describe('billing', () => {
     it('should create a function with opts', () => {
       const func = billing.onOperation(
         ALERT_TYPE,
-        { ...BASIC_OPTIONS },
+        { ...FULL_OPTIONS },
         myHandler
       );
 
       expect(func.__endpoint).to.deep.equal({
-        ...BASIC_ENDPOINT,
+        ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
           eventFilters: {

--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -1,0 +1,126 @@
+import { expect } from 'chai';
+import * as alerts from '../../../../src/v2/providers/alerts';
+import * as billing from '../../../../src/v2/providers/alerts/billing';
+import { BASIC_ENDPOINT, BASIC_OPTIONS } from '../helpers';
+
+const ALERT_TYPE = 'new-alert-type';
+const myHandler = () => 42;
+
+describe('billing', () => {
+  describe('onPlanUpdatePublished', () => {
+    it('should create a function with only handler', () => {
+      const func = billing.onPlanUpdatePublished(myHandler);
+
+      expect(func.__endpoint).to.deep.equal({
+        platform: 'gcfv2',
+        labels: {},
+        eventTrigger: {
+          eventType: alerts.eventType,
+          eventFilters: {
+            alertType: billing.planUpdateAlert,
+          },
+          retry: false,
+        },
+      });
+    });
+
+    it('should create a function with opts & handler', () => {
+      const func = billing.onPlanUpdatePublished(
+        { ...BASIC_OPTIONS },
+        myHandler
+      );
+
+      expect(func.__endpoint).to.deep.equal({
+        ...BASIC_ENDPOINT,
+        eventTrigger: {
+          eventType: alerts.eventType,
+          eventFilters: {
+            alertType: billing.planUpdateAlert,
+          },
+          retry: false,
+        },
+      });
+    });
+  });
+
+  describe('onAutomatedPlanUpdatePublished', () => {
+    it('should create a function with only handler', () => {
+      const func = billing.onAutomatedPlanUpdatePublished(myHandler);
+
+      expect(func.__endpoint).to.deep.equal({
+        platform: 'gcfv2',
+        labels: {},
+        eventTrigger: {
+          eventType: alerts.eventType,
+          eventFilters: {
+            alertType: billing.automatedPlanUpdateAlert,
+          },
+          retry: false,
+        },
+      });
+    });
+
+    it('should create a function with opts & handler', () => {
+      const func = billing.onAutomatedPlanUpdatePublished(
+        { ...BASIC_OPTIONS },
+        myHandler
+      );
+
+      expect(func.__endpoint).to.deep.equal({
+        ...BASIC_ENDPOINT,
+        eventTrigger: {
+          eventType: alerts.eventType,
+          eventFilters: {
+            alertType: billing.automatedPlanUpdateAlert,
+          },
+          retry: false,
+        },
+      });
+    });
+  });
+
+  describe('onOperation', () => {
+    it('should create a function with alertType only', () => {
+      const func = billing.onOperation(ALERT_TYPE, myHandler, undefined);
+
+      expect(func.__endpoint).to.deep.equal({
+        platform: 'gcfv2',
+        labels: {},
+        eventTrigger: {
+          eventType: alerts.eventType,
+          eventFilters: {
+            alertType: ALERT_TYPE,
+          },
+          retry: false,
+        },
+      });
+    });
+
+    it('should create a function with opts', () => {
+      const func = billing.onOperation(
+        ALERT_TYPE,
+        { ...BASIC_OPTIONS },
+        myHandler
+      );
+
+      expect(func.__endpoint).to.deep.equal({
+        ...BASIC_ENDPOINT,
+        eventTrigger: {
+          eventType: alerts.eventType,
+          eventFilters: {
+            alertType: ALERT_TYPE,
+          },
+          retry: false,
+        },
+      });
+    });
+
+    it('should create a function with a run method', () => {
+      const func = billing.onOperation(ALERT_TYPE, (event) => event, undefined);
+
+      const res = func.run('input' as any);
+
+      expect(res).to.equal('input');
+    });
+  });
+});

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -4,19 +4,16 @@ import { CloudEvent, CloudFunction } from '../../core';
 import * as options from '../../options';
 
 /** Data */
-// billing.planUpdate
 export interface PlanUpdatePayload {
   ['@type']: 'com.google.firebase.firebasealerts.PlanUpdatePayload';
   billingPlan: string;
   principalEmail: string;
 }
-// billing.automatedPlanUpdate
 export interface PlanAutomatedUpdatePayload {
   ['@type']: 'com.google.firebase.firebasealerts.PlanAutomatedUpdatePayload';
   billingPlan: string;
 }
 
-/** Events */
 /** @internal */
 export const planUpdateAlert = 'billing.planUpdate';
 /** @internal */

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -37,8 +37,9 @@ export const automatedPlanUpdateAlert = 'billing.automatedPlanUpdate';
 /** @internal */
 type BillingEventHandler<T> = (event: BillingEvent<T>) => any | Promise<any>;
 
-/** Handlers */
-/** Handle a plan update published */
+/**
+ * Declares a function that can handle a billing plan update event.
+ */
 export function onPlanUpdatePublished(
   handler: BillingEventHandler<PlanUpdatePayload>
 ): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
@@ -59,7 +60,9 @@ export function onPlanUpdatePublished(
   );
 }
 
-/** Handle an automated plan update published */
+/**
+ * Declares a function that can handle an automated billing plan update event.
+ */
 export function onAutomatedPlanUpdatePublished(
   handler: BillingEventHandler<PlanAutomatedUpdatePayload>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -1,0 +1,105 @@
+import { defineEndpoint, FirebaseAlertData } from '.';
+import { ManifestEndpoint } from '../../../common/manifest';
+import { CloudEvent, CloudFunction } from '../../core';
+import * as options from '../../options';
+
+/** Data */
+// billing.planUpdate
+export interface PlanUpdatePayload {
+  ['@type']: 'com.google.firebase.firebasealerts.PlanUpdatePayload';
+  billingPlan: string;
+  principalEmail: string;
+}
+// billing.automatedPlanUpdate
+export interface PlanAutomatedUpdatePayload {
+  ['@type']: 'com.google.firebase.firebasealerts.PlanAutomatedUpdatePayload';
+  billingPlan: string;
+}
+
+/** Events */
+/** @internal */
+export const planUpdateAlert = 'billing.planUpdate';
+/** @internal */
+export const automatedPlanUpdateAlert = 'billing.automatedPlanUpdate';
+
+/** Cloud Event Type */
+interface WithAlertType {
+  alertType: string;
+}
+export type BillingEvent<T> = CloudEvent<FirebaseAlertData<T>, WithAlertType>;
+
+/** Handlers */
+export function onPlanUpdatePublished(
+  handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
+export function onPlanUpdatePublished(
+  opts: options.EventHandlerOptions,
+  handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
+export function onPlanUpdatePublished(
+  optsOrHandler:
+    | options.EventHandlerOptions
+    | ((event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>),
+  handler?: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<PlanUpdatePayload>> {
+  return onOperation<PlanUpdatePayload>(
+    planUpdateAlert,
+    optsOrHandler,
+    handler
+  );
+}
+
+export function onAutomatedPlanUpdatePublished(
+  handler: (
+    event: BillingEvent<PlanAutomatedUpdatePayload>
+  ) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
+export function onAutomatedPlanUpdatePublished(
+  opts: options.EventHandlerOptions,
+  handler: (
+    event: BillingEvent<PlanAutomatedUpdatePayload>
+  ) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
+export function onAutomatedPlanUpdatePublished(
+  optsOrHandler:
+    | options.EventHandlerOptions
+    | ((event: BillingEvent<PlanAutomatedUpdatePayload>) => any | Promise<any>),
+  handler?: (
+    event: BillingEvent<PlanAutomatedUpdatePayload>
+  ) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>> {
+  return onOperation<PlanAutomatedUpdatePayload>(
+    automatedPlanUpdateAlert,
+    optsOrHandler,
+    handler
+  );
+}
+
+/** @internal */
+export function onOperation<T>(
+  alertType: string,
+  optsOrHandler:
+    | options.EventHandlerOptions
+    | ((event: BillingEvent<T>) => any | Promise<any>),
+  handler: (event: BillingEvent<T>) => any | Promise<any>
+): CloudFunction<FirebaseAlertData<T>> {
+  if (typeof optsOrHandler === 'function') {
+    handler = optsOrHandler as (event: BillingEvent<T>) => any | Promise<any>;
+    optsOrHandler = {};
+  }
+
+  const func = (raw: CloudEvent<unknown>) => {
+    return handler(raw as BillingEvent<T>);
+  };
+
+  func.run = handler;
+
+  // TypeScript doesn't recognize defineProperty as adding a property and complains
+  // that __endpoint doesn't exist. We can either cast to any and lose all type safety
+  // or we can just assign a meaningless value before calling defineProperty.
+  func.__trigger = 'silence the transpiler';
+  func.__endpoint = {} as ManifestEndpoint;
+  defineEndpoint(func, optsOrHandler, alertType, undefined);
+
+  return func;
+}

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -4,11 +4,13 @@ import { CloudEvent, CloudFunction } from '../../core';
 import * as options from '../../options';
 
 /** Data */
+/** Payload for plan update */
 export interface PlanUpdatePayload {
   ['@type']: 'com.google.firebase.firebasealerts.PlanUpdatePayload';
   billingPlan: string;
   principalEmail: string;
 }
+/** Payload for plan automated update */
 export interface PlanAutomatedUpdatePayload {
   ['@type']: 'com.google.firebase.firebasealerts.PlanAutomatedUpdatePayload';
   billingPlan: string;
@@ -26,6 +28,7 @@ interface WithAlertType {
 export type BillingEvent<T> = CloudEvent<FirebaseAlertData<T>, WithAlertType>;
 
 /** Handlers */
+/** Handle a plan update published */
 export function onPlanUpdatePublished(
   handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
@@ -46,6 +49,7 @@ export function onPlanUpdatePublished(
   );
 }
 
+/** Handle an automated plan update published */
 export function onAutomatedPlanUpdatePublished(
   handler: (
     event: BillingEvent<PlanAutomatedUpdatePayload>

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -86,13 +86,11 @@ export function onAutomatedPlanUpdatePublished(
 /** @internal */
 export function onOperation<T>(
   alertType: string,
-  optsOrHandler:
-    | options.EventHandlerOptions
-    | ((event: BillingEvent<T>) => any | Promise<any>),
-  handler: (event: BillingEvent<T>) => any | Promise<any>
+  optsOrHandler: options.EventHandlerOptions | BillingEventHandler<T>,
+  handler: BillingEventHandler<T>
 ): CloudFunction<FirebaseAlertData<T>> {
   if (typeof optsOrHandler === 'function') {
-    handler = optsOrHandler as (event: BillingEvent<T>) => any | Promise<any>;
+    handler = optsOrHandler as BillingEventHandler<T>;
     optsOrHandler = {};
   }
 

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -34,24 +34,21 @@ export const planUpdateAlert = 'billing.planUpdate';
 /** @internal */
 export const automatedPlanUpdateAlert = 'billing.automatedPlanUpdate';
 
-/** @internal */
-type BillingEventHandler<T> = (event: BillingEvent<T>) => any | Promise<any>;
-
 /**
  * Declares a function that can handle a billing plan update event.
  */
 export function onPlanUpdatePublished(
-  handler: BillingEventHandler<PlanUpdatePayload>
+  handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
 export function onPlanUpdatePublished(
   opts: options.EventHandlerOptions,
-  handler: BillingEventHandler<PlanUpdatePayload>
+  handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
 export function onPlanUpdatePublished(
   optsOrHandler:
     | options.EventHandlerOptions
-    | BillingEventHandler<PlanUpdatePayload>,
-  handler?: BillingEventHandler<PlanUpdatePayload>
+    | ((event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>),
+  handler?: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanUpdatePayload>> {
   return onOperation<PlanUpdatePayload>(
     planUpdateAlert,
@@ -64,17 +61,23 @@ export function onPlanUpdatePublished(
  * Declares a function that can handle an automated billing plan update event.
  */
 export function onAutomatedPlanUpdatePublished(
-  handler: BillingEventHandler<PlanAutomatedUpdatePayload>
+  handler: (
+    event: BillingEvent<PlanAutomatedUpdatePayload>
+  ) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
 export function onAutomatedPlanUpdatePublished(
   opts: options.EventHandlerOptions,
-  handler: BillingEventHandler<PlanAutomatedUpdatePayload>
+  handler: (
+    event: BillingEvent<PlanAutomatedUpdatePayload>
+  ) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
 export function onAutomatedPlanUpdatePublished(
   optsOrHandler:
     | options.EventHandlerOptions
-    | BillingEventHandler<PlanAutomatedUpdatePayload>,
-  handler?: BillingEventHandler<PlanAutomatedUpdatePayload>
+    | ((event: BillingEvent<PlanAutomatedUpdatePayload>) => any | Promise<any>),
+  handler?: (
+    event: BillingEvent<PlanAutomatedUpdatePayload>
+  ) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>> {
   return onOperation<PlanAutomatedUpdatePayload>(
     automatedPlanUpdateAlert,
@@ -86,11 +89,13 @@ export function onAutomatedPlanUpdatePublished(
 /** @internal */
 export function onOperation<T>(
   alertType: string,
-  optsOrHandler: options.EventHandlerOptions | BillingEventHandler<T>,
-  handler: BillingEventHandler<T>
+  optsOrHandler:
+    | options.EventHandlerOptions
+    | ((event: BillingEvent<T>) => any | Promise<any>),
+  handler: (event: BillingEvent<T>) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<T>> {
   if (typeof optsOrHandler === 'function') {
-    handler = optsOrHandler as BillingEventHandler<T>;
+    handler = optsOrHandler as (event: BillingEvent<T>) => any | Promise<any>;
     optsOrHandler = {};
   }
 

--- a/src/v2/providers/alerts/index.ts
+++ b/src/v2/providers/alerts/index.ts
@@ -1,5 +1,1 @@
-import * as billing from './billing';
-
-export { billing };
-
 export * from './alerts';

--- a/src/v2/providers/alerts/index.ts
+++ b/src/v2/providers/alerts/index.ts
@@ -1,1 +1,5 @@
+import * as billing from './billing';
+
+export { billing };
+
 export * from './alerts';

--- a/v2/alerts/billing.js
+++ b/v2/alerts/billing.js
@@ -1,0 +1,26 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2021 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This file is not part of the firebase-functions SDK. It is used to silence the
+// imports eslint plugin until it can understand import paths defined by node
+// package exports.
+// For more information, see github.com/import-js/eslint-plugin-import/issues/1810


### PR DESCRIPTION
Change for the the specific billing interface. Exposes `onPlanUpdatePublished` & `onAutomatedPlanUpdatePublished` from the `v2/alerts/billing` namespace

Ex ~ 
```
import {
  onPlanUpdatePublished,
  onAutomatedPlanUpdatePublished
} from "firebase-functions/v2/alerts/billing";

// planUpdatePublished interface
export const func1 = onPlanUpdatePublished((event) => { … });
export const func2 = onPlanUpdatePublished({ region: "us-west1" }, (event) => { … });
// robotPlanUpdatePublished interface
export const func3 = onAutomatedPlanUpdatePublished((event) => { … });
export const func5 = onAutomatedPlanUpdatePublished({ region: "us-west1" }, (event) => { … });
```