### PR TITLE
Expose stack on functions.yaml instead of stack.yaml.

### DIFF
--- a/scripts/bin-test/test.ts
+++ b/scripts/bin-test/test.ts
@@ -85,7 +85,8 @@ async function startBin(
     env: {
       PATH: process.env.PATH,
       GLCOUD_PROJECT: 'test-project',
-      STACK_CONTROL_API_PORT: port,
+      PORT: port,
+      FUNCTIONS_CONTROL_API: "true",
     },
   });
 
@@ -95,7 +96,7 @@ async function startBin(
 
   await retryUntil(async () => {
     try {
-      await fetch(`http://localhost:${port}/__/stack.yaml`);
+      await fetch(`http://localhost:${port}/__/functions.yaml`);
     } catch (e) {
       if (e?.code === 'ECONNREFUSED') {
         return false;
@@ -132,7 +133,7 @@ async function startBin(
   };
 }
 
-describe('stack.yaml', () => {
+describe('functions.yaml', () => {
   async function runTests(tc: Testcase) {
     let port: number;
     let cleanup: () => Promise<void>;
@@ -147,14 +148,14 @@ describe('stack.yaml', () => {
       await cleanup?.();
     });
 
-    it('stack.yaml returns expected Manifest', async () => {
-      const res = await fetch(`http://localhost:${port}/__/stack.yaml`);
+    it('functions.yaml returns expected Manifest', async () => {
+      const res = await fetch(`http://localhost:${port}/__/functions.yaml`);
       const text = await res.text();
       let parsed: any;
       try {
         parsed = yaml.load(text);
       } catch (err) {
-        throw new Error('Failed to parse stack.yaml ' + err);
+        throw new Error('Failed to parse functions.yaml ' + err);
       }
       expect(parsed).to.be.deep.equal(tc.expected);
     });

--- a/scripts/bin-test/test.ts
+++ b/scripts/bin-test/test.ts
@@ -86,7 +86,7 @@ async function startBin(
       PATH: process.env.PATH,
       GLCOUD_PROJECT: 'test-project',
       PORT: port,
-      FUNCTIONS_CONTROL_API: "true",
+      FUNCTIONS_CONTROL_API: 'true',
     },
   });
 

--- a/src/bin/firebase-functions.ts
+++ b/src/bin/firebase-functions.ts
@@ -36,7 +36,7 @@ async function handleQuitquitquit(req: express.Request, res: express.Response) {
 app.get('/__/quitquitquit', handleQuitquitquit);
 app.post('/__/quitquitquit', handleQuitquitquit);
 
-if (process.env.FUNCTIONS_CONTROL_API === "true") {
+if (process.env.FUNCTIONS_CONTROL_API === 'true') {
   app.get('/__/functions.yaml', async (req, res) => {
     try {
       const stack = await loadStack(functionsDir);
@@ -44,8 +44,8 @@ if (process.env.FUNCTIONS_CONTROL_API === "true") {
       res.send(JSON.stringify(stack));
     } catch (e) {
       res
-          .status(400)
-          .send(`Failed to generate manifest from function source: ${e}`);
+        .status(400)
+        .send(`Failed to generate manifest from function source: ${e}`);
     }
   });
 }

--- a/src/bin/firebase-functions.ts
+++ b/src/bin/firebase-functions.ts
@@ -35,21 +35,24 @@ async function handleQuitquitquit(req: express.Request, res: express.Response) {
 
 app.get('/__/quitquitquit', handleQuitquitquit);
 app.post('/__/quitquitquit', handleQuitquitquit);
-app.get('/__/stack.yaml', async (req, res) => {
-  try {
-    const stack = await loadStack(functionsDir);
-    res.setHeader('content-type', 'text/yaml');
-    res.send(JSON.stringify(stack));
-  } catch (e) {
-    res
-      .status(400)
-      .send(`Failed to generate manifest from function source: ${e}`);
-  }
-});
+
+if (process.env.FUNCTIONS_CONTROL_API === "true") {
+  app.get('/__/functions.yaml', async (req, res) => {
+    try {
+      const stack = await loadStack(functionsDir);
+      res.setHeader('content-type', 'text/yaml');
+      res.send(JSON.stringify(stack));
+    } catch (e) {
+      res
+          .status(400)
+          .send(`Failed to generate manifest from function source: ${e}`);
+    }
+  });
+}
 
 let port = 8080;
-if (process.env.STACK_CONTROL_API_PORT) {
-  port = Number.parseInt(process.env.STACK_CONTROL_API_PORT);
+if (process.env.PORT) {
+  port = Number.parseInt(process.env.PORT);
 }
 
 console.log('Serving at port', port);

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -110,10 +110,9 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
 
   extractStack(mod, endpoints, requiredAPIs);
 
-  const stack: ManifestStack = {
+  return {
     endpoints,
     specVersion: 'v1alpha1',
     requiredAPIs: mergeRequiredAPIs(requiredAPIs),
   };
-  return stack;
 }


### PR DESCRIPTION
Some contractual changes to how we expose the container contract:

* We will expose `__/functions.yaml` instead of `__/stack.yaml` in the control api
* Environment variables for exposing the control api changes from `STACK_CONTROL_API_PORT` to `PORT` and `FUNCTIONS_CONTROL_API` (whose value should equal `true`).