### PR TITLE
Fixes a bug that disallowed setting customClaims and/or sessionClaims in blocking functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fixes a bug that disallowed setting customClaims and/or sessionClaims in blocking functions (#1199).

--- a/integration_test/functions/src/index.ts
+++ b/integration_test/functions/src/index.ts
@@ -1,9 +1,9 @@
 import { PubSub } from '@google-cloud/pubsub';
-import { GoogleAuth } from 'google-auth-library';
 import { Request, Response } from 'express';
 import * as admin from 'firebase-admin';
 import * as functions from 'firebase-functions';
 import * as fs from 'fs';
+import { GoogleAuth } from 'google-auth-library';
 import fetch from 'node-fetch';
 
 import * as v1 from './v1';

--- a/spec/common/providers/identity.spec.ts
+++ b/spec/common/providers/identity.spec.ts
@@ -765,19 +765,6 @@ describe('identity', () => {
       expect(identity.getUpdateMask()).to.eq('');
     });
 
-    it('should return empty on only customClaims and sessionClaims', () => {
-      const response = {
-        customClaims: {
-          claim1: 'abc',
-        },
-        sessionClaims: {
-          claim2: 'def',
-        },
-      };
-
-      expect(identity.getUpdateMask(response)).to.eq('');
-    });
-
     it('should return the right claims on a response', () => {
       const response = {
         displayName: 'john',
@@ -793,7 +780,7 @@ describe('identity', () => {
       };
 
       expect(identity.getUpdateMask(response)).to.eq(
-        'displayName,disabled,emailVerified,photoURL'
+        'displayName,disabled,emailVerified,photoURL,customClaims,sessionClaims'
       );
     });
   });

--- a/src/common/providers/identity.ts
+++ b/src/common/providers/identity.ts
@@ -799,9 +799,6 @@ export function getUpdateMask(
   }
   const updateMask: string[] = [];
   for (const key in authResponse) {
-    if (key === 'customClaims' || key === 'sessionClaims') {
-      continue;
-    }
     if (
       authResponse.hasOwnProperty(key) &&
       typeof authResponse[key] !== 'undefined'

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -28,8 +28,8 @@
 import { BlockingFunction } from '../../cloud-functions';
 import {
   AuthBlockingEvent,
-  AuthUserRecord,
   AuthBlockingEventType,
+  AuthUserRecord,
   BeforeCreateResponse,
   BeforeSignInResponse,
   HttpsError,


### PR DESCRIPTION
- Adds `customClaims` and `sessionClaims` to the updateMask.