### PR TITLE
Fix integration tests

### DIFF
--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -20,6 +20,8 @@ import * as testLab from "./v1/testLab-utils";
 const firebaseConfig = JSON.parse(process.env.FIREBASE_CONFIG);
 admin.initializeApp();
 
+// Re-enable no-unused-var check once callable functions are testable again.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function callHttpsTrigger(name: string, data: any) {
   const url = `https://${REGION}-${firebaseConfig.projectId}.cloudfunctions.net/${name}`;
   const client = await new GoogleAuth().getIdTokenClient("32555940559.apps.googleusercontent.com");
@@ -36,6 +38,8 @@ async function callHttpsTrigger(name: string, data: any) {
   }
 }
 
+// Re-enable no-unused-var check once callable functions are testable again.
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 async function callV2HttpsTrigger(name: string, data: any, accessToken: string) {
   const getFnResp = await fetch(
     `https://cloudfunctions.googleapis.com/v2beta/projects/${firebaseConfig.projectId}/locations/${REGION}/functions/${name}`,

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -127,7 +127,8 @@ function v1Tests(testId: string, accessToken: string): Array<Promise<unknown>> {
     // A firestore write to trigger the Cloud Firestore tests.
     admin.firestore().collection("tests").doc(testId).set({ test: testId }),
     // Invoke a callable HTTPS trigger.
-    callHttpsTrigger("v1-callableTests", { foo: "bar", testId }),
+    // TODO: Temporarily disable - doesn't work unless running on projects w/ permission to create public functions.
+    // callHttpsTrigger("v1-callableTests", { foo: "bar", testId }),
     // A Remote Config update to trigger the Remote Config tests.
     updateRemoteConfig(testId, accessToken),
     // A storage upload to trigger the Storage tests
@@ -141,10 +142,12 @@ function v1Tests(testId: string, accessToken: string): Array<Promise<unknown>> {
   ];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 function v2Tests(testId: string, accessToken: string): Array<Promise<void>> {
   return [
     // Invoke a callable HTTPS trigger.
-    callV2HttpsTrigger("v2-callabletests", { foo: "bar", testId }, accessToken),
+    // TODO: Temporarily disable - doesn't work unless running on projects w/ permission to create public functions.
+    // callV2HttpsTrigger("v2-callabletests", { foo: "bar", testId }, accessToken),
   ];
 }
 

--- a/integration_test/functions/src/v1/index.ts
+++ b/integration_test/functions/src/v1/index.ts
@@ -2,7 +2,8 @@ export * from "./pubsub-tests";
 export * from "./database-tests";
 export * from "./auth-tests";
 export * from "./firestore-tests";
-export * from "./https-tests";
+// Temporarily disable http test - will not work unless running on projects w/ permission to create public functions.
+// export * from "./https-tests";
 export * from "./remoteConfig-tests";
 export * from "./storage-tests";
 export * from "./testLab-tests";

--- a/integration_test/functions/src/v2/index.ts
+++ b/integration_test/functions/src/v2/index.ts
@@ -2,4 +2,5 @@ import { setGlobalOptions } from "firebase-functions/v2";
 import { REGION } from "../region";
 setGlobalOptions({ region: REGION });
 
-export * from "./https-tests";
+// TODO: Temporarily disable - doesn't work unless running on projects w/ permission to create public functions.
+// export * from "./https-tests";

--- a/src/common/params.ts
+++ b/src/common/params.ts
@@ -20,7 +20,11 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/** @internal */
+/**
+ * A type that splits literal string S with delimiter D.
+ *
+ * For example Split<"a/b/c", "/"> is ['a' | "b" | "c"]
+ */
 export type Split<S extends string, D extends string> =
   // A non-literal string splits into a string[]
   string extends S
@@ -36,7 +40,9 @@ export type Split<S extends string, D extends string> =
     : // A string without delimiters splits into an array of itself
       [S];
 
-/** @internal */
+/**
+ * A type that ensure that type S is not null or undefined.
+ */
 export type NullSafe<S extends null | undefined | string> = S extends null
   ? never
   : S extends undefined
@@ -45,7 +51,14 @@ export type NullSafe<S extends null | undefined | string> = S extends null
   ? S
   : never;
 
-/** @internal */
+/**
+ * A type that extracts parameter name enclosed in bracket as string.
+ * Ignore wildcard matches
+ *
+ * For example, Extract<"{uid}"> is "uid".
+ * For example, Extract<"{uid=*}"> is "uid".
+ * For example, Extract<"{uid=**}"> is "uid".
+ */
 export type Extract<Part extends string> = Part extends `{${infer Param}=**}`
   ? Param
   : Part extends `{${infer Param}=*}`


### PR DESCRIPTION
Integration test caught some bugs!

1. From https://github.com/firebase/firebase-functions/pull/1155 - Some internal type must be exposed - otherwise compiling user projects fails w/ error message like below:

```
Error: node_modules/firebase-functions/lib/common/params.d.ts(10,13): error TS2314: Generic type 'Extract' requires 2 type argument(s).
Error: node_modules/firebase-functions/lib/common/params.d.ts(10,21): error TS2304: Cannot find name 'Split'.
Error: node_modules/firebase-functions/lib/common/params.d.ts(10,27): error TS2304: Cannot find name 'NullSafe'.
```

2. From https://github.com/firebase/firebase-functions/pull/1181 - There is no way to call private callable functions since GCF requrie GCP identity token as authorization header while callable function requires Firebase auth tokens. Disabling those test cases in the integration test until we can mint a GCP project w/ permission to create public functions.