### PR TITLE
Unbreak integration tests

### DIFF
--- a/integration_test/package.json.template
+++ b/integration_test/package.json.template
@@ -5,7 +5,7 @@
     "build": "./node_modules/.bin/tsc"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^2.10.0",
+    "@google-cloud/pubsub": "2.19.1",
     "firebase-admin": "__FIREBASE_ADMIN__",
     "firebase-functions": "__SDK_TARBALL__",
     "node-fetch": "^2.6.7"


### PR DESCRIPTION
Looks like `@google-cloud/pubsub` 2.19.3 has a bad version of `@grpc/proto-loader` and `google-gax` version pinned. Version 2.19.2 doesn't exist. Pinning to version 2.19.1 fixes the issue.