### PR TITLE
Add missing changelog entry for #1036.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Expose stack YAML via \_\_/functions.yaml endpoint instead (#1036).


### PR DESCRIPTION
Let's prepare for 3.19.0 release by adding the missing changelog entry.