### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -437,7 +437,7 @@ function isValidRequest(req: Request): req is HttpRequest {
   // If it has a charset, just ignore it for now.
   const semiColon = contentType.indexOf(';');
   if (semiColon >= 0) {
-    contentType = contentType.substr(0, semiColon).trim();
+    contentType = contentType.slice(0, semiColon).trim();
   }
   if (contentType !== 'application/json') {
     logger.warn('Request has incorrect Content-Type.', contentType);


### PR DESCRIPTION
### Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
