### PR TITLE
Unbreak TS users by removing internal annotations for non-internal type definitions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,1 @@
-- Fix issue where TS users couldn' compile their code because of unexported type. (#1032)
+- Fix issue where TS users couldn't compile their code because of unexported types. (#1032)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix issue where TS users couldn' compile their code because of unexported type. (#1032)

--- a/src/common/manifest.ts
+++ b/src/common/manifest.ts
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 /**
- * @internal
  * An definition of a function as appears in the Manifest.
  */
 export interface ManifestEndpoint {
@@ -68,7 +67,6 @@ export interface ManifestEndpoint {
   };
 }
 
-/* @internal */
 export interface ManifestRequiredAPI {
   api: string;
   reason: string;


### PR DESCRIPTION
Fixes https://github.com/firebase/firebase-functions/issues/1031