### PR TITLE
Remove all errors when generating reference doc using api-extractor

### DIFF
--- a/docgen/api-extractor.v2.json
+++ b/docgen/api-extractor.v2.json
@@ -10,5 +10,25 @@
     "enabled": true,
     "reportTempFolder": "<projectFolder>/docgen/v2/temp",
     "reportFolder": "<projectFolder>/docgen/v2"
+  },
+  "messages": {
+    "compilerMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+      }
+    },
+    "extractorMessageReporting": {
+      "default": {
+        "logLevel": "warning"
+      },
+      "ae-missing-release-tag": {
+        "logLevel": "none"
+      }
+    },
+    "tsdocMessageReporting": {
+      "default": {
+        "logLevel": "error"
+      }
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,10 +61,120 @@
         "tslib": "^2.1.0"
       },
       "dependencies": {
+        "@microsoft/tsdoc": {
+          "version": "0.12.24",
+          "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz",
+          "integrity": "sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==",
+          "dev": true
+        },
+        "@rushstack/node-core-library": {
+          "version": "3.36.0",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.0.tgz",
+          "integrity": "sha512-bID2vzXpg8zweXdXgQkKToEdZwVrVCN9vE9viTRk58gqzYaTlz4fMId6V3ZfpXN6H0d319uGi2KDlm+lUEeqCg==",
+          "dev": true,
+          "requires": {
+            "@types/node": "10.17.13",
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.17.0",
+            "semver": "~7.3.0",
+            "timsort": "~0.3.0",
+            "z-schema": "~3.18.3"
+          }
+        },
+        "@rushstack/ts-command-line": {
+          "version": "4.7.8",
+          "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.8.tgz",
+          "integrity": "sha512-8ghIWhkph7NnLCMDJtthpsb7TMOsVGXVDvmxjE/CeklTqjbbUFBjGXizJfpbEkRQTELuZQ2+vGn7sGwIWKN2uA==",
+          "dev": true,
+          "requires": {
+            "@types/argparse": "1.0.38",
+            "argparse": "~1.0.9",
+            "colors": "~1.2.1",
+            "string-argv": "~0.3.1"
+          },
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.10",
+              "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+              "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+              "dev": true,
+              "requires": {
+                "sprintf-js": "~1.0.2"
+              }
+            }
+          }
+        },
+        "@types/argparse": {
+          "version": "1.0.38",
+          "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
+          "integrity": "sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==",
+          "dev": true
+        },
+        "@types/node": {
+          "version": "10.17.13",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
+          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
+          "dev": true
+        },
+        "api-extractor-model-me": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/api-extractor-model-me/-/api-extractor-model-me-0.1.1.tgz",
+          "integrity": "sha512-Ez801ZMADfkseOWNRFquvyQYDm3D9McpxfkKMWL6JFCGcpub0miJ+TFNphIR1nSZbrsxz3kIeOovNMY4VlL6Bw==",
+          "dev": true,
+          "requires": {
+            "@microsoft/tsdoc": "0.12.24",
+            "@rushstack/node-core-library": "3.36.0"
+          }
+        },
         "argparse": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
           "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "colors": {
+          "version": "1.2.5",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
+          "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.2.10",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
+          "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+          "dev": true
+        },
+        "import-lazy": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+          "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+          "dev": true
+        },
+        "jju": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
+          "integrity": "sha1-o6vicYryQaKykE+EpiWXDzia4yo=",
           "dev": true
         },
         "js-yaml": {
@@ -76,6 +186,42 @@
             "argparse": "^2.0.1"
           }
         },
+        "jsonfile": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "lodash.get": {
+          "version": "4.4.2",
+          "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+          "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+          "dev": true
+        },
+        "lodash.isequal": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+          "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+          "dev": true
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "path-parse": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+          "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+          "dev": true
+        },
         "resolve": {
           "version": "1.17.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
@@ -83,6 +229,69 @@
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "sprintf-js": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+          "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+          "dev": true
+        },
+        "string-argv": {
+          "version": "0.3.1",
+          "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
+          "integrity": "sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==",
+          "dev": true
+        },
+        "timsort": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
+          "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
+          "dev": true
+        },
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+          "dev": true
+        },
+        "universalify": {
+          "version": "0.1.2",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+          "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+          "dev": true
+        },
+        "validator": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
+          "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
+        },
+        "z-schema": {
+          "version": "3.18.4",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
+          "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.7.1",
+            "lodash.get": "^4.0.0",
+            "lodash.isequal": "^4.0.0",
+            "validator": "^8.0.0"
           }
         }
       }
@@ -552,12 +761,6 @@
         }
       }
     },
-    "@microsoft/tsdoc": {
-      "version": "0.12.24",
-      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.12.24.tgz",
-      "integrity": "sha512-Mfmij13RUTmHEMi9vRUhMXD7rnGR2VvxeNYtaGtaJ4redwwjT4UXYJ+nzmVJF7hhd4pn/Fx5sncDKxMVFJSWPg==",
-      "dev": true
-    },
     "@microsoft/tsdoc-config": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/@microsoft/tsdoc-config/-/tsdoc-config-0.16.1.tgz",
@@ -668,40 +871,6 @@
       "dev": true,
       "optional": true
     },
-    "@rushstack/node-core-library": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.36.0.tgz",
-      "integrity": "sha512-bID2vzXpg8zweXdXgQkKToEdZwVrVCN9vE9viTRk58gqzYaTlz4fMId6V3ZfpXN6H0d319uGi2KDlm+lUEeqCg==",
-      "dev": true,
-      "requires": {
-        "@types/node": "10.17.13",
-        "colors": "~1.2.1",
-        "fs-extra": "~7.0.1",
-        "import-lazy": "~4.0.0",
-        "jju": "~1.4.0",
-        "resolve": "~1.17.0",
-        "semver": "~7.3.0",
-        "timsort": "~0.3.0",
-        "z-schema": "~3.18.3"
-      },
-      "dependencies": {
-        "@types/node": {
-          "version": "10.17.13",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.13.tgz",
-          "integrity": "sha512-pMCcqU2zT4TjqYFrWtYHKal7Sl30Ims6ulZ4UFXxI4xbtQqK/qqKwkDoBFCfooRqqmRu9vY3xaJRwxSh673aYg==",
-          "dev": true
-        },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.6"
-          }
-        }
-      }
-    },
     "@rushstack/rig-package": {
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/@rushstack/rig-package/-/rig-package-0.3.11.tgz",
@@ -727,18 +896,6 @@
           "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
           "dev": true
         }
-      }
-    },
-    "@rushstack/ts-command-line": {
-      "version": "4.7.8",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.7.8.tgz",
-      "integrity": "sha512-8ghIWhkph7NnLCMDJtthpsb7TMOsVGXVDvmxjE/CeklTqjbbUFBjGXizJfpbEkRQTELuZQ2+vGn7sGwIWKN2uA==",
-      "dev": true,
-      "requires": {
-        "@types/argparse": "1.0.38",
-        "argparse": "~1.0.9",
-        "colors": "~1.2.1",
-        "string-argv": "~0.3.1"
       }
     },
     "@sinonjs/commons": {
@@ -1128,16 +1285,6 @@
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
       "dev": true
-    },
-    "api-extractor-model-me": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/api-extractor-model-me/-/api-extractor-model-me-0.1.1.tgz",
-      "integrity": "sha512-Ez801ZMADfkseOWNRFquvyQYDm3D9McpxfkKMWL6JFCGcpub0miJ+TFNphIR1nSZbrsxz3kIeOovNMY4VlL6Bw==",
-      "dev": true,
-      "requires": {
-        "@microsoft/tsdoc": "0.12.24",
-        "@rushstack/node-core-library": "3.36.0"
-      }
     },
     "arg": {
       "version": "4.1.3",
@@ -2290,19 +2437,6 @@
         "jws": "^4.0.0"
       }
     },
-    "handlebars": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.7.tgz",
-      "integrity": "sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5",
-        "neo-async": "^2.6.0",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4",
-        "wordwrap": "^1.0.0"
-      }
-    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -3180,9 +3314,9 @@
       "dev": true
     },
     "marked": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
-      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+      "version": "4.0.15",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.15.tgz",
+      "integrity": "sha512-esX5lPdTfG4p8LDkv+obbRCyOKzB+820ZZyMOXJZygZBHrH9b3xXR64X4kT3sPe9Nx8qQXbmcz6kFSMt4Nfk6Q==",
       "dev": true
     },
     "media-typer": {
@@ -3468,12 +3602,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
-    },
-    "neo-async": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-      "dev": true
     },
     "nise": {
       "version": "1.5.3",
@@ -3813,12 +3941,6 @@
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
       "dev": true
     },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true
-    },
     "promise-polyfill": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-6.1.0.tgz",
@@ -4130,9 +4252,9 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "shiki": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
-      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.10.1.tgz",
+      "integrity": "sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==",
       "dev": true,
       "requires": {
         "jsonc-parser": "^3.0.0",
@@ -4564,20 +4686,16 @@
       }
     },
     "typedoc": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.21.2.tgz",
-      "integrity": "sha512-SR1ByJB3USg+jxoxwzMRP07g/0f/cQUE5t7gOh1iTUyjTPyJohu9YSKRlK+MSXXqlhIq+m0jkEHEG5HoY7/Adg==",
+      "version": "0.22.15",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.15.tgz",
+      "integrity": "sha512-CMd1lrqQbFvbx6S9G6fL4HKp3GoIuhujJReWqlIvSb2T26vGai+8Os3Mde7Pn832pXYemd9BMuuYWhFpL5st0Q==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.7",
-        "handlebars": "^4.7.7",
-        "lodash": "^4.17.21",
+        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^2.1.1",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "shiki": "^0.9.3",
-        "typedoc-default-themes": "^0.12.10"
+        "marked": "^4.0.12",
+        "minimatch": "^5.0.1",
+        "shiki": "^0.10.1"
       },
       "dependencies": {
         "glob": {
@@ -4592,28 +4710,46 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
+          },
+          "dependencies": {
+            "minimatch": {
+              "version": "3.1.2",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+              "dev": true,
+              "requires": {
+                "brace-expansion": "^1.1.7"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          },
+          "dependencies": {
+            "brace-expansion": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+              "dev": true,
+              "requires": {
+                "balanced-match": "^1.0.0"
+              }
+            }
           }
         }
       }
-    },
-    "typedoc-default-themes": {
-      "version": "0.12.10",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.12.10.tgz",
-      "integrity": "sha512-fIS001cAYHkyQPidWXmHuhs8usjP5XVJjWB8oZGqkTowZaz3v7g3KDZeeqE82FBrmkAnIBOY3jgy7lnPnqATbA==",
-      "dev": true
     },
     "typescript": {
       "version": "4.6.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.3.tgz",
       "integrity": "sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.15.4",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.15.4.tgz",
-      "integrity": "sha512-vMOPGDuvXecPs34V74qDKk4iJ/SN4vL3Ow/23ixafENYvtrNvtbcgUeugTcUGRGsOF/5fU8/NYSL5Hyb3l1OJA==",
-      "dev": true,
-      "optional": true
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -4680,12 +4816,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
-    },
-    "validator": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-      "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA==",
       "dev": true
     },
     "vary": {
@@ -4843,12 +4973,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-      "dev": true
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
       "dev": true
     },
     "wrap-ansi": {
@@ -5172,18 +5296,6 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "optional": true
-    },
-    "z-schema": {
-      "version": "3.18.4",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.18.4.tgz",
-      "integrity": "sha512-DUOKC/IhbkdLKKiV89gw9DUauTV8U/8yJl1sjf6MtDmzevLKOF2duNJ495S3MFVjqZarr+qNGCPbkg4mu4PpLw==",
-      "dev": true,
-      "requires": {
-        "commander": "^2.7.1",
-        "lodash.get": "^4.0.0",
-        "lodash.isequal": "^4.0.0",
-        "validator": "^8.0.0"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
     "mock-require": "^3.0.3",
     "mz": "^2.7.0",
     "nock": "^10.0.6",
-    "node-fetch": "^2.6.7",
     "portfinder": "^1.0.28",
     "prettier": "^1.18.2",
     "semver": "^7.3.5",
@@ -218,7 +217,7 @@
     "tslint-config-prettier": "^1.18.0",
     "tslint-no-unused-expression-chai": "^0.1.4",
     "tslint-plugin-prettier": "^2.0.1",
-    "typedoc": "0.21.2",
+    "typedoc": "^0.22.15",
     "typescript": "^4.3.5",
     "yargs": "^15.3.1"
   },

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -260,8 +260,6 @@ export interface Resource {
 /**
  * TriggerAnnotated is used internally by the firebase CLI to understand what
  * type of Cloud Function to deploy.
- *
- * @internal
  */
 export interface TriggerAnnotated {
   __trigger: {
@@ -292,7 +290,6 @@ export interface TriggerAnnotated {
 }
 
 /**
- * @internal
  * EndpointAnnotated is used to generate the manifest that conforms to the container contract.
  */
 export interface EndpointAnnotated {

--- a/src/cloud-functions.ts
+++ b/src/cloud-functions.ts
@@ -39,13 +39,13 @@ import {
 } from './common/encoding';
 import { ManifestEndpoint, ManifestRequiredAPI } from './runtime/manifest';
 
-/** @hidden */
+/* @internal */
 const WILDCARD_REGEX = new RegExp('{[^/{}]*}', 'g');
 
 /**
- * @hidden
- *
  * Wire format for an event.
+ *
+ * @internal
  */
 export interface Event {
   context: {
@@ -181,20 +181,21 @@ export interface ChangeJson {
    */
   before?: any;
   /**
-   * @hidden
    * Comma-separated string that represents names of fields that changed.
+   *
+   * @internal
    */
   fieldMask?: string;
 }
 
 export namespace Change {
-  /** @hidden */
+  /** @internal */
   function reinterpretCast<T>(x: any) {
     return x as T;
   }
 
   /**
-   * @hidden
+   * @internal
    * Factory method for creating a Change from a `before` object and an `after`
    * object.
    */
@@ -203,7 +204,7 @@ export namespace Change {
   }
 
   /**
-   * @hidden
+   * @internal
    * Factory method for creating a Change from a JSON and an optional customizer
    * function to be applied to both the `before` and the `after` fields.
    */
@@ -222,7 +223,7 @@ export namespace Change {
     );
   }
 
-  /** @hidden */
+  /** @internal */
   export function applyFieldMask(
     sparseBefore: any,
     after: any,
@@ -257,9 +258,10 @@ export interface Resource {
 }
 
 /**
- * @hidden
  * TriggerAnnotated is used internally by the firebase CLI to understand what
  * type of Cloud Function to deploy.
+ *
+ * @internal
  */
 export interface TriggerAnnotated {
   __trigger: {
@@ -290,7 +292,7 @@ export interface TriggerAnnotated {
 }
 
 /**
- * @hidden
+ * @internal
  * EndpointAnnotated is used to generate the manifest that conforms to the container contract.
  */
 export interface EndpointAnnotated {
@@ -336,7 +338,7 @@ export type CloudFunction<T> = Runnable<T> &
   EndpointAnnotated &
   ((input: any, context?: any) => PromiseLike<any> | any);
 
-/** @hidden */
+/** @internal */
 export interface MakeCloudFunctionArgs<EventData> {
   after?: (raw: Event) => void;
   before?: (raw: Event) => void;
@@ -356,7 +358,7 @@ export interface MakeCloudFunctionArgs<EventData> {
   triggerResource: () => string;
 }
 
-/** @hidden */
+/** @internal */
 export function makeCloudFunction<EventData>({
   after = () => {},
   before = () => {},
@@ -499,7 +501,7 @@ export function makeCloudFunction<EventData>({
   return cloudFunction;
 }
 
-/** @hidden */
+/** @internal */
 function _makeParams(
   context: EventContext,
   triggerResourceGetter: () => string
@@ -527,7 +529,7 @@ function _makeParams(
   return params;
 }
 
-/** @hidden */
+/** @internal */
 function _makeAuth(event: Event, authType: string) {
   if (authType === 'UNAUTHENTICATED') {
     return null;
@@ -538,7 +540,7 @@ function _makeAuth(event: Event, authType: string) {
   };
 }
 
-/** @hidden */
+/** @internal */
 function _detectAuthType(event: Event) {
   if (_.get(event, 'context.auth.admin')) {
     return 'ADMIN';
@@ -549,7 +551,7 @@ function _detectAuthType(event: Event) {
   return 'UNAUTHENTICATED';
 }
 
-/** @hidden */
+/** @internal */
 export function optionsToTrigger(options: DeploymentOptions) {
   const trigger: any = {};
   copyIfPresent(

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -34,7 +34,9 @@ import { TaskContext } from './tasks';
 
 const JWT_REGEX = /^[a-zA-Z0-9\-_=]+?\.[a-zA-Z0-9\-_=]+?\.([a-zA-Z0-9\-_=]+)?$/;
 
-/** @hidden */
+/**
+ * Represents incoming request object.
+ */
 export interface Request extends express.Request {
   rawBody: Buffer;
 }
@@ -228,7 +230,9 @@ export type FunctionsErrorCode =
   | 'data-loss'
   | 'unauthenticated';
 
-/** @hidden */
+/**
+ * Canonical name of HTTP status.
+ */
 export type CanonicalErrorCodeName =
   | 'OK'
   | 'CANCELLED'
@@ -248,7 +252,6 @@ export type CanonicalErrorCodeName =
   | 'UNAVAILABLE'
   | 'DATA_LOSS';
 
-/** @hidden */
 interface HttpErrorCode {
   canonicalName: CanonicalErrorCodeName;
   status: number;
@@ -283,7 +286,6 @@ const errorCodeMap: { [name in FunctionsErrorCode]: HttpErrorCode } = {
   'data-loss': { canonicalName: 'DATA_LOSS', status: 500 },
 };
 
-/** @hidden */
 interface HttpErrorWireFormat {
   details?: unknown;
   message: string;
@@ -309,7 +311,7 @@ export class HttpsError extends Error {
   /**
    * A wire format representation of a provided error code.
    *
-   * @hidden
+   * @internal
    */
   public readonly httpErrorCode: HttpErrorCode;
 
@@ -341,7 +343,6 @@ export class HttpsError extends Error {
   }
 }
 
-/** @hidden */
 // The allowed interface for an HTTP request to a Callable function.
 interface HttpRequest extends Request {
   body: {
@@ -349,15 +350,17 @@ interface HttpRequest extends Request {
   };
 }
 
-/** @hidden */
 // The format for an HTTP body response from a Callable function.
 interface HttpResponseBody {
   result?: any;
   error?: HttpsError;
 }
 
-/** @hidden */
-// Returns true if req is a properly formatted callable request.
+/**
+ * Returns true if req is a properly formatted callable request.
+ *
+ * @internal
+ */
 export function isValidRequest(req: Request): req is HttpRequest {
   // The body must not be empty.
   if (!req.body) {
@@ -400,16 +403,15 @@ export function isValidRequest(req: Request): req is HttpRequest {
   return true;
 }
 
-/** @hidden */
 const LONG_TYPE = 'type.googleapis.com/google.protobuf.Int64Value';
-/** @hidden */
 const UNSIGNED_LONG_TYPE = 'type.googleapis.com/google.protobuf.UInt64Value';
 
 /**
  * Encodes arbitrary data in our special format for JSON.
  * This is exposed only for testing.
+ *
+ * @internal
  */
-/** @hidden */
 export function encode(data: any): any {
   if (data === null || typeof data === 'undefined') {
     return null;
@@ -448,8 +450,9 @@ export function encode(data: any): any {
 /**
  * Decodes our special format for JSON into native types.
  * This is exposed only for testing.
+ *
+ * @internal
  */
-/** @hidden */
 export function decode(data: any): any {
   if (data === null) {
     return data;
@@ -494,12 +497,9 @@ export function decode(data: any): any {
  *
  * Users are encouraged to setup log-based metric based on these values, and
  * changing their values may cause their metrics to break.
- *
  */
-/** @hidden */
 type TokenStatus = 'MISSING' | 'VALID' | 'INVALID';
 
-/** @hidden */
 interface CallableTokenStatus {
   app: TokenStatus;
   auth: TokenStatus;

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -30,7 +30,6 @@ export interface LogEntry {
   [key: string]: any;
 }
 
-/** @internal */
 function removeCircular(obj: any, refs: any[] = []): any {
   if (typeof obj !== 'object' || !obj) {
     return obj;
@@ -62,7 +61,7 @@ function removeCircular(obj: any, refs: any[] = []): any {
 
 /**
  * Writes a `LogEntry` to `stdout`/`stderr` (depending on severity).
- * @param entry The `LogEntry` including severity, message, and any additional structured metadata.
+ * @param entry - The `LogEntry` including severity, message, and any additional structured metadata.
  */
 export function write(entry: LogEntry) {
   if (SUPPORTS_STRUCTURED_LOGS) {
@@ -94,7 +93,7 @@ export function write(entry: LogEntry) {
 /**
  * Writes a `DEBUG` severity log. If the last argument provided is a plain object,
  * it is added to the `jsonPayload` in the Cloud Logging entry.
- * @param args Arguments, concatenated into the log message with space separators.
+ * @param args - Arguments, concatenated into the log message with space separators.
  */
 export function debug(...args: any[]) {
   write(entryFromArgs('DEBUG', args));
@@ -103,7 +102,7 @@ export function debug(...args: any[]) {
 /**
  * Writes an `INFO` severity log. If the last argument provided is a plain object,
  * it is added to the `jsonPayload` in the Cloud Logging entry.
- * @param args Arguments, concatenated into the log message with space separators.
+ * @param args - Arguments, concatenated into the log message with space separators.
  */
 export function log(...args: any[]) {
   write(entryFromArgs('INFO', args));
@@ -112,7 +111,7 @@ export function log(...args: any[]) {
 /**
  * Writes an `INFO` severity log. If the last argument provided is a plain object,
  * it is added to the `jsonPayload` in the Cloud Logging entry.
- * @param args Arguments, concatenated into the log message with space separators.
+ * @param args - Arguments, concatenated into the log message with space separators.
  */
 export function info(...args: any[]) {
   write(entryFromArgs('INFO', args));
@@ -121,7 +120,7 @@ export function info(...args: any[]) {
 /**
  * Writes a `WARNING` severity log. If the last argument provided is a plain object,
  * it is added to the `jsonPayload` in the Cloud Logging entry.
- * @param args Arguments, concatenated into the log message with space separators.
+ * @param args - Arguments, concatenated into the log message with space separators.
  */
 export function warn(...args: any[]) {
   write(entryFromArgs('WARNING', args));
@@ -130,13 +129,12 @@ export function warn(...args: any[]) {
 /**
  * Writes an `ERROR` severity log. If the last argument provided is a plain object,
  * it is added to the `jsonPayload` in the Cloud Logging entry.
- * @param args Arguments, concatenated into the log message with space separators.
+ * @param args - Arguments, concatenated into the log message with space separators.
  */
 export function error(...args: any[]) {
   write(entryFromArgs('ERROR', args));
 }
 
-/** @hidden */
 function entryFromArgs(severity: LogSeverity, args: any[]): LogEntry {
   let entry = {};
   const lastArg = args[args.length - 1];

--- a/src/providers/pubsub.ts
+++ b/src/providers/pubsub.ts
@@ -30,23 +30,23 @@ import {
   ScheduleRetryConfig,
 } from '../function-configuration';
 
-/** @hidden */
+/** @internal */
 export const provider = 'google.pubsub';
-/** @hidden */
+/** @internal */
 export const service = 'pubsub.googleapis.com';
 
 /**
  * Registers a Cloud Function triggered when a Google Cloud Pub/Sub message
  * is sent to a specified topic.
  *
- * @param topic The Pub/Sub topic to watch for message events.
+ * @param topic - The Pub/Sub topic to watch for message events.
  * @return Pub/Sub topic builder interface.
  */
 export function topic(topic: string) {
   return _topicWithOptions(topic, {});
 }
 
-/** @hidden */
+/** @internal */
 export function _topicWithOptions(
   topic: string,
   options: DeploymentOptions
@@ -69,7 +69,7 @@ export function _topicWithOptions(
  * Access via [`functions.pubsub.topic()`](providers_pubsub_.html#topic).
  */
 export class TopicBuilder {
-  /** @hidden */
+  /** @internal */
   constructor(
     private triggerResource: () => string,
     private options: DeploymentOptions
@@ -79,7 +79,7 @@ export class TopicBuilder {
    * Event handler that fires every time a Cloud Pub/Sub message is
    * published.
    *
-   * @param handler Event handler that runs every time a Cloud Pub/Sub message
+   * @param handler - Event handler that runs every time a Cloud Pub/Sub message
    *   is published.
    * @return A Cloud Function that you can export and deploy.
    */
@@ -101,14 +101,14 @@ export class TopicBuilder {
 /**
  * Registers a Cloud Function to run at specified times.
  *
- * @param schedule The schedule, in Unix Crontab or AppEngine syntax.
+ * @param schedule - The schedule, in Unix Crontab or AppEngine syntax.
  * @return ScheduleBuilder interface.
  */
 export function schedule(schedule: string): ScheduleBuilder {
   return _scheduleWithOptions(schedule, {});
 }
 
-/** @hidden */
+/** @internal */
 export function _scheduleWithOptions(
   schedule: string,
   options: DeploymentOptions
@@ -136,7 +136,7 @@ export function _scheduleWithOptions(
  * Access via [`functions.pubsub.schedule()`](providers_pubsub_.html#schedule).
  */
 export class ScheduleBuilder {
-  /** @hidden */
+  /** @internal */
   constructor(
     private triggerResource: () => string,
     private options: DeploymentOptions
@@ -156,7 +156,7 @@ export class ScheduleBuilder {
    * Event handler for scheduled functions. Triggered whenever the associated
    * scheduler job sends a Pub/Sub message.
    *
-   * @param handler Handler that fires whenever the associated
+   * @param handler - Handler that fires whenever the associated
    *   scheduler job sends a Pub/Sub message.
    * @return A Cloud Function that you can export and deploy.
    */
@@ -177,7 +177,7 @@ export class ScheduleBuilder {
 /**
  * Interface representing a Google Cloud Pub/Sub message.
  *
- * @param data Payload of a Pub/Sub message.
+ * @param data - Payload of a Pub/Sub message.
  */
 export class Message {
   /**
@@ -190,7 +190,7 @@ export class Message {
    */
   readonly attributes: { [key: string]: string };
 
-  /** @hidden */
+  /** @internal */
   private _json: any;
 
   constructor(data: any) {

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -168,14 +168,14 @@ export interface GlobalOptions {
   /**
    * Number of requests a function can serve at once.
    * Can only be applied to functions running on Cloud Functions v2.
-   * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
+   * A value of null restores the default concurrency (80 when CPU \>= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    */
   concurrency?: number | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
-   * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
+   * Defaults to 1 for functions with \<= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
    * To revert to the CPU amounts used in gcloud or in Cloud Functions generation 1, set this
@@ -227,7 +227,7 @@ let globalOptions: GlobalOptions | undefined;
 
 /**
  * Sets default options for all functions written using the v2 SDK.
- * @param options Options to set as default
+ * @param options - Options to set as default
  */
 export function setGlobalOptions(options: GlobalOptions) {
   if (globalOptions) {
@@ -239,6 +239,7 @@ export function setGlobalOptions(options: GlobalOptions) {
 /**
  * Get the currently set default options.
  * Used only for trigger generation.
+ *
  * @internal
  */
 export function getGlobalOptions(): GlobalOptions {
@@ -254,6 +255,7 @@ export interface EventHandlerOptions extends GlobalOptions {
 
 /**
  * Apply GlobalOptions to trigger definitions.
+ *
  * @internal
  */
 export function optionsToTriggerAnnotations(
@@ -316,6 +318,7 @@ export function optionsToTriggerAnnotations(
 
 /**
  * Apply GlobalOptions to endpoint manifest.
+ *
  * @internal
  */
 export function optionsToEndpoint(
@@ -368,9 +371,7 @@ export function optionsToEndpoint(
   return endpoint;
 }
 
-/**
- * @hidden
- */
+/* @internal */
 export function __getSpec(): {
   globalOptions: GlobalOptions;
   params: ParamSpec[];

--- a/src/v2/params/index.ts
+++ b/src/v2/params/index.ts
@@ -1,4 +1,3 @@
-/** @hidden */
 import {
   BooleanParam,
   FloatParam,
@@ -10,14 +9,15 @@ import {
   StringParam,
 } from './types';
 
+/* @alpha */
 export { ParamOptions };
 
+/* @alpha */
 export const declaredParams: Param[] = [];
 
 /**
  * Use a helper to manage the list such that params are uniquely
  * registered once only but order is preserved.
- * @internal
  */
 function registerParam(param: Param) {
   for (let i = 0; i < declaredParams.length; i++) {
@@ -31,9 +31,11 @@ function registerParam(param: Param) {
 /**
  * Declare a string param.
  *
- * @param name The name of the environment variable to use to load the param.
- * @param options Configuration options for the param.
+ * @param name - The name of the environment variable to use to load the param.
+ * @param options - Configuration options for the param.
  * @returns A Param with a `string` return type for `.value`.
+ *
+ * @alpha
  */
 export function defineString(
   name: string,
@@ -47,9 +49,11 @@ export function defineString(
 /**
  * Declare a boolean param.
  *
- * @param name The name of the environment variable to use to load the param.
- * @param options Configuration options for the param.
+ * @param name - The name of the environment variable to use to load the param.
+ * @param options - Configuration options for the param.
  * @returns A Param with a `boolean` return type for `.value`.
+ *
+ * @alpha
  */
 export function defineBoolean(
   name: string,
@@ -63,9 +67,11 @@ export function defineBoolean(
 /**
  * Declare an integer param.
  *
- * @param name The name of the environment variable to use to load the param.
- * @param options Configuration options for the param.
+ * @param name - The name of the environment variable to use to load the param.
+ * @param options - Configuration options for the param.
  * @returns A Param with a `number` return type for `.value`.
+ *
+ * @alpha
  */
 export function defineInt(
   name: string,
@@ -79,9 +85,11 @@ export function defineInt(
 /**
  * Declare a float param.
  *
- * @param name The name of the environment variable to use to load the param.
- * @param options Configuration options for the param.
+ * @param name - The name of the environment variable to use to load the param.
+ * @param options - Configuration options for the param.
  * @returns A Param with a `number` return type for `.value`.
+ *
+ * @alpha
  */
 export function defineFloat(
   name: string,
@@ -95,9 +103,11 @@ export function defineFloat(
 /**
  * Declare a list param (array of strings).
  *
- * @param name The name of the environment variable to use to load the param.
- * @param options Configuration options for the param.
+ * @param name - The name of the environment variable to use to load the param.
+ * @param options - Configuration options for the param.
  * @returns A Param with a `string[]` return type for `.value`.
+ *
+ * @alpha
  */
 export function defineList(
   name: string,
@@ -112,9 +122,11 @@ export function defineList(
  * Declare a JSON param. The associated environment variable will be treated
  * as a JSON string when loading its value.
  *
- * @param name The name of the environment variable to use to load the param.
- * @param options Configuration options for the param.
+ * @param name - The name of the environment variable to use to load the param.
+ * @param options - Configuration options for the param.
  * @returns A Param with a specifiable return type for `.value`.
+ *
+ * @alpha
  */
 export function defineJSON<T = any>(
   name: string,

--- a/src/v2/params/types.ts
+++ b/src/v2/params/types.ts
@@ -1,6 +1,6 @@
-/** @hidden */
 type ParamValueType = 'string' | 'list' | 'boolean' | 'int' | 'float' | 'json';
 
+/* @alpha */
 export interface ParamSpec<T = unknown> {
   name: string;
   default?: T;
@@ -9,11 +9,13 @@ export interface ParamSpec<T = unknown> {
   valueType?: ParamValueType;
 }
 
+/* @alpha */
 export type ParamOptions<T = unknown> = Omit<
   ParamSpec<T>,
   'name' | 'valueType'
 >;
 
+/* @alpha */
 export class Param<T = unknown> {
   static valueType: ParamValueType = 'string';
 
@@ -51,10 +53,12 @@ export class Param<T = unknown> {
   }
 }
 
+/* @alpha */
 export class StringParam extends Param<string> {
   // identical to the abstract class, just explicitly a string
 }
 
+/* @alpha */
 export class IntParam extends Param<number> {
   static valueType: ParamValueType = 'int';
 
@@ -74,6 +78,7 @@ export class IntParam extends Param<number> {
   }
 }
 
+/* @alpha */
 export class FloatParam extends Param<number> {
   static valueType: ParamValueType = 'float';
 
@@ -92,6 +97,7 @@ export class FloatParam extends Param<number> {
   }
 }
 
+/* @alpha */
 export class BooleanParam extends Param {
   static valueType: ParamValueType = 'boolean';
 
@@ -114,6 +120,7 @@ export class BooleanParam extends Param {
   }
 }
 
+/* @alpha */
 export class ListParam extends Param<string[]> {
   static valueType: ParamValueType = 'list';
 
@@ -137,6 +144,7 @@ export class ListParam extends Param<string[]> {
   }
 }
 
+/* @alpha */
 export class JSONParam<T = any> extends Param<T> {
   static valueType: ParamValueType = 'json';
 

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -56,8 +56,8 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
 
 /**
  * Declares a function that can handle Firebase Alerts from CloudEvents.
- * @param alertTypeOrOpts the alert type or Firebase Alert function configuration.
- * @param handler a function that can handle the Firebase Alert inside a CloudEvent.
+ * @param alertTypeOrOpts - the alert type or Firebase Alert function configuration.
+ * @param handler - a function that can handle the Firebase Alert inside a CloudEvent.
  */
 export function onAlertPublished<T extends { ['@type']: string } = any>(
   alertTypeOrOpts: AlertType | FirebaseAlertOptions,

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -6,7 +6,7 @@ import * as options from '../options';
 /**
  * Interface representing a Google Cloud Pub/Sub message.
  *
- * @param data Payload of a Pub/Sub message.
+ * @param data - Payload of a Pub/Sub message.
  */
 export class Message<T> {
   /**
@@ -34,7 +34,7 @@ export class Message<T> {
    */
   readonly orderingKey: string;
 
-  /** @hidden */
+  /** @internal */
   private _json: T;
 
   constructor(data: any) {
@@ -68,7 +68,7 @@ export class Message<T> {
   /**
    * Returns a JSON-serializable representation of this object.
    *
-   * @return A JSON-serializable representation of this object.
+   * @returns A JSON-serializable representation of this object.
    */
   toJSON(): any {
     const json: Record<string, any> = {


### PR DESCRIPTION
As is, generating reference doc for v2 sdk produces tons of errors. Most common errors are:

1) Exported type definition depending on unexported type definition 

2) Using `@hidden` tag which is unsupported in api-extractor

I solve both of these issues here.

I selected to use `@alpha` tag for params related types - that would prevent it from showing up in reference docs.