### PR TITLE
Error logs always show up in Cloud Error Reporting

### DIFF
--- a/spec/logger.spec.ts
+++ b/spec/logger.spec.ts
@@ -2,12 +2,7 @@ import { expect } from 'chai';
 
 import * as logger from '../src/logger';
 
-const SUPPORTS_STRUCTURED_LOGS =
-  parseInt(process.versions?.node?.split('.')?.[0] || '8', 10) >= 10;
-
-describe(`logger (${
-  SUPPORTS_STRUCTURED_LOGS ? 'structured' : 'unstructured'
-})`, () => {
+describe('logger', () => {
   const stdoutWrite = process.stdout.write.bind(process.stdout);
   const stderrWrite = process.stderr.write.bind(process.stderr);
   let lastOut: string;
@@ -30,12 +25,7 @@ describe(`logger (${
   });
 
   function expectOutput(last: string, entry: any) {
-    if (SUPPORTS_STRUCTURED_LOGS) {
-      return expect(JSON.parse(last.trim())).to.deep.eq(entry);
-    } else {
-      // legacy logging is not structured, but do a sanity check
-      return expect(last).to.include(entry.message);
-    }
+    return expect(JSON.parse(last.trim())).to.deep.eq(entry);
   }
 
   function expectStdout(entry: any) {

--- a/src/logger/common.ts
+++ b/src/logger/common.ts
@@ -20,11 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-// Determine if structured logs are supported (node >= 10). If something goes wrong,
-// assume no since unstructured is safer.
-/** @hidden */
-export const SUPPORTS_STRUCTURED_LOGS =
-  parseInt(process.versions?.node?.split('.')?.[0] || '8', 10) >= 10;
 
 // Map LogSeverity types to their equivalent `console.*` method.
 /** @hidden */

--- a/src/logger/common.ts
+++ b/src/logger/common.ts
@@ -20,7 +20,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-
 // Map LogSeverity types to their equivalent `console.*` method.
 /** @hidden */
 export const CONSOLE_SEVERITY: {

--- a/src/logger/compat.ts
+++ b/src/logger/compat.ts
@@ -31,7 +31,7 @@ function patchedConsole(severity: string): (data: any, ...args: any[]) => void {
   return function(data: any, ...args: any[]): void {
     let message = format(data, ...args);
     if (severity === 'ERROR') {
-      message = new Error(message).stack;
+      message = new Error(message).stack || message;
     }
 
     UNPATCHED_CONSOLE[CONSOLE_SEVERITY[severity]](

--- a/src/logger/compat.ts
+++ b/src/logger/compat.ts
@@ -23,21 +23,20 @@
 import { format } from 'util';
 import {
   CONSOLE_SEVERITY,
-  SUPPORTS_STRUCTURED_LOGS,
   UNPATCHED_CONSOLE,
 } from './common';
 
 /** @hidden */
 function patchedConsole(severity: string): (data: any, ...args: any[]) => void {
   return function(data: any, ...args: any[]): void {
-    if (SUPPORTS_STRUCTURED_LOGS) {
-      UNPATCHED_CONSOLE[CONSOLE_SEVERITY[severity]](
-        JSON.stringify({ severity, message: format(data, ...args) })
-      );
-      return;
+    let message = format(data, ...args);
+    if (severity === 'ERROR') {
+      message = new Error(message).stack;
     }
 
-    UNPATCHED_CONSOLE[CONSOLE_SEVERITY[severity]](data, ...args);
+    UNPATCHED_CONSOLE[CONSOLE_SEVERITY[severity]](
+      JSON.stringify({ severity, message })
+    );
   };
 }
 

--- a/src/logger/compat.ts
+++ b/src/logger/compat.ts
@@ -21,10 +21,7 @@
 // SOFTWARE.
 
 import { format } from 'util';
-import {
-  CONSOLE_SEVERITY,
-  UNPATCHED_CONSOLE,
-} from './common';
+import { CONSOLE_SEVERITY, UNPATCHED_CONSOLE } from './common';
 
 /** @hidden */
 function patchedConsole(severity: string): (data: any, ...args: any[]) => void {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -153,7 +153,7 @@ function entryFromArgs(severity: LogSeverity, args: any[]): LogEntry {
   }
   // mimic `console.*` behavior, see https://nodejs.org/api/console.html#console_console_log_data_args
   let message = format.apply(null, args);
-  if (severity === "ERROR") {
+  if (severity === "ERROR" && !args.find(arg => arg instanceof Error)) {
     message = new Error(message).stack || message;
   }
   return { ...entry, severity, message };

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -22,10 +22,7 @@
 
 import { format } from 'util';
 
-import {
-  CONSOLE_SEVERITY,
-  UNPATCHED_CONSOLE,
-} from './common';
+import { CONSOLE_SEVERITY, UNPATCHED_CONSOLE } from './common';
 
 /**
  * `LogSeverity` indicates the detailed severity of the log entry. See [LogSeverity](https://cloud.google.com/logging/docs/reference/v2/rest/v2/LogEntry#logseverity).
@@ -153,7 +150,7 @@ function entryFromArgs(severity: LogSeverity, args: any[]): LogEntry {
   }
   // mimic `console.*` behavior, see https://nodejs.org/api/console.html#console_console_log_data_args
   let message = format.apply(null, args);
-  if (severity === "ERROR" && !args.find(arg => arg instanceof Error)) {
+  if (severity === 'ERROR' && !args.find((arg) => arg instanceof Error)) {
     message = new Error(message).stack || message;
   }
   return { ...entry, severity, message };


### PR DESCRIPTION
Fixes #954.

1. Removed support for Node 8 and 10 unstructured logging since we no longer support those versions of Node.
2. Wrap all logging.error messages in an Error if none of the args are an error.

(2) makes sure that we get a stack trace in the log message, which is required for the Cloud Run data plane to send the log line to Cloud Error Reporting, where it shows up in the Firebase "Health" tab.

Tested with the following sample:

```
import { onRequest } from 'firebase-functions/v2/https';
import * as logger from 'firebase-functions/logger';

export const func = onRequest((req, res) => {
    logger.info("This is an info log");
    logger.error("This is an error log");
    logger.info("This is an info log with an error suffix", new Error("suffix"));
    logger.error("This is an error log with an error suffix", new Error("suffix"));
    res.send("OK");
    throw new Error("This is an unhandled error");
});
```

Cloud error reporting recorded all logger.error lines and the unhandled exception. The case with an Error suffix did not nest errors, which would cause the stack trace to be repeated.