### PR TITLE
Require auth token but skip verification for tasks queue functions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Improve authorization for tasks. (#1073)

--- a/spec/v1/providers/tasks.spec.ts
+++ b/spec/v1/providers/tasks.spec.ts
@@ -146,6 +146,7 @@ describe('#onDispatch', () => {
       },
       {
         'content-type': 'application/json',
+        authorization: 'Bearer abc',
       }
     );
     req.method = 'POST';

--- a/spec/v2/providers/tasks.spec.ts
+++ b/spec/v2/providers/tasks.spec.ts
@@ -149,16 +149,9 @@ describe('onTaskDispatched', () => {
   });
 
   it('has a .run method', async () => {
-    const request: any = {
-      data: 'data',
-      auth: {
-        uid: 'abc',
-        token: 'token',
-      },
-    };
+    const request: any = { data: 'data' };
     const cf = onTaskDispatched((r) => {
       expect(r.data).to.deep.equal(request.data);
-      expect(r.auth).to.deep.equal(request.auth);
     });
 
     await cf.run(request);
@@ -173,6 +166,7 @@ describe('onTaskDispatched', () => {
       },
       {
         'content-type': 'application/json',
+        authorization: 'Bearer abc',
         origin: 'example.com',
       }
     );

--- a/src/common/providers/tasks.ts
+++ b/src/common/providers/tasks.ts
@@ -110,12 +110,20 @@ export function onDispatchHandler<Req = any>(
         throw new https.HttpsError('invalid-argument', 'Bad Request');
       }
 
-      const context: TaskContext = {};
-      const status = await https.checkAuthToken(req, context);
+      const authHeader = req.header('Authorization') || '';
+      const token = authHeader.match(/^Bearer (.*)$/)?.[1];
       // Note: this should never happen since task queue functions are guarded by IAM.
-      if (status === 'INVALID') {
+      if (!token) {
         throw new https.HttpsError('unauthenticated', 'Unauthenticated');
       }
+      // We skip authenticating the token since tq functions are guarded by IAM.
+      const authToken = await https.unsafeDecodeIdToken(token);
+      const context: TaskContext = {
+        auth: {
+          uid: authToken.uid,
+          token: authToken,
+        },
+      };
 
       const data: Req = https.decode(req.body.data);
       if (handler.length === 2) {


### PR DESCRIPTION
Previously, we allowed TQ functions to either:

1) Not have any auth token
2) Have admin SDK verified auth tokens.

Since TQ functions are guarded by IAM, we instead implement the following behavior:

1) MUST have auth token
2) Do not verify auth token - instead we just decode it and pass it to the handler