### PR TITLE
Migrate endpoint annotation eventTrigger.eventFilters to list of filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -149,7 +149,7 @@
     "format:fix": "prettier --write '**/*.{json,md,ts,yml,yaml}'",
     "lint": "tslint --config tslint.json --project tsconfig.json ",
     "lint:fix": "tslint --config tslint.json --fix --project tsconfig.json",
-    "test": "mocha --file ./mocha/setup.ts spec/**/*.spec.ts ",
+    "test": "mocha --file ./mocha/setup.ts \"spec/**/*.spec.ts\"",
     "test:bin": "./scripts/bin-test/run.sh"
   },
   "dependencies": {

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -122,7 +122,12 @@ describe('extractStack', () => {
           platform: 'gcfv1',
           eventTrigger: {
             eventType: 'google.pubsub.topic.publish',
-            eventFilters: { resource: 'projects/my-project/topics/my-topic' },
+            eventFilters: [
+              {
+                attribute: 'resource',
+                value: 'projects/my-project/topics/my-topic',
+              },
+            ],
             retry: false,
           },
           labels: {},

--- a/spec/v1/cloud-functions.spec.ts
+++ b/spec/v1/cloud-functions.spec.ts
@@ -62,9 +62,12 @@ describe('makeCloudFunction', () => {
       platform: 'gcfv1',
       eventTrigger: {
         eventType: 'mock.provider.mock.event',
-        eventFilters: {
-          resource: 'resource',
-        },
+        eventFilters: [
+          {
+            attribute: 'resource',
+            value: 'resource',
+          },
+        ],
         retry: false,
       },
       labels: {},
@@ -86,9 +89,12 @@ describe('makeCloudFunction', () => {
       platform: 'gcfv1',
       eventTrigger: {
         eventType: 'providers/provider/eventTypes/event',
-        eventFilters: {
-          resource: 'resource',
-        },
+        eventFilters: [
+          {
+            attribute: 'resource',
+            value: 'resource',
+          },
+        ],
         retry: false,
       },
       labels: {},
@@ -119,9 +125,12 @@ describe('makeCloudFunction', () => {
       serviceAccountEmail: 'foo@google.com',
       eventTrigger: {
         eventType: 'mock.provider.mock.event',
-        eventFilters: {
-          resource: 'resource',
-        },
+        eventFilters: [
+          {
+            attribute: 'resource',
+            value: 'resource',
+          },
+        ],
         retry: false,
       },
       secretEnvironmentVariables: [{ secret: 'MY_SECRET', key: 'MY_SECRET' }],
@@ -143,9 +152,12 @@ describe('makeCloudFunction', () => {
       platform: 'gcfv1',
       eventTrigger: {
         eventType: 'mock.provider.mock.event',
-        eventFilters: {
-          resource: 'resource',
-        },
+        eventFilters: [
+          {
+            attribute: 'resource',
+            value: 'resource',
+          },
+        ],
         retry: true,
       },
       labels: {},

--- a/spec/v1/providers/analytics.spec.ts
+++ b/spec/v1/providers/analytics.spec.ts
@@ -72,9 +72,12 @@ describe('Analytics Functions', () => {
         expect(cloudFunction.__endpoint).to.deep.equal({
           platform: 'gcfv1',
           eventTrigger: {
-            eventFilters: {
-              resource: 'projects/project1/events/first_open',
-            },
+            eventFilters: [
+              {
+                attribute: 'resource',
+                value: 'projects/project1/events/first_open',
+              },
+            ],
             eventType:
               'providers/google.firebase.analytics/eventTypes/event.log',
             retry: false,

--- a/spec/v1/providers/auth.spec.ts
+++ b/spec/v1/providers/auth.spec.ts
@@ -64,9 +64,12 @@ describe('Auth Functions', () => {
       return {
         platform: 'gcfv1',
         eventTrigger: {
-          eventFilters: {
-            resource: `projects/${project}`,
-          },
+          eventFilters: [
+            {
+              attribute: 'resource',
+              value: `projects/${project}`,
+            },
+          ],
           eventType: `providers/firebase.auth/eventTypes/${eventType}`,
           retry: false,
         },

--- a/spec/v1/providers/database.spec.ts
+++ b/spec/v1/providers/database.spec.ts
@@ -45,9 +45,12 @@ describe('Database Functions', () => {
       return {
         platform: 'gcfv1',
         eventTrigger: {
-          eventFilters: {
-            resource,
-          },
+          eventFilters: [
+            {
+              attribute: 'resource',
+              value: resource,
+            },
+          ],
           eventType: `providers/google.firebase.database/eventTypes/${eventType}`,
           retry: false,
         },

--- a/spec/v1/providers/firestore.spec.ts
+++ b/spec/v1/providers/firestore.spec.ts
@@ -107,9 +107,12 @@ describe('Firestore Functions', () => {
       return {
         platform: 'gcfv1',
         eventTrigger: {
-          eventFilters: {
-            resource,
-          },
+          eventFilters: [
+            {
+              attribute: 'resource',
+              value: resource,
+            },
+          ],
           eventType: `providers/cloud.firestore/eventTypes/${eventType}`,
           retry: false,
         },

--- a/spec/v1/providers/pubsub.spec.ts
+++ b/spec/v1/providers/pubsub.spec.ts
@@ -108,9 +108,12 @@ describe('Pubsub Functions', () => {
           platform: 'gcfv1',
           eventTrigger: {
             eventType: 'google.pubsub.topic.publish',
-            eventFilters: {
-              resource: 'projects/project1/topics/toppy',
-            },
+            eventFilters: [
+              {
+                attribute: 'resource',
+                value: 'projects/project1/topics/toppy',
+              },
+            ],
             retry: false,
           },
           labels: {},

--- a/spec/v1/providers/remoteConfig.spec.ts
+++ b/spec/v1/providers/remoteConfig.spec.ts
@@ -68,9 +68,12 @@ describe('RemoteConfig Functions', () => {
         platform: 'gcfv1',
         eventTrigger: {
           eventType: 'google.firebase.remoteconfig.update',
-          eventFilters: {
-            resource: 'projects/project1',
-          },
+          eventFilters: [
+            {
+              attribute: 'resource',
+              value: 'projects/project1',
+            },
+          ],
           retry: false,
         },
         labels: {},

--- a/spec/v1/providers/storage.spec.ts
+++ b/spec/v1/providers/storage.spec.ts
@@ -42,9 +42,12 @@ describe('Storage Functions', () => {
       return {
         platform: 'gcfv1',
         eventTrigger: {
-          eventFilters: {
-            resource: `projects/_/buckets/${bucket}`,
-          },
+          eventFilters: [
+            {
+              attribute: 'resource',
+              value: `projects/_/buckets/${bucket}`,
+            },
+          ],
           eventType: `google.storage.object.${eventType}`,
           retry: false,
         },

--- a/spec/v1/providers/testLab.spec.ts
+++ b/spec/v1/providers/testLab.spec.ts
@@ -50,9 +50,12 @@ describe('Test Lab Functions', () => {
           platform: 'gcfv1',
           eventTrigger: {
             eventType: 'google.testing.testMatrix.complete',
-            eventFilters: {
-              resource: 'projects/project1/testMatrices/{matrix}',
-            },
+            eventFilters: [
+              {
+                attribute: 'resource',
+                value: 'projects/project1/testMatrices/{matrix}',
+              },
+            ],
             retry: false,
           },
           labels: {},

--- a/spec/v2/providers/alerts/alerts.spec.ts
+++ b/spec/v2/providers/alerts/alerts.spec.ts
@@ -18,7 +18,7 @@ describe('alerts', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],
@@ -43,11 +43,11 @@ describe('alerts', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],
@@ -83,7 +83,7 @@ describe('alerts', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],
@@ -101,7 +101,7 @@ describe('alerts', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],
@@ -119,11 +119,11 @@ describe('alerts', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],
@@ -155,11 +155,11 @@ describe('alerts', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],

--- a/spec/v2/providers/alerts/alerts.spec.ts
+++ b/spec/v2/providers/alerts/alerts.spec.ts
@@ -16,9 +16,12 @@ describe('alerts', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });
@@ -38,10 +41,16 @@ describe('alerts', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });
@@ -72,9 +81,12 @@ describe('alerts', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });
@@ -87,9 +99,12 @@ describe('alerts', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });
@@ -102,10 +117,16 @@ describe('alerts', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });
@@ -132,10 +153,16 @@ describe('alerts', () => {
         minInstances: 3,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });

--- a/spec/v2/providers/alerts/appDistribution.spec.ts
+++ b/spec/v2/providers/alerts/appDistribution.spec.ts
@@ -21,11 +21,11 @@ describe('appDistribution', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: appDistribution.newTesterIosDeviceAlert,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],
@@ -46,7 +46,7 @@ describe('appDistribution', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: appDistribution.newTesterIosDeviceAlert,
             },
           ],
@@ -67,11 +67,11 @@ describe('appDistribution', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: appDistribution.newTesterIosDeviceAlert,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],
@@ -90,7 +90,7 @@ describe('appDistribution', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: appDistribution.newTesterIosDeviceAlert,
             },
           ],

--- a/spec/v2/providers/alerts/appDistribution.spec.ts
+++ b/spec/v2/providers/alerts/appDistribution.spec.ts
@@ -19,10 +19,16 @@ describe('appDistribution', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: appDistribution.newTesterIosDeviceAlert,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: appDistribution.newTesterIosDeviceAlert,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });
@@ -38,9 +44,12 @@ describe('appDistribution', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: appDistribution.newTesterIosDeviceAlert,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: appDistribution.newTesterIosDeviceAlert,
+            },
+          ],
           retry: false,
         },
       });
@@ -56,10 +65,16 @@ describe('appDistribution', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: appDistribution.newTesterIosDeviceAlert,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: appDistribution.newTesterIosDeviceAlert,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });
@@ -73,9 +88,12 @@ describe('appDistribution', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: appDistribution.newTesterIosDeviceAlert,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: appDistribution.newTesterIosDeviceAlert,
+            },
+          ],
           retry: false,
         },
       });

--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -16,9 +16,12 @@ describe('billing', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: billing.planUpdateAlert,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: billing.planUpdateAlert,
+            },
+          ],
           retry: false,
         },
       });
@@ -34,9 +37,12 @@ describe('billing', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: billing.planUpdateAlert,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: billing.planUpdateAlert,
+            },
+          ],
           retry: false,
         },
       });
@@ -52,9 +58,12 @@ describe('billing', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: billing.automatedPlanUpdateAlert,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: billing.automatedPlanUpdateAlert,
+            },
+          ],
           retry: false,
         },
       });
@@ -70,9 +79,12 @@ describe('billing', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: billing.automatedPlanUpdateAlert,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: billing.automatedPlanUpdateAlert,
+            },
+          ],
           retry: false,
         },
       });
@@ -88,9 +100,12 @@ describe('billing', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });
@@ -107,9 +122,12 @@ describe('billing', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });

--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -18,7 +18,7 @@ describe('billing', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: billing.planUpdateAlert,
             },
           ],
@@ -39,7 +39,7 @@ describe('billing', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: billing.planUpdateAlert,
             },
           ],
@@ -60,7 +60,7 @@ describe('billing', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: billing.automatedPlanUpdateAlert,
             },
           ],
@@ -81,7 +81,7 @@ describe('billing', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: billing.automatedPlanUpdateAlert,
             },
           ],
@@ -102,7 +102,7 @@ describe('billing', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],
@@ -124,7 +124,7 @@ describe('billing', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],

--- a/spec/v2/providers/alerts/billing.spec.ts
+++ b/spec/v2/providers/alerts/billing.spec.ts
@@ -58,6 +58,7 @@ describe('billing', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
+          eventFilters: [
             {
               attribute: 'alerttype',
               value: billing.planAutomatedUpdateAlert,

--- a/spec/v2/providers/alerts/crashlytics.spec.ts
+++ b/spec/v2/providers/alerts/crashlytics.spec.ts
@@ -8,437 +8,121 @@ const APPID = '123456789';
 const myHandler = () => 42;
 
 describe('crashlytics', () => {
-  describe('onNewFatalIssuePublished', () => {
-    it('should create a function only handler', () => {
-      const func = crashlytics.onNewFatalIssuePublished(myHandler);
+  const testcases = [
+    {
+      method: 'onNewFatalIssuePublished',
+      event: crashlytics.newFatalIssueAlert,
+    },
+    {
+      method: 'onNewNonfatalIssuePublished',
+      event: crashlytics.newNonfatalIssueAlert,
+    },
+    {
+      method: 'onRegressionAlertPublished',
+      event: crashlytics.regressionAlert,
+    },
+    {
+      method: 'onStabilityDigestPublished',
+      event: crashlytics.stabilityDigestAlert,
+    },
+    {
+      method: 'onVelocityAlertPublished',
+      event: crashlytics.velocityAlert,
+    },
+    {
+      method: 'onNewAnrIssuePublished',
+      event: crashlytics.newAnrIssueAlert,
+    },
+  ];
 
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newFatalIssueAlert,
+  for (const { method, event } of testcases) {
+    describe(method, () => {
+      it('should create a function only handler', () => {
+        const func = crashlytics[method](myHandler);
+
+        expect(func.__endpoint).to.deep.equal({
+          platform: 'gcfv2',
+          labels: {},
+          eventTrigger: {
+            eventType: alerts.eventType,
+            eventFilters: [
+              {
+                attribute: 'alertType',
+                value: event,
+              },
+            ],
+            retry: false,
           },
-          retry: false,
-        },
+        });
+      });
+
+      it('should create a function with appId', () => {
+        const func = crashlytics[method](APPID, myHandler);
+
+        expect(func.__endpoint).to.deep.equal({
+          platform: 'gcfv2',
+          labels: {},
+          eventTrigger: {
+            eventType: alerts.eventType,
+            eventFilters: [
+              {
+                attribute: 'alertType',
+                value: event,
+              },
+              {
+                attribute: 'appId',
+                value: APPID,
+              },
+            ],
+            retry: false,
+          },
+        });
+      });
+
+      it('should create a function with base opts', () => {
+        const func = crashlytics[method]({ ...FULL_OPTIONS }, myHandler);
+
+        expect(func.__endpoint).to.deep.equal({
+          ...FULL_ENDPOINT,
+          eventTrigger: {
+            eventType: alerts.eventType,
+            eventFilters: [
+              {
+                attribute: 'alertType',
+                value: event,
+              },
+            ],
+            retry: false,
+          },
+        });
+      });
+
+      it('should create a function with opts', () => {
+        const func = crashlytics[method](
+          { ...FULL_OPTIONS, appId: APPID },
+          myHandler
+        );
+
+        expect(func.__endpoint).to.deep.equal({
+          ...FULL_ENDPOINT,
+          eventTrigger: {
+            eventType: alerts.eventType,
+            eventFilters: [
+              {
+                attribute: 'alertType',
+                value: event,
+              },
+              {
+                attribute: 'appId',
+                value: APPID,
+              },
+            ],
+            retry: false,
+          },
+        });
       });
     });
-
-    it('should create a function with appId', () => {
-      const func = crashlytics.onNewFatalIssuePublished(APPID, myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newFatalIssueAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with base opts', () => {
-      const func = crashlytics.onNewFatalIssuePublished(
-        { ...FULL_OPTIONS },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newFatalIssueAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with opts', () => {
-      const func = crashlytics.onNewFatalIssuePublished(
-        { ...FULL_OPTIONS, appId: APPID },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newFatalIssueAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-  });
-
-  describe('onNewNonfatalIssuePublished', () => {
-    it('should create a function only handler', () => {
-      const func = crashlytics.onNewNonfatalIssuePublished(myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newNonfatalIssueAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with appId', () => {
-      const func = crashlytics.onNewNonfatalIssuePublished(APPID, myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newNonfatalIssueAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with base opts', () => {
-      const func = crashlytics.onNewNonfatalIssuePublished(
-        { ...FULL_OPTIONS },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newNonfatalIssueAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with opts', () => {
-      const func = crashlytics.onNewNonfatalIssuePublished(
-        { ...FULL_OPTIONS, appId: APPID },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newNonfatalIssueAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-  });
-
-  describe('onRegressionAlertPublished', () => {
-    it('should create a function only handler', () => {
-      const func = crashlytics.onRegressionAlertPublished(myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.regressionAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with appId', () => {
-      const func = crashlytics.onRegressionAlertPublished(APPID, myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.regressionAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with base opts', () => {
-      const func = crashlytics.onRegressionAlertPublished(
-        { ...FULL_OPTIONS },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.regressionAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with opts', () => {
-      const func = crashlytics.onRegressionAlertPublished(
-        { ...FULL_OPTIONS, appId: APPID },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.regressionAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-  });
-
-  describe('onStabilityDigestPublished', () => {
-    it('should create a function only handler', () => {
-      const func = crashlytics.onStabilityDigestPublished(myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.stabilityDigestAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with appId', () => {
-      const func = crashlytics.onStabilityDigestPublished(APPID, myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.stabilityDigestAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with base opts', () => {
-      const func = crashlytics.onStabilityDigestPublished(
-        { ...FULL_OPTIONS },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.stabilityDigestAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with opts', () => {
-      const func = crashlytics.onStabilityDigestPublished(
-        { ...FULL_OPTIONS, appId: APPID },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.stabilityDigestAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-  });
-
-  describe('onVelocityAlertPublished', () => {
-    it('should create a function only handler', () => {
-      const func = crashlytics.onVelocityAlertPublished(myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.velocityAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with appId', () => {
-      const func = crashlytics.onVelocityAlertPublished(APPID, myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.velocityAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with base opts', () => {
-      const func = crashlytics.onVelocityAlertPublished(
-        { ...FULL_OPTIONS },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.velocityAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with opts', () => {
-      const func = crashlytics.onVelocityAlertPublished(
-        { ...FULL_OPTIONS, appId: APPID },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.velocityAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-  });
-
-  describe('onNewAnrIssuePublished', () => {
-    it('should create a function only handler', () => {
-      const func = crashlytics.onNewAnrIssuePublished(myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newAnrIssueAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with appId', () => {
-      const func = crashlytics.onNewAnrIssuePublished(APPID, myHandler);
-
-      expect(func.__endpoint).to.deep.equal({
-        platform: 'gcfv2',
-        labels: {},
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newAnrIssueAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with base opts', () => {
-      const func = crashlytics.onNewAnrIssuePublished(
-        { ...FULL_OPTIONS },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newAnrIssueAlert,
-          },
-          retry: false,
-        },
-      });
-    });
-
-    it('should create a function with opts', () => {
-      const func = crashlytics.onNewAnrIssuePublished(
-        { ...FULL_OPTIONS, appId: APPID },
-        myHandler
-      );
-
-      expect(func.__endpoint).to.deep.equal({
-        ...FULL_ENDPOINT,
-        eventTrigger: {
-          eventType: alerts.eventType,
-          eventFilters: {
-            alertType: crashlytics.newAnrIssueAlert,
-            appId: APPID,
-          },
-          retry: false,
-        },
-      });
-    });
-  });
+  }
 
   describe('onOperation', () => {
     it('should create a function with alertType only', () => {
@@ -449,9 +133,12 @@ describe('crashlytics', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });
@@ -465,10 +152,16 @@ describe('crashlytics', () => {
         labels: {},
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });
@@ -485,9 +178,12 @@ describe('crashlytics', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+          ],
           retry: false,
         },
       });
@@ -504,10 +200,16 @@ describe('crashlytics', () => {
         ...FULL_ENDPOINT,
         eventTrigger: {
           eventType: alerts.eventType,
-          eventFilters: {
-            alertType: ALERT_TYPE,
-            appId: APPID,
-          },
+          eventFilters: [
+            {
+              attribute: 'alertType',
+              value: ALERT_TYPE,
+            },
+            {
+              attribute: 'appId',
+              value: APPID,
+            },
+          ],
           retry: false,
         },
       });

--- a/spec/v2/providers/alerts/crashlytics.spec.ts
+++ b/spec/v2/providers/alerts/crashlytics.spec.ts
@@ -47,7 +47,7 @@ describe('crashlytics', () => {
             eventType: alerts.eventType,
             eventFilters: [
               {
-                attribute: 'alertType',
+                attribute: 'alerttype',
                 value: event,
               },
             ],
@@ -66,11 +66,11 @@ describe('crashlytics', () => {
             eventType: alerts.eventType,
             eventFilters: [
               {
-                attribute: 'alertType',
+                attribute: 'alerttype',
                 value: event,
               },
               {
-                attribute: 'appId',
+                attribute: 'appid',
                 value: APPID,
               },
             ],
@@ -88,7 +88,7 @@ describe('crashlytics', () => {
             eventType: alerts.eventType,
             eventFilters: [
               {
-                attribute: 'alertType',
+                attribute: 'alerttype',
                 value: event,
               },
             ],
@@ -109,11 +109,11 @@ describe('crashlytics', () => {
             eventType: alerts.eventType,
             eventFilters: [
               {
-                attribute: 'alertType',
+                attribute: 'alerttype',
                 value: event,
               },
               {
-                attribute: 'appId',
+                attribute: 'appid',
                 value: APPID,
               },
             ],
@@ -135,7 +135,7 @@ describe('crashlytics', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],
@@ -154,11 +154,11 @@ describe('crashlytics', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],
@@ -180,7 +180,7 @@ describe('crashlytics', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
           ],
@@ -202,11 +202,11 @@ describe('crashlytics', () => {
           eventType: alerts.eventType,
           eventFilters: [
             {
-              attribute: 'alertType',
+              attribute: 'alerttype',
               value: ALERT_TYPE,
             },
             {
-              attribute: 'appId',
+              attribute: 'appid',
               value: APPID,
             },
           ],

--- a/spec/v2/providers/pubsub.spec.ts
+++ b/spec/v2/providers/pubsub.spec.ts
@@ -12,9 +12,12 @@ const EVENT_TRIGGER = {
 
 const ENDPOINT_EVENT_TRIGGER = {
   eventType: 'google.cloud.pubsub.topic.v1.messagePublished',
-  eventFilters: {
-    topic: 'topic',
-  },
+  eventFilters: [
+    {
+      attribute: 'topic',
+      value: 'topic',
+    },
+  ],
   retry: false,
 };
 

--- a/spec/v2/providers/storage.spec.ts
+++ b/spec/v2/providers/storage.spec.ts
@@ -12,9 +12,12 @@ const EVENT_TRIGGER = {
 
 const ENDPOINT_EVENT_TRIGGER = {
   eventType: 'event-type',
-  eventFilters: {
-    bucket: 'some-bucket',
-  },
+  eventFilters: [
+    {
+      attribute: 'bucket',
+      value: 'some-bucket',
+    },
+  ],
   retry: false,
 };
 
@@ -116,9 +119,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_EVENT_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -268,9 +274,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_ARCHIVED_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
       });
     });
@@ -292,9 +301,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_ARCHIVED_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
       });
     });
@@ -320,9 +332,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_ARCHIVED_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -348,9 +363,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_ARCHIVED_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -395,9 +413,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_FINALIZED_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
       });
     });
@@ -419,9 +440,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_FINALIZED_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
       });
     });
@@ -447,9 +471,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_FINALIZED_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -478,9 +505,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_FINALIZED_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -525,9 +555,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_DELETED_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
       });
 
@@ -551,9 +584,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_DELETED_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
       });
     });
@@ -579,9 +615,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_DELETED_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -607,9 +646,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_DELETED_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -654,9 +696,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_METADATA_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
       });
 
@@ -680,9 +725,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_METADATA_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
       });
     });
@@ -708,9 +756,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_METADATA_TRIGGER,
-          eventFilters: {
-            bucket: 'my-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'my-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });
@@ -739,9 +790,12 @@ describe('v2/storage', () => {
         labels: {},
         eventTrigger: {
           ...ENDPOINT_METADATA_TRIGGER,
-          eventFilters: {
-            bucket: 'default-bucket',
-          },
+          eventFilters: [
+            {
+              attribute: 'bucket',
+              value: 'default-bucket',
+            },
+          ],
         },
         region: ['us-west1'],
       });

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -461,9 +461,12 @@ export function makeCloudFunction<EventData>({
       } else {
         endpoint.eventTrigger = {
           eventType: legacyEventType || provider + '.' + eventType,
-          eventFilters: {
-            resource: triggerResource(),
-          },
+          eventFilters: [
+            {
+              attribute: 'resource',
+              value: triggerResource(),
+            },
+          ],
           retry: !!options.failurePolicy,
         };
       }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -20,6 +20,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 /**
+ * One or more event filters restrict the set of events delivered to an EventTrigger.
+ */
+interface EventFilter {
+  attribute: string;
+  value: string;
+  // if left unspecified, equality is used.
+  operator?: string;
+}
+
+/**
  * An definition of a function as appears in the Manifest.
  */
 export interface ManifestEndpoint {
@@ -48,12 +58,7 @@ export interface ManifestEndpoint {
   callableTrigger?: {};
 
   eventTrigger?: {
-    eventFilters: Array<{
-      attribute: string;
-      value: string;
-      // if left unspecified, equality is used.
-      operator?: 'match-path-pattern';
-    }>;
+    eventFilters: EventFilter[];
     eventType: string;
     retry: boolean;
     region?: string;

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -48,7 +48,7 @@ export interface ManifestEndpoint {
   callableTrigger?: {};
 
   eventTrigger?: {
-    eventFilters: Record<string, string>;
+    eventFilters: { attribute: string; value: string }[];
     eventType: string;
     retry: boolean;
     region?: string;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -36,10 +36,13 @@ import { ManifestEndpoint } from '../runtime/manifest';
  * List of all regions supported by Cloud Functions v2
  */
 export const SUPPORTED_REGIONS = [
-  'us-west1',
-  'us-central1',
-  'europe-west4',
   'asia-northeast1',
+  'europe-north1',
+  'europe-west1',
+  'europe-west4',
+  'us-central1',
+  'us-east1',
+  'us-west1',
 ] as const;
 
 /**
@@ -71,21 +74,27 @@ export const MAX_CONCURRENCY = 1_000;
  * List of available memory options supported by Cloud Functions.
  */
 export const SUPPORTED_MEMORY_OPTIONS = [
+  '128MB',
   '256MB',
   '512MB',
   '1GB',
   '2GB',
   '4GB',
   '8GB',
+  '16GB',
+  '32GB',
 ] as const;
 
 const MemoryOptionToMB: Record<MemoryOption, number> = {
+  '128MB': 128,
   '256MB': 256,
   '512MB': 512,
   '1GB': 1024,
   '2GB': 2048,
   '4GB': 4096,
   '8GB': 8192,
+  '16GB': 16384,
+  '32GB': 32768,
 };
 
 /**

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -93,7 +93,7 @@ export function getEndpointAnnotation(
       eventType,
       eventFilters: [
         {
-          attribute: 'alertType',
+          attribute: 'alerttype',
           value: alertType,
         },
       ],
@@ -102,7 +102,7 @@ export function getEndpointAnnotation(
   };
   if (appId) {
     endpoint.eventTrigger.eventFilters.push({
-      attribute: 'appId',
+      attribute: 'appid',
       value: appId,
     });
   }

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -91,14 +91,20 @@ export function getEndpointAnnotation(
     },
     eventTrigger: {
       eventType,
-      eventFilters: {
-        alertType,
-      },
+      eventFilters: [
+        {
+          attribute: 'alertType',
+          value: alertType,
+        },
+      ],
       retry: !!opts.retry,
     },
   };
   if (appId) {
-    endpoint.eventTrigger.eventFilters.appId = appId;
+    endpoint.eventTrigger.eventFilters.push({
+      attribute: 'appId',
+      value: appId,
+    });
   }
   return endpoint;
 }

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -174,7 +174,7 @@ export function onMessagePublished<T = any>(
     },
     eventTrigger: {
       eventType: 'google.cloud.pubsub.topic.v1.messagePublished',
-      eventFilters: { topic },
+      eventFilters: [{ attribute: 'topic', value: topic }],
       retry: false,
     },
   };

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -360,9 +360,7 @@ export function onOperation(
         },
         eventTrigger: {
           eventType,
-          eventFilters: {
-            bucket,
-          },
+          eventFilters: [{ attribute: 'bucket', value: bucket }],
           retry: false,
         },
       };


### PR DESCRIPTION
Previously, `eventFilter` attribute was an object:

```
eventTrigger: {
  eventType: "an.event",
  eventFilter: {
    resource: "my-storage-bucket",
    appId: "12345",
  }
}
```

We now prefer eventFilter as a list:

```
eventTrigger: {
  eventType: "an.event",
  eventFilter: [
  {
    attribute: "resource",
    value: "my-storage-bucket",
  }.
  {
    attribute: "appId",
    value: "12345",
  }.
  ]
}
```

Most of the change in this PR is in tests. Few other minor changes I've squeezed in here:

1. Added a changelog entry for https://github.com/firebase/firebase-functions/pull/1037
2. Deleted obsolete src/common/manifest.ts file
3. Small refactoring of alerts/crashlytics spec to make this migration easier.