### PR TITLE
WIP: present parameters in place of literal values for parameterized fields

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -27,12 +27,12 @@ export interface ManifestEndpoint {
   entryPoint?: string;
   region?: string[];
   platform?: string;
-  availableMemoryMb?: number;
-  maxInstances?: number;
-  minInstances?: number;
-  concurrency?: number;
+  availableMemoryMb?: number | string;
+  maxInstances?: number | string;
+  minInstances?: number | string;
+  concurrency?: number | string;
   serviceAccountEmail?: string;
-  timeoutSeconds?: number;
+  timeoutSeconds?: number | string;
   cpu?: number | 'gcf_gen1';
   vpc?: {
     connector: string;

--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -33,10 +33,10 @@ export { Change };
 /** @internal */
 export interface TriggerAnnotation {
   platform?: string;
-  concurrency?: number;
-  minInstances?: number;
-  maxInstances?: number;
-  availableMemoryMb?: number;
+  concurrency?: number | string;
+  minInstances?: number | string;
+  maxInstances?: number | string;
+  availableMemoryMb?: number | string;
   eventTrigger?: {
     eventType: string;
     resource: string;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -102,13 +102,15 @@ export interface GlobalOptions {
 
   /**
    * Amount of memory to allocate to a function.
+   * Must be either null, an integer or a CEL expression specifying a parameter with integer type.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: MemoryOption | null;
+  memory?: MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
+   * Must be either null, an integer or a CEL expression specifying a parameter with integer type.
    * A value of null restores the default of 60s
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
@@ -116,30 +118,33 @@ export interface GlobalOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
+   * Must be either null, an integer or a CEL expression specifying a parameter with integer type.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
+   * Must be either null, an integer or a CEL expression specifying a parameter with integer type.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
    * Can only be applied to functions running on Cloud Functions v2.
+   * Must be either an integer or a CEL expression specifying a parameter with integer type.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -246,8 +251,8 @@ export function optionsToTriggerAnnotations(
     opts,
     'availableMemoryMb',
     'memory',
-    (mem: MemoryOption) => {
-      return MemoryOptionToMB[mem];
+    (mem: MemoryOption | string) => {
+      return MemoryOptionToMB[mem] || mem;
     }
   );
   convertIfPresent(annotation, opts, 'regions', 'region', (region) => {
@@ -309,7 +314,7 @@ export function optionsToEndpoint(
     endpoint.vpc = vpc;
   }
   convertIfPresent(endpoint, opts, 'availableMemoryMb', 'memory', (mem) => {
-    return MemoryOptionToMB[mem];
+    return MemoryOptionToMB[mem] || mem;
   });
   convertIfPresent(endpoint, opts, 'region', 'region', (region) => {
     if (typeof region === 'string') {

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -89,7 +89,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -101,7 +101,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -109,13 +109,13 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -124,7 +124,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -76,7 +76,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -88,7 +88,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -96,13 +96,13 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -111,7 +111,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -182,7 +182,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -194,7 +194,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -202,13 +202,13 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -217,7 +217,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/eventarc.ts
+++ b/src/v2/providers/eventarc.ts
@@ -67,7 +67,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -79,7 +79,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -87,13 +87,13 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -102,7 +102,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -60,7 +60,7 @@ export interface HttpsOptions extends Omit<GlobalOptions, 'region'> {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -72,7 +72,7 @@ export interface HttpsOptions extends Omit<GlobalOptions, 'region'> {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -80,13 +80,13 @@ export interface HttpsOptions extends Omit<GlobalOptions, 'region'> {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -95,7 +95,7 @@ export interface HttpsOptions extends Omit<GlobalOptions, 'region'> {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -164,7 +164,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -176,7 +176,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -184,13 +184,13 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -199,7 +199,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -209,7 +209,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -221,7 +221,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -229,13 +229,13 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -244,7 +244,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -66,7 +66,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | null;
+  memory?: options.MemoryOption | string | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -78,7 +78,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | null;
+  timeoutSeconds?: number | string | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -86,13 +86,13 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | null;
+  minInstances?: number | string | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | null;
+  maxInstances?: number | string | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -101,7 +101,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | null;
+  concurrency?: number | string | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.


### PR DESCRIPTION
So what I'm pretty sure is going on is that users can set Functions options in two ways: either by presenting a GlobalOptions object to setGlobalOptions, or by presenting an extension type of GlobalOptions as the parameter to an individual function declaration. The fields from GlobalOptions are just copied into ManifestEndpoint, which is the type the CLI sees, as part of the discovery process.

Therefore, changing the type signatures of GlobalOptions(/its various extensions) and ManifestEndpoint _should_ be enough to allow users to provide parameterized values of their configuration fields.

So far, this PR does _not_ include:
- the trigger type specific parameterized fields
- full adjustments to the comments for the changed fields
- any tests whatsoever
- sanity checking on whether provided strings are actually CEL (but shouldn't we just validate that in the CLI?)
but I wanted to see whether I was totally barking up the wrong tree first.