### PR TITLE
Update AppDistribution [@type]

### DIFF
--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -7,7 +7,7 @@ import { FirebaseAlertData, getEndpointAnnotation } from './alerts';
  * Payload is wrapped inside a FirebaseAlertData object.
  */
 export interface NewTesterDevicePayload {
-  ['@type']: 'com.google.firebase.firebasealerts.NewTesterDevicePayload';
+  ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.AppDistroNewTesterIosDevicePayload';
   testerName: string;
   testerEmail: string;
   testerDeviceModelName: string;


### PR DESCRIPTION
This is a short followup to update the App Distribution @type.

[More info here](https://github.com/firebase/firebase-functions/commit/c4f63c719f200dca723771922727b477b2e08eb2)

```
type.googleapis.com/google.events.firebase.firebasealerts.v1.AppDistroNewTesterIosDevicePayload
```
