### PR TITLE
Fix bug where callable function skipped unrecognized auth headers 

### DIFF
--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -638,7 +638,7 @@ export async function checkAuthToken(
   if (!authorization) {
     return 'MISSING';
   }
-  const match = authorization.match(/^Bearer (.*)$/);
+  const match = authorization.match(/^Bearer (.*)$/i);
   if (match) {
     const idToken = match[1];
     try {
@@ -660,6 +660,7 @@ export async function checkAuthToken(
       return 'INVALID';
     }
   }
+  return 'INVALID';
 }
 
 /** @internal */


### PR DESCRIPTION
We have a weird edge case where an authorization in form we don't recognize will completely skip the auth check.

The fix here applies 2 changes:

1) We allow 'Bearer <TOKEN>' format to be case insensitive. 'bearer <TOKEN>' also works.

2) We reject other authorization header. e.g. 'Beaver <token>' is rejected.