### PR TITLE
types: support function builder to have typed `context.params` based on `path`

### DIFF
--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -68,7 +68,9 @@ export interface Event {
  * - Authorization of the request that triggered the event, if applicable and
  *   available.
  */
-export interface EventContext {
+export interface EventContext<
+  Params extends Record<string, string> = Record<string, string>
+> {
   /**
    * Authentication information for the user that triggered the function.
    * This object contains `uid` and `token` properties for authenticated users.
@@ -130,7 +132,7 @@ export interface EventContext {
    * provided to the [`ref()`](providers_database_.html#ref) method for a Realtime
    * Database trigger. Cannot be accessed while inside the handler namespace.
    */
-  params: { [option: string]: any };
+  params: Params;
 
   /**
    * The resource that emitted the event. Valid values are:

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -295,10 +295,10 @@ export function runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
     return new FunctionBuilder(runtimeOptions);
   }
 }
-
+  
 type ExtractParams<T> = T extends `${infer Pre}{${infer A}}${infer Post}`
   ? { [K in A]: string } & ExtractParams<Pre> & ExtractParams<Post>
-  : {};
+  : string extends T ? Record<string,string> :  {};
 
 export class FunctionBuilder {
   constructor(private options: DeploymentOptions) {}

--- a/src/function-builder.ts
+++ b/src/function-builder.ts
@@ -296,6 +296,10 @@ export function runWith(runtimeOptions: RuntimeOptions): FunctionBuilder {
   }
 }
 
+type ExtractParams<T> = T extends `${infer Pre}{${infer A}}${infer Post}`
+  ? { [K in A]: string } & ExtractParams<Pre> & ExtractParams<Post>
+  : {};
+
 export class FunctionBuilder {
   constructor(private options: DeploymentOptions) {}
 
@@ -427,8 +431,13 @@ export class FunctionBuilder {
        * collection is named "users" and the document is named "Ada", then the
        * path is "/users/Ada".
        */
-      document: (path: string) =>
-        firestore._documentWithOptions(path, this.options),
+
+      
+      document: <T extends string>(path: T) =>
+        firestore._documentWithOptions<ExtractParams<T>>(
+          path,
+          this.options
+        ),
 
       /** @hidden */
       namespace: (namespace: string) =>


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

Support for better typescript when using FunctionBuilder, allowing to resolve the `context.params` based on the `path` and allow passing the type to `onCreate`, etc on `firebase`.

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
```ts
declare function expect<T>(a: T) :void

region("europe-west3")
.firestore
.document('test/{id}/{collection}/{childId}')
.onCreate<{ myDoc: number }>((snap, context)=> {
  expect<number>(snap.data().myDoc)
  // @ts-expect-error doesn't exist
  snap.data().error
  expect<{
    id: string,
    collection: string,
    childId:string
  }>(context.params)

  // @ts-expect-error doesn't exist
  context.params.error
})

```
<img width="288" alt="image" src="https://user-images.githubusercontent.com/4620458/159033278-e115ed3b-0a7f-446b-9ba8-84d000d3836e.png">


## NOTES
This only applies to the `firestore` but we can support the other ones. 

- it would be nice to have types test in place (eg: https://github.com/vuejs/core/tree/main/test-dts)
- This should be backwards compatible and the only errors is when params are defined but the wrong param is accessed 
