### PR TITLE
Fix handler typo in billing alerts

### DIFF
--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -45,7 +45,7 @@ describe('billing', () => {
 
   describe('onAutomatedPlanUpdatePublished', () => {
     it('should create a function with only handler', () => {
-      const func = billing.onAutomatedPlanUpdatePublished(myHandler);
+      const func = billing.onPlanAutomatedUpdatePublished(myHandler);
 
       expect(func.__endpoint).to.deep.equal({
         platform: 'gcfv2',
@@ -61,7 +61,7 @@ describe('billing', () => {
     });
 
     it('should create a function with opts & handler', () => {
-      const func = billing.onAutomatedPlanUpdatePublished(
+      const func = billing.onPlanAutomatedUpdatePublished(
         { ...FULL_OPTIONS },
         myHandler
       );

--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -43,7 +43,7 @@ describe('billing', () => {
     });
   });
 
-  describe('onAutomatedPlanUpdatePublished', () => {
+  describe('onPlanAutomatedUpdatePublished', () => {
     it('should create a function with only handler', () => {
       const func = billing.onPlanAutomatedUpdatePublished(myHandler);
 
@@ -53,7 +53,7 @@ describe('billing', () => {
         eventTrigger: {
           eventType: alerts.eventType,
           eventFilters: {
-            alertType: billing.automatedPlanUpdateAlert,
+            alertType: billing.planAutomatedUpdateAlert,
           },
           retry: false,
         },
@@ -71,7 +71,7 @@ describe('billing', () => {
         eventTrigger: {
           eventType: alerts.eventType,
           eventFilters: {
-            alertType: billing.automatedPlanUpdateAlert,
+            alertType: billing.planAutomatedUpdateAlert,
           },
           retry: false,
         },

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -32,7 +32,7 @@ export type BillingEvent<T> = CloudEvent<FirebaseAlertData<T>, WithAlertType>;
 /** @internal */
 export const planUpdateAlert = 'billing.planUpdate';
 /** @internal */
-export const planAutomatedUpdateAlert = 'billing.automatedPlanUpdate';
+export const planAutomatedUpdateAlert = 'billing.planAutomatedUpdate';
 
 /**
  * Declares a function that can handle a billing plan update event.

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -60,18 +60,18 @@ export function onPlanUpdatePublished(
 /**
  * Declares a function that can handle an automated billing plan update event.
  */
-export function onAutomatedPlanUpdatePublished(
+export function onPlanAutomatedUpdatePublished(
   handler: (
     event: BillingEvent<PlanAutomatedUpdatePayload>
   ) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
-export function onAutomatedPlanUpdatePublished(
+export function onPlanAutomatedUpdatePublished(
   opts: options.EventHandlerOptions,
   handler: (
     event: BillingEvent<PlanAutomatedUpdatePayload>
   ) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
-export function onAutomatedPlanUpdatePublished(
+export function onPlanAutomatedUpdatePublished(
   optsOrHandler:
     | options.EventHandlerOptions
     | ((event: BillingEvent<PlanAutomatedUpdatePayload>) => any | Promise<any>),

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -32,7 +32,7 @@ export type BillingEvent<T> = CloudEvent<FirebaseAlertData<T>, WithAlertType>;
 /** @internal */
 export const planUpdateAlert = 'billing.planUpdate';
 /** @internal */
-export const automatedPlanUpdateAlert = 'billing.automatedPlanUpdate';
+export const planAutomatedUpdateAlert = 'billing.automatedPlanUpdate';
 
 /**
  * Declares a function that can handle a billing plan update event.
@@ -80,7 +80,7 @@ export function onPlanAutomatedUpdatePublished(
   ) => any | Promise<any>
 ): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>> {
   return onOperation<PlanAutomatedUpdatePayload>(
-    automatedPlanUpdateAlert,
+    planAutomatedUpdateAlert,
     optsOrHandler,
     handler
   );


### PR DESCRIPTION
Replaces `onAutomatedPlanUpdatePublished()` with the correct `onPlanAutomatedUpdatePublished()` in billing alerts.