### PR TITLE
add firebase-admin@^11.0.0 to peer dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Adds RTDB Triggers for v2 functions (#1127)
+- Adds support for Firebase Admin SDK v11 (#1151)

--- a/package.json
+++ b/package.json
@@ -229,7 +229,7 @@
     "yargs": "^15.3.1"
   },
   "peerDependencies": {
-    "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0"
+    "firebase-admin": "^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0"
   },
   "engines": {
     "node": "^8.13.0 || >=10.10.0"


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description
Some CI fails after upgrading to [firebase-admin@11.0.0][fa]. 

This is because firebase cloud-functions does not recognize [firebase-admin@11.0.0][fa] as peer dependency

fixes: #1147 

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

[fa]: https://github.com/firebase/firebase-admin-node/releases/tag/v11.0.0 "firebase-admin@11.0.0"
