### PR TITLE
Change type info to be inheritance friendly.

### DIFF
--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -57,7 +57,7 @@ export interface TriggerAnnotation {
  * A CloudEventBase is the base of a cross-platform format for encoding a serverless event.
  * More information can be found in https://github.com/cloudevents/spec
  */
-interface CloudEventBase<T> {
+export interface CloudEvent<T> {
   /** Version of the CloudEvents spec for this event. */
   readonly specversion: '1.0';
 
@@ -78,32 +78,14 @@ interface CloudEventBase<T> {
 
   /** Information about this specific event. */
   data: T;
-
-  /**
-   * A map of template parameter name to value for subject strings.
-   *
-   * This map is only available on some event types that allow templates
-   * in the subject string, such as Firestore. When listening to a document
-   * template "/users/{uid}", an event with subject "/documents/users/1234"
-   * would have a params of {"uid": "1234"}.
-   *
-   * Params are generated inside the firebase-functions SDK and are not
-   * part of the CloudEvents spec nor the payload that a Cloud Function
-   * actually receives.
-   */
-  params?: Record<string, string>;
 }
 
-/**
- * A CloudEvent with custom extension attributes
- */
-export type CloudEvent<T = any, Ext = {}> = CloudEventBase<T> & Ext;
 /** A handler for CloudEvents. */
-export interface CloudFunction<T> {
+export interface CloudFunction<EventType extends CloudEvent<unknown>> {
   (raw: CloudEvent<unknown>): any | Promise<any>;
 
   __trigger?: unknown;
   __endpoint: ManifestEndpoint;
 
-  run(event: CloudEvent<T>): any | Promise<any>;
+  run(event: EventType): any | Promise<any>;
 }

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -14,19 +14,16 @@ export interface NewTesterDevicePayload {
   testerDeviceIdentifier: string;
 }
 
-interface WithAlertTypeAndApp {
+/**
+ * A custom CloudEvent for Firebase Alerts (with custom extension attributes).
+ */
+export interface AppDistributionEvent<T>
+  extends CloudEvent<FirebaseAlertData<T>> {
   /** The type of the alerts that got triggered. */
   alertType: string;
   /** The Firebase App ID that’s associated with the alert. */
   appId: string;
 }
-/**
- * A custom CloudEvent for Firebase Alerts (with custom extension attributes).
- */
-export type AppDistributionEvent<T> = CloudEvent<
-  FirebaseAlertData<T>,
-  WithAlertTypeAndApp
->;
 
 /** @internal */
 export const newTesterIosDeviceAlert = 'appDistribution.newTesterIosDevice';
@@ -45,19 +42,19 @@ export function onNewTesterIosDevicePublished(
   handler: (
     event: AppDistributionEvent<NewTesterDevicePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewTesterDevicePayload>>;
+): CloudFunction<AppDistributionEvent<NewTesterDevicePayload>>;
 export function onNewTesterIosDevicePublished(
   appId: string,
   handler: (
     event: AppDistributionEvent<NewTesterDevicePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewTesterDevicePayload>>;
+): CloudFunction<AppDistributionEvent<NewTesterDevicePayload>>;
 export function onNewTesterIosDevicePublished(
   opts: AppDistributionOptions,
   handler: (
     event: AppDistributionEvent<NewTesterDevicePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewTesterDevicePayload>>;
+): CloudFunction<AppDistributionEvent<NewTesterDevicePayload>>;
 export function onNewTesterIosDevicePublished(
   appIdOrOptsOrHandler:
     | string
@@ -68,7 +65,7 @@ export function onNewTesterIosDevicePublished(
   handler?: (
     event: AppDistributionEvent<NewTesterDevicePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewTesterDevicePayload>> {
+): CloudFunction<AppDistributionEvent<NewTesterDevicePayload>> {
   if (typeof appIdOrOptsOrHandler === 'function') {
     handler = appIdOrOptsOrHandler as (
       event: AppDistributionEvent<NewTesterDevicePayload>

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -28,14 +28,13 @@ export interface PlanAutomatedUpdatePayload {
   notificationType: string;
 }
 
-interface WithAlertType {
-  /** The type of the alerts that got triggered. */
-  alertType: string;
-}
 /**
  * A custom CloudEvent for billing Firebase Alerts (with custom extension attributes).
  */
-export type BillingEvent<T> = CloudEvent<FirebaseAlertData<T>, WithAlertType>;
+export interface BillingEvent<T> extends CloudEvent<FirebaseAlertData<T>> {
+  /** The type of the alerts that got triggered. */
+  alertType: string;
+}
 
 /** @internal */
 export const planUpdateAlert = 'billing.planUpdate';
@@ -47,17 +46,17 @@ export const planAutomatedUpdateAlert = 'billing.planAutomatedUpdate';
  */
 export function onPlanUpdatePublished(
   handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
+): CloudFunction<BillingEvent<PlanUpdatePayload>>;
 export function onPlanUpdatePublished(
   opts: options.EventHandlerOptions,
   handler: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<PlanUpdatePayload>>;
+): CloudFunction<BillingEvent<PlanUpdatePayload>>;
 export function onPlanUpdatePublished(
   optsOrHandler:
     | options.EventHandlerOptions
     | ((event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>),
   handler?: (event: BillingEvent<PlanUpdatePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<PlanUpdatePayload>> {
+): CloudFunction<BillingEvent<PlanUpdatePayload>> {
   return onOperation<PlanUpdatePayload>(
     planUpdateAlert,
     optsOrHandler,
@@ -72,13 +71,13 @@ export function onPlanAutomatedUpdatePublished(
   handler: (
     event: BillingEvent<PlanAutomatedUpdatePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
+): CloudFunction<BillingEvent<PlanAutomatedUpdatePayload>>;
 export function onPlanAutomatedUpdatePublished(
   opts: options.EventHandlerOptions,
   handler: (
     event: BillingEvent<PlanAutomatedUpdatePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>>;
+): CloudFunction<BillingEvent<PlanAutomatedUpdatePayload>>;
 export function onPlanAutomatedUpdatePublished(
   optsOrHandler:
     | options.EventHandlerOptions
@@ -86,7 +85,7 @@ export function onPlanAutomatedUpdatePublished(
   handler?: (
     event: BillingEvent<PlanAutomatedUpdatePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<PlanAutomatedUpdatePayload>> {
+): CloudFunction<BillingEvent<PlanAutomatedUpdatePayload>> {
   return onOperation<PlanAutomatedUpdatePayload>(
     planAutomatedUpdateAlert,
     optsOrHandler,
@@ -101,7 +100,7 @@ export function onOperation<T>(
     | options.EventHandlerOptions
     | ((event: BillingEvent<T>) => any | Promise<any>),
   handler: (event: BillingEvent<T>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<T>> {
+): CloudFunction<BillingEvent<T>> {
   if (typeof optsOrHandler === 'function') {
     handler = optsOrHandler as (event: BillingEvent<T>) => any | Promise<any>;
     optsOrHandler = {};

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -111,19 +111,15 @@ export interface NewAnrIssuePayload {
   issue: Issue;
 }
 
-interface WithAlertTypeAndApp {
+/**
+ * A custom CloudEvent for Firebase Alerts (with custom extension attributes).
+ */
+export interface CrashlyticsEvent<T> extends CloudEvent<FirebaseAlertData<T>> {
   /** The type of the alerts that got triggered. */
   alertType: string;
   /** The Firebase App ID that’s associated with the alert. */
   appId: string;
 }
-/**
- * A custom CloudEvent for Firebase Alerts (with custom extension attributes).
- */
-export type CrashlyticsEvent<T> = CloudEvent<
-  FirebaseAlertData<T>,
-  WithAlertTypeAndApp
->;
 
 /** @internal */
 export const newFatalIssueAlert = 'crashlytics.newFatalIssue';
@@ -150,15 +146,15 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
  */
 export function onNewFatalIssuePublished(
   handler: (event: CrashlyticsEvent<NewFatalIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewFatalIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewFatalIssuePayload>>;
 export function onNewFatalIssuePublished(
   appId: string,
   handler: (event: CrashlyticsEvent<NewFatalIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewFatalIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewFatalIssuePayload>>;
 export function onNewFatalIssuePublished(
   opts: CrashlyticsOptions,
   handler: (event: CrashlyticsEvent<NewFatalIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewFatalIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewFatalIssuePayload>>;
 export function onNewFatalIssuePublished(
   appIdOrOptsOrHandler:
     | string
@@ -167,7 +163,7 @@ export function onNewFatalIssuePublished(
   handler?: (
     event: CrashlyticsEvent<NewFatalIssuePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewFatalIssuePayload>> {
+): CloudFunction<CrashlyticsEvent<NewFatalIssuePayload>> {
   return onOperation<NewFatalIssuePayload>(
     newFatalIssueAlert,
     appIdOrOptsOrHandler,
@@ -182,19 +178,19 @@ export function onNewNonfatalIssuePublished(
   handler: (
     event: CrashlyticsEvent<NewNonfatalIssuePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewNonfatalIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewNonfatalIssuePayload>>;
 export function onNewNonfatalIssuePublished(
   appId: string,
   handler: (
     event: CrashlyticsEvent<NewNonfatalIssuePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewNonfatalIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewNonfatalIssuePayload>>;
 export function onNewNonfatalIssuePublished(
   opts: CrashlyticsOptions,
   handler: (
     event: CrashlyticsEvent<NewNonfatalIssuePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewNonfatalIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewNonfatalIssuePayload>>;
 export function onNewNonfatalIssuePublished(
   appIdOrOptsOrHandler:
     | string
@@ -205,7 +201,7 @@ export function onNewNonfatalIssuePublished(
   handler?: (
     event: CrashlyticsEvent<NewNonfatalIssuePayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewNonfatalIssuePayload>> {
+): CloudFunction<CrashlyticsEvent<NewNonfatalIssuePayload>> {
   return onOperation<NewNonfatalIssuePayload>(
     newNonfatalIssueAlert,
     appIdOrOptsOrHandler,
@@ -220,19 +216,19 @@ export function onRegressionAlertPublished(
   handler: (
     event: CrashlyticsEvent<RegressionAlertPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<RegressionAlertPayload>>;
+): CloudFunction<CrashlyticsEvent<RegressionAlertPayload>>;
 export function onRegressionAlertPublished(
   appId: string,
   handler: (
     event: CrashlyticsEvent<RegressionAlertPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<RegressionAlertPayload>>;
+): CloudFunction<CrashlyticsEvent<RegressionAlertPayload>>;
 export function onRegressionAlertPublished(
   opts: CrashlyticsOptions,
   handler: (
     event: CrashlyticsEvent<RegressionAlertPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<RegressionAlertPayload>>;
+): CloudFunction<CrashlyticsEvent<RegressionAlertPayload>>;
 export function onRegressionAlertPublished(
   appIdOrOptsOrHandler:
     | string
@@ -241,7 +237,7 @@ export function onRegressionAlertPublished(
   handler?: (
     event: CrashlyticsEvent<RegressionAlertPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<RegressionAlertPayload>> {
+): CloudFunction<CrashlyticsEvent<RegressionAlertPayload>> {
   return onOperation<RegressionAlertPayload>(
     regressionAlert,
     appIdOrOptsOrHandler,
@@ -256,19 +252,19 @@ export function onStabilityDigestPublished(
   handler: (
     event: CrashlyticsEvent<StabilityDigestPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<StabilityDigestPayload>>;
+): CloudFunction<CrashlyticsEvent<StabilityDigestPayload>>;
 export function onStabilityDigestPublished(
   appId: string,
   handler: (
     event: CrashlyticsEvent<StabilityDigestPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<StabilityDigestPayload>>;
+): CloudFunction<CrashlyticsEvent<StabilityDigestPayload>>;
 export function onStabilityDigestPublished(
   opts: CrashlyticsOptions,
   handler: (
     event: CrashlyticsEvent<StabilityDigestPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<StabilityDigestPayload>>;
+): CloudFunction<CrashlyticsEvent<StabilityDigestPayload>>;
 export function onStabilityDigestPublished(
   appIdOrOptsOrHandler:
     | string
@@ -277,7 +273,7 @@ export function onStabilityDigestPublished(
   handler?: (
     event: CrashlyticsEvent<StabilityDigestPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<StabilityDigestPayload>> {
+): CloudFunction<CrashlyticsEvent<StabilityDigestPayload>> {
   return onOperation<StabilityDigestPayload>(
     stabilityDigestAlert,
     appIdOrOptsOrHandler,
@@ -290,15 +286,15 @@ export function onStabilityDigestPublished(
  */
 export function onVelocityAlertPublished(
   handler: (event: CrashlyticsEvent<VelocityAlertPayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<VelocityAlertPayload>>;
+): CloudFunction<CrashlyticsEvent<VelocityAlertPayload>>;
 export function onVelocityAlertPublished(
   appId: string,
   handler: (event: CrashlyticsEvent<VelocityAlertPayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<VelocityAlertPayload>>;
+): CloudFunction<CrashlyticsEvent<VelocityAlertPayload>>;
 export function onVelocityAlertPublished(
   opts: CrashlyticsOptions,
   handler: (event: CrashlyticsEvent<VelocityAlertPayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<VelocityAlertPayload>>;
+): CloudFunction<CrashlyticsEvent<VelocityAlertPayload>>;
 export function onVelocityAlertPublished(
   appIdOrOptsOrHandler:
     | string
@@ -307,7 +303,7 @@ export function onVelocityAlertPublished(
   handler?: (
     event: CrashlyticsEvent<VelocityAlertPayload>
   ) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<VelocityAlertPayload>> {
+): CloudFunction<CrashlyticsEvent<VelocityAlertPayload>> {
   return onOperation<VelocityAlertPayload>(
     velocityAlert,
     appIdOrOptsOrHandler,
@@ -320,22 +316,22 @@ export function onVelocityAlertPublished(
  */
 export function onNewAnrIssuePublished(
   handler: (event: CrashlyticsEvent<NewAnrIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewAnrIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewAnrIssuePayload>>;
 export function onNewAnrIssuePublished(
   appId: string,
   handler: (event: CrashlyticsEvent<NewAnrIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewAnrIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewAnrIssuePayload>>;
 export function onNewAnrIssuePublished(
   opts: CrashlyticsOptions,
   handler: (event: CrashlyticsEvent<NewAnrIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewAnrIssuePayload>>;
+): CloudFunction<CrashlyticsEvent<NewAnrIssuePayload>>;
 export function onNewAnrIssuePublished(
   appIdOrOptsOrHandler:
     | string
     | CrashlyticsOptions
     | ((event: CrashlyticsEvent<NewAnrIssuePayload>) => any | Promise<any>),
   handler?: (event: CrashlyticsEvent<NewAnrIssuePayload>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<NewAnrIssuePayload>> {
+): CloudFunction<CrashlyticsEvent<NewAnrIssuePayload>> {
   return onOperation<NewAnrIssuePayload>(
     newAnrIssueAlert,
     appIdOrOptsOrHandler,
@@ -351,7 +347,7 @@ export function onOperation<T>(
     | CrashlyticsOptions
     | ((event: CrashlyticsEvent<T>) => any | Promise<any>),
   handler: (event: CrashlyticsEvent<T>) => any | Promise<any>
-): CloudFunction<FirebaseAlertData<T>> {
+): CloudFunction<CrashlyticsEvent<T>> {
   if (typeof appIdOrOptsOrHandler === 'function') {
     handler = appIdOrOptsOrHandler as (
       event: CrashlyticsEvent<T>

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -101,18 +101,18 @@ export interface PubSubOptions extends options.EventHandlerOptions {
 export function onMessagePublished<T = any>(
   topic: string,
   handler: (event: CloudEvent<MessagePublishedData<T>>) => any | Promise<any>
-): CloudFunction<MessagePublishedData<T>>;
+): CloudFunction<CloudEvent<MessagePublishedData<T>>>;
 
 /** Handle a message being published to a Pub/Sub topic. */
 export function onMessagePublished<T = any>(
   options: PubSubOptions,
   handler: (event: CloudEvent<MessagePublishedData<T>>) => any | Promise<any>
-): CloudFunction<MessagePublishedData<T>>;
+): CloudFunction<CloudEvent<MessagePublishedData<T>>>;
 
 export function onMessagePublished<T = any>(
   topicOrOptions: string | PubSubOptions,
   handler: (event: CloudEvent<MessagePublishedData<T>>) => any | Promise<any>
-): CloudFunction<MessagePublishedData<T>> {
+): CloudFunction<CloudEvent<MessagePublishedData<T>>> {
   let topic: string;
   let opts: options.EventHandlerOptions;
   if (typeof topicOrOptions === 'string') {

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -174,12 +174,10 @@ export interface CustomerEncryption {
   keySha256?: string;
 }
 
-interface WithBucket {
+export interface StorageEvent extends CloudEvent<StorageObjectData> {
   /** The name of the bucket containing this object. */
   bucket: string;
 }
-
-export type StorageEvent = CloudEvent<StorageObjectData, WithBucket>;
 
 /** @internal */
 export const archivedEvent = 'google.cloud.storage.object.v1.archived';
@@ -199,17 +197,17 @@ export interface StorageOptions extends options.EventHandlerOptions {
 /** Handle a storage object archived */
 export function onObjectArchived(
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectArchived(
   bucket: string,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectArchived(
   opts: StorageOptions,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectArchived(
   buketOrOptsOrHandler:
@@ -217,24 +215,24 @@ export function onObjectArchived(
     | StorageOptions
     | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData> {
+): CloudFunction<StorageEvent> {
   return onOperation(archivedEvent, buketOrOptsOrHandler, handler);
 }
 
 /** Handle a storage object finalized */
 export function onObjectFinalized(
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectFinalized(
   bucket: string,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectFinalized(
   opts: StorageOptions,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectFinalized(
   buketOrOptsOrHandler:
@@ -242,24 +240,24 @@ export function onObjectFinalized(
     | StorageOptions
     | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData> {
+): CloudFunction<StorageEvent> {
   return onOperation(finalizedEvent, buketOrOptsOrHandler, handler);
 }
 
 /** Handle a storage object deleted */
 export function onObjectDeleted(
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectDeleted(
   bucket: string,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectDeleted(
   opts: StorageOptions,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectDeleted(
   buketOrOptsOrHandler:
@@ -267,24 +265,24 @@ export function onObjectDeleted(
     | StorageOptions
     | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData> {
+): CloudFunction<StorageEvent> {
   return onOperation(deletedEvent, buketOrOptsOrHandler, handler);
 }
 
 /** Handle a storage object metadata updated */
 export function onObjectMetadataUpdated(
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectMetadataUpdated(
   bucket: string,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectMetadataUpdated(
   opts: StorageOptions,
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData>;
+): CloudFunction<StorageEvent>;
 
 export function onObjectMetadataUpdated(
   buketOrOptsOrHandler:
@@ -292,7 +290,7 @@ export function onObjectMetadataUpdated(
     | StorageOptions
     | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData> {
+): CloudFunction<StorageEvent> {
   return onOperation(metadataUpdatedEvent, buketOrOptsOrHandler, handler);
 }
 
@@ -304,7 +302,7 @@ export function onOperation(
     | StorageOptions
     | ((event: StorageEvent) => any | Promise<any>),
   handler: (event: StorageEvent) => any | Promise<any>
-): CloudFunction<StorageObjectData> {
+): CloudFunction<StorageEvent> {
   if (typeof bucketOrOptsOrHandler === 'function') {
     handler = bucketOrOptsOrHandler as (
       event: StorageEvent


### PR DESCRIPTION
Unwind the cleverness of CloudEvent<EventType, Extensions>. Types
now match the approved format of the Python API. CloudFunction now
templatizes the CloudEvent rather than the EventType so that we can
keep typing to include subtypes of events both in code complete and
in firebase-functions-test.

CC @TheIronDev since this affects firebase-functions-test