### PR TITLE
Temporarily remove docs for fireabse-functions-test

### DIFF
--- a/docgen/content-sources/v1/toc.yaml
+++ b/docgen/content-sources/v1/toc.yaml
@@ -174,8 +174,3 @@ toc:
     section:
       - title: 'HandlerBuilder'
         path: /docs/reference/functions/handler_builder.handlerbuilder.html
-
-  - heading: Test SDK for Cloud Functions for Firebase
-  - title: firebase-functions-test
-    section:
-      - include: /docs/reference/functions/test/_toc.yaml


### PR DESCRIPTION
Temporarily remove the reference to firebase-functions-test docs since the parser barfs on anything that doesn't have a `path`. @taeold will possibly have an idea what should actually happen here.