### PR TITLE
Modify getUpdateMask to no longer ignore customClaims and sessionClaims

### DIFF
--- a/spec/common/providers/identity.spec.ts
+++ b/spec/common/providers/identity.spec.ts
@@ -765,19 +765,6 @@ describe('identity', () => {
       expect(identity.getUpdateMask()).to.eq('');
     });
 
-    it('should return empty on only customClaims and sessionClaims', () => {
-      const response = {
-        customClaims: {
-          claim1: 'abc',
-        },
-        sessionClaims: {
-          claim2: 'def',
-        },
-      };
-
-      expect(identity.getUpdateMask(response)).to.eq('');
-    });
-
     it('should return the right claims on a response', () => {
       const response = {
         displayName: 'john',
@@ -793,7 +780,7 @@ describe('identity', () => {
       };
 
       expect(identity.getUpdateMask(response)).to.eq(
-        'displayName,disabled,emailVerified,photoURL'
+        'displayName,disabled,emailVerified,photoURL,customClaims,sessionClaims'
       );
     });
   });

--- a/src/common/providers/identity.ts
+++ b/src/common/providers/identity.ts
@@ -799,9 +799,6 @@ export function getUpdateMask(
   }
   const updateMask: string[] = [];
   for (const key in authResponse) {
-    if (key === 'customClaims' || key === 'sessionClaims') {
-      continue;
-    }
     if (
       authResponse.hasOwnProperty(key) &&
       typeof authResponse[key] !== 'undefined'


### PR DESCRIPTION
### Description

Attempts to fix: #1135 - sessionClaims content not getting added to the decoded token 

From my personal testing, adding `sessionClaims` or `customerClaims` through a blocking function does not work. 
The emulator code is expecting both of these keys to show up in the `updateMask` of the blocking function's response.

https://github.com/firebase/firebase-tools/blob/30771f6498f32791cd2e88ac142611df58d32b7e/src/emulator/auth/operations.ts#L3083-L3117

I of course do not know what the internal firebase auth platform is expecting to receive in the `updateMask`, so these changes may not be the correct approach. 

The test that is removed in the PR notes that the updateMask "should return empty on only customClaims and sessionClaims", and the consuming code will actually return an empty response if only the claims values are set: 

https://github.com/firebase/firebase-functions/blob/cc18326068278dcf2f5e15bf38d8ca5f5aaa9ff2/src/common/providers/identity.ts#L863-L872

I do not see any mention of this requirement in the documentation: https://firebase.google.com/docs/auth/extend-with-blocking-functions 

I am happy to update these fixes if the internal firebase auth implementation is expecting a different response (which will also require an update to the firebase-tools emulators).