### PR TITLE
Update types for AlertPayloads

### DIFF
--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -7,7 +7,7 @@ import * as options from '../../options';
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface PlanUpdatePayload {
-  ['@type']: 'com.google.firebase.firebasealerts.PlanUpdatePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.PlanUpdatePayload';
   billingPlan: string;
   principalEmail: string;
 }
@@ -17,7 +17,7 @@ export interface PlanUpdatePayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface PlanAutomatedUpdatePayload {
-  ['@type']: 'com.google.firebase.firebasealerts.PlanAutomatedUpdatePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.PlanAutomatedUpdatePayload';
   billingPlan: string;
 }
 

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -7,7 +7,7 @@ import * as options from '../../options';
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface PlanUpdatePayload {
-  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.PlanUpdatePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.BillingPlanUpdatePayload';
   billingPlan: string;
   principalEmail: string;
 }
@@ -17,7 +17,7 @@ export interface PlanUpdatePayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface PlanAutomatedUpdatePayload {
-  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.PlanAutomatedUpdatePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.BillingPlanAutomatedUpdatePayload';
   billingPlan: string;
 }
 

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -15,7 +15,7 @@ interface Issue {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface NewFatalIssuePayload {
-  ['@type']: 'com.google.firebase.firebasealerts.CrashlyticsNewFatalIssuePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.CrashlyticsNewFatalIssuePayload';
   issue: Issue;
 }
 
@@ -24,7 +24,7 @@ export interface NewFatalIssuePayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface NewNonfatalIssuePayload {
-  ['@type']: 'com.google.firebase.firebasealerts.CrashlyticsNewNonfatalIssuePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.CrashlyticsNewNonfatalIssuePayload';
   issue: Issue;
 }
 
@@ -33,7 +33,7 @@ export interface NewNonfatalIssuePayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface RegressionAlertPayload {
-  ['@type']: 'com.google.firebase.firebasealerts.CrashlyticsRegressionAlertPayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.CrashlyticsRegressionAlertPayload';
   type: string;
   issue: Issue;
   resolveTime: string;
@@ -52,7 +52,7 @@ interface TrendingIssueDetails {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface StabilityDigestPayload {
-  ['@type']: 'com.google.firebase.firebasealerts.CrashlyticsStabilityDigestPayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.CrashlyticsStabilityDigestPayload';
   digestDate: string;
   trendingIssues: TrendingIssueDetails[];
 }
@@ -62,7 +62,7 @@ export interface StabilityDigestPayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface VelocityAlertPayload {
-  ['@type']: 'com.google.firebase.firebasealerts.VelocityAlertPayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.VelocityAlertPayload';
   issue: Issue;
   createTime: string;
   crashCount: number;
@@ -75,7 +75,7 @@ export interface VelocityAlertPayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface NewAnrIssuePayload {
-  ['@type']: 'com.google.firebase.firebasealerts.NewAnrIssuePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.NewAnrIssuePayload';
   issue: Issue;
 }
 

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -62,7 +62,7 @@ export interface StabilityDigestPayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface VelocityAlertPayload {
-  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.VelocityAlertPayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.CrashlyticsVelocityAlertPayload';
   issue: Issue;
   createTime: string;
   crashCount: number;
@@ -75,7 +75,7 @@ export interface VelocityAlertPayload {
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface NewAnrIssuePayload {
-  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.NewAnrIssuePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.CrashlyticsNewAnrIssuePayload';
   issue: Issue;
 }
 


### PR DESCRIPTION
This commit updates the typing for the AlertPayloads.

There was a discrepency between the type definitions and what
prod was returning.

From:
com.google.firebase.firebasealerts.*

To
type.googleapis.com/google.events.firebase.firebasealerts.v1.*
