### PR TITLE
Update v2 rtdb to expose RawRTDBEvent and RawRTDBCloudEventData

### DIFF
--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -44,14 +44,12 @@ export const updatedEventType = 'google.firebase.database.ref.v1.updated';
 /** @internal */
 export const deletedEventType = 'google.firebase.database.ref.v1.deleted';
 
-/** @internal */
 export interface RawRTDBCloudEventData {
   ['@type']: 'type.googleapis.com/google.events.firebase.database.v1.ReferenceEventData';
   data: any;
   delta: any;
 }
 
-/** @internal */
 export interface RawRTDBCloudEvent extends CloudEvent<RawRTDBCloudEventData> {
   firebasedatabasehost: string;
   instance: string;

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -44,12 +44,14 @@ export const updatedEventType = 'google.firebase.database.ref.v1.updated';
 /** @internal */
 export const deletedEventType = 'google.firebase.database.ref.v1.deleted';
 
+/** @hidden */
 export interface RawRTDBCloudEventData {
   ['@type']: 'type.googleapis.com/google.events.firebase.database.v1.ReferenceEventData';
   data: any;
   delta: any;
 }
 
+/** @hidden */
 export interface RawRTDBCloudEvent extends CloudEvent<RawRTDBCloudEventData> {
   firebasedatabasehost: string;
   instance: string;


### PR DESCRIPTION
This commit updates the v2 database provider to also expose the
RawRTDB Events.

This will be used in test-sdk when mocking returned DatabaseEvents.