### PR TITLE
Bring SDK Expression types into alignment with CLI + unit tests for Expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 ### Breaking Changes
+
 - Deprecated `allowInvalidAppCheckToken` option. Instead use
   `enforceAppCheck`.
 
 > App Check enforcement on callable functions is disabled by default in v4.
-  Requests containing invalid App Check tokens won't be denied unless you
-  explicitly enable App Check enforcement using the new `enforceAppCheck` option.
-  Furthermore, when enforcement is enabled, callable functions will deny
-  all requests without App Check tokens.
+> Requests containing invalid App Check tokens won't be denied unless you
+> explicitly enable App Check enforcement using the new `enforceAppCheck` option.
+> Furthermore, when enforcement is enabled, callable functions will deny
+> all requests without App Check tokens.
 
 - Dropped support for Node.js versions 8, 10, and 12.
 - Dropped support for Admin SDK versions 8 and 9.
@@ -16,9 +17,10 @@
   removed.
 - Removed `__trigger` object on function handlers.
 - Reorganized source code location. This affects only apps that directly import files instead of using the recommend entry points specified in the
-- Reworked the `apps` library and removed `lodash` as a runtime dependency. 
+- Reworked the `apps` library and removed `lodash` as a runtime dependency.
 
 ### Enhancements
+
 - Logs created with the `functions.logger` package in v2 functions
   are now annotated with each request's trace ID, making it easy to correlate
   log entries with the incoming request. Trace IDs are especially useful for
@@ -28,5 +30,3 @@
 - `functions.logger.error` now always outputs an error object and is included in Google Cloud Error Reporting.
 - The logging severity of Auth/App Check token validation has changed from `info` to `debug` level.
 - Event parameters for 2nd generation functions are now strongly typed, permitting stronger TypeScript types for matched parameters.
-
-  

--- a/spec/fixtures/sources/commonjs-params/index.js
+++ b/spec/fixtures/sources/commonjs-params/index.js
@@ -3,11 +3,11 @@ const functionsv2 = require("../../../../src/v2/index");
 const params = require("../../../../src/params");
 
 params.defineString("BORING");
-params.defineString("FOO", { input: { text: { validationRegex: "w+" } } });
-params.defineString("BAR", { default: "{{ params.FOO }}", label: "asdf" });
+const foo = params.defineString("FOO", { input: { text: { validationRegex: "w+" } } });
+const bar = params.defineString("BAR", { default: foo , label: "asdf" });
 params.defineString("BAZ", { input: { select: { options: [{ value: "a" }, { value: "b" }] } } });
 
-params.defineInt("AN_INT", { default: 22 });
+params.defineInt("AN_INT", { default: bar.equals("qux").then(0, 1) });
 params.defineInt("ANOTHER_INT", {
   input: {
     select: {

--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -1,6 +1,16 @@
 import { expect } from "chai";
 import * as params from "../../src/params";
 
+describe("Params spec extraction", () => {
+  it("converts Expressions in the param default to strings", () => {
+    const bar = params.defineInt("BAR");
+    expect(
+      params.defineString("FOO", { default: bar.notEquals(22).then("asdf", "jkl;") }).toSpec()
+        .default
+    ).to.equal(`{{ params.BAR != 22 ? "asdf" : "jkl;" }}`);
+  });
+});
+
 describe("Params value extraction", () => {
   beforeEach(() => {
     process.env.A_STRING = "asdf";

--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -1,0 +1,202 @@
+import { expect } from "chai";
+import * as params from "../../src/params";
+
+describe("Params value extraction", () => {
+  beforeEach(() => {
+    process.env.A_STRING = "asdf";
+    process.env.SAME_STRING = "asdf";
+    process.env.DIFF_STRING = "jkl;";
+    process.env.AN_INT = "-11";
+    process.env.SAME_INT = "-11";
+    process.env.DIFF_INT = "22";
+    process.env.PI = "3.14159";
+    process.env.TRUE = "true";
+    process.env.FALSE = "false";
+  });
+
+  afterEach(() => {
+    params.clearParams();
+    delete process.env.A_STRING;
+    delete process.env.SAME_STRING;
+    delete process.env.DIFF_STRING;
+    delete process.env.AN_INT;
+    delete process.env.SAME_INT;
+    delete process.env.DIFF_INT;
+    delete process.env.TRUE;
+    delete process.env.PI;
+    delete process.env.TRUE;
+    delete process.env.FALSE;
+  });
+
+  it("extracts identity params from the environment", () => {
+    const strParam = params.defineString("A_STRING");
+    expect(strParam.value()).to.equal("asdf");
+
+    const intParam = params.defineInt("AN_INT");
+    expect(intParam.value()).to.equal(-11);
+
+    const boolParam = params.defineBoolean("TRUE");
+    expect(boolParam.value()).to.be.true;
+
+    const floatParam = params.defineFloat("PI");
+    expect(floatParam.value()).to.equal(3.14159);
+
+    const falseParam = params.defineBoolean("FALSE");
+    expect(falseParam.value()).to.be.false;
+  });
+
+  it("falls back on the javascript zero values in case of type mismatch", () => {
+    const stringToInt = params.defineInt("A_STRING");
+    expect(stringToInt.value()).to.equal(0);
+
+    const stringToBool = params.defineBoolean("A_STRING");
+    expect(stringToBool.value()).to.equal(false);
+  });
+
+  it("returns a boolean value for Comparison expressions", () => {
+    const str = params.defineString("A_STRING");
+    const sameStr = params.defineString("SAME_STRING");
+    const diffStr = params.defineString("DIFF_STRING");
+    expect(str.equals(sameStr).value()).to.be.true;
+    expect(str.equals("asdf").value()).to.be.true;
+    expect(str.equals(diffStr).value()).to.be.false;
+    expect(str.equals("jkl;").value()).to.be.false;
+
+    const int = params.defineInt("AN_INT");
+    const sameInt = params.defineInt("SAME_INT");
+    const diffInt = params.defineInt("DIFF_INT");
+    expect(int.equals(sameInt).value()).to.be.true;
+    expect(int.equals(-11).value()).to.be.true;
+    expect(int.equals(diffInt).value()).to.be.false;
+    expect(int.equals(22).value()).to.be.false;
+  });
+
+  it("can use all the comparison operators when explicitly requested", () => {
+    const jkl = params.defineString("DIFF_STRING");
+    expect(jkl.cmp(">", "asdf").value()).to.be.true;
+    expect(jkl.cmp(">", "jkl;").value()).to.be.false;
+    expect(jkl.cmp(">", "qwerty").value()).to.be.false;
+    expect(jkl.cmp(">=", "asdf").value()).to.be.true;
+    expect(jkl.cmp(">=", "jkl;").value()).to.be.true;
+    expect(jkl.cmp(">=", "qwerty").value()).to.be.false;
+    expect(jkl.cmp("<", "asdf").value()).to.be.false;
+    expect(jkl.cmp("<", "jkl;").value()).to.be.false;
+    expect(jkl.cmp("<", "qwerty").value()).to.be.true;
+    expect(jkl.cmp("<=", "asdf").value()).to.be.false;
+    expect(jkl.cmp("<=", "jkl;").value()).to.be.true;
+    expect(jkl.cmp("<=", "qwerty").value()).to.be.true;
+
+    const twentytwo = params.defineInt("DIFF_INT");
+    expect(twentytwo.cmp(">", 11).value()).to.be.true;
+    expect(twentytwo.cmp(">", 22).value()).to.be.false;
+    expect(twentytwo.cmp(">", 33).value()).to.be.false;
+    expect(twentytwo.cmp(">=", 11).value()).to.be.true;
+    expect(twentytwo.cmp(">=", 22).value()).to.be.true;
+    expect(twentytwo.cmp(">=", 33).value()).to.be.false;
+    expect(twentytwo.cmp("<", 11).value()).to.be.false;
+    expect(twentytwo.cmp("<", 22).value()).to.be.false;
+    expect(twentytwo.cmp("<", 33).value()).to.be.true;
+    expect(twentytwo.cmp("<=", 11).value()).to.be.false;
+    expect(twentytwo.cmp("<=", 22).value()).to.be.true;
+    expect(twentytwo.cmp("<=", 33).value()).to.be.true;
+
+    const trueParam = params.defineBoolean("TRUE");
+    expect(trueParam.cmp(">", true).value()).to.be.false;
+    expect(trueParam.cmp(">", false).value()).to.be.true;
+    expect(trueParam.cmp(">=", true).value()).to.be.true;
+    expect(trueParam.cmp(">=", false).value()).to.be.true;
+    expect(trueParam.cmp("<", true).value()).to.be.false;
+    expect(trueParam.cmp("<", false).value()).to.be.false;
+    expect(trueParam.cmp("<=", true).value()).to.be.true;
+    expect(trueParam.cmp("<=", false).value()).to.be.false;
+  });
+
+  it("can select the output of a ternary expression based on the comparison", () => {
+    const trueExpr = params.defineString("A_STRING").equals(params.defineString("SAME_STRING"));
+    expect(trueExpr.then(1, 0).value()).to.equal(1);
+    const falseExpr = params.defineInt("AN_INT").equals(params.defineInt("DIFF_INT"));
+    expect(falseExpr.then(1, 0).value()).to.equal(0);
+
+    const twentytwo = params.defineInt("DIFF_INT");
+    expect(trueExpr.then(twentytwo, 0).value()).to.equal(22);
+    expect(falseExpr.then(1, twentytwo).value()).to.equal(22);
+  });
+});
+
+describe("Params as CEL", () => {
+  it("identity expressions", () => {
+    expect(params.defineString("FOO").toCEL()).to.equal("{{ params.FOO }}");
+    expect(params.defineInt("FOO").toCEL()).to.equal("{{ params.FOO }}");
+    expect(params.defineBoolean("FOO").toCEL()).to.equal("{{ params.FOO }}");
+  });
+
+  it("comparison expressions", () => {
+    expect(params.defineString("FOO").equals(params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO == params.BAR }}"
+    );
+    expect(params.defineString("FOO").cmp("==", params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO == params.BAR }}"
+    );
+    expect(params.defineString("FOO").cmp("!=", params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO != params.BAR }}"
+    );
+    expect(params.defineString("FOO").cmp(">", params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO > params.BAR }}"
+    );
+    expect(params.defineString("FOO").cmp(">=", params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO >= params.BAR }}"
+    );
+    expect(params.defineString("FOO").cmp("<", params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO < params.BAR }}"
+    );
+    expect(params.defineString("FOO").cmp("<=", params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.FOO <= params.BAR }}"
+    );
+
+    expect(params.defineString("FOO").equals("BAR").toCEL()).to.equal('{{ params.FOO == "BAR" }}');
+    expect(params.defineString("FOO").cmp("==", "BAR").toCEL()).to.equal(
+      '{{ params.FOO == "BAR" }}'
+    );
+    expect(params.defineString("FOO").cmp("!=", "BAR").toCEL()).to.equal(
+      '{{ params.FOO != "BAR" }}'
+    );
+    expect(params.defineString("FOO").cmp(">", "BAR").toCEL()).to.equal('{{ params.FOO > "BAR" }}');
+    expect(params.defineString("FOO").cmp(">=", "BAR").toCEL()).to.equal(
+      '{{ params.FOO >= "BAR" }}'
+    );
+    expect(params.defineString("FOO").cmp("<", "BAR").toCEL()).to.equal('{{ params.FOO < "BAR" }}');
+    expect(params.defineString("FOO").cmp("<=", "BAR").toCEL()).to.equal(
+      '{{ params.FOO <= "BAR" }}'
+    );
+
+    expect(params.defineInt("FOO").equals(-11).toCEL()).to.equal("{{ params.FOO == -11 }}");
+    expect(params.defineInt("FOO").cmp("==", -11).toCEL()).to.equal("{{ params.FOO == -11 }}");
+    expect(params.defineInt("FOO").cmp("!=", -11).toCEL()).to.equal("{{ params.FOO != -11 }}");
+    expect(params.defineInt("FOO").cmp(">", -11).toCEL()).to.equal("{{ params.FOO > -11 }}");
+    expect(params.defineInt("FOO").cmp(">=", -11).toCEL()).to.equal("{{ params.FOO >= -11 }}");
+    expect(params.defineInt("FOO").cmp("<", -11).toCEL()).to.equal("{{ params.FOO < -11 }}");
+    expect(params.defineInt("FOO").cmp("<=", -11).toCEL()).to.equal("{{ params.FOO <= -11 }}");
+  });
+
+  it("ternary expressions", () => {
+    const booleanExpr = params.defineBoolean("BOOL");
+    const cmpExpr = params.defineInt("A").cmp("!=", params.defineInt("B"));
+
+    expect(booleanExpr.then("asdf", "jkl;").toCEL()).to.equal(
+      '{{ params.BOOL ? "asdf" : "jkl;" }}'
+    );
+    expect(booleanExpr.then(-11, 22).toCEL()).to.equal("{{ params.BOOL ? -11 : 22 }}");
+    expect(booleanExpr.then(false, true).toCEL()).to.equal("{{ params.BOOL ? false : true }}");
+    expect(
+      booleanExpr.then(params.defineString("FOO"), params.defineString("BAR")).toCEL()
+    ).to.equal("{{ params.BOOL ? params.FOO : params.BAR }}");
+    expect(cmpExpr.then("asdf", "jkl;").toCEL()).to.equal(
+      '{{ params.A != params.B ? "asdf" : "jkl;" }}'
+    );
+    expect(cmpExpr.then(-11, 22).toCEL()).to.equal("{{ params.A != params.B ? -11 : 22 }}");
+    expect(cmpExpr.then(false, true).toCEL()).to.equal("{{ params.A != params.B ? false : true }}");
+    expect(cmpExpr.then(params.defineString("FOO"), params.defineString("BAR")).toCEL()).to.equal(
+      "{{ params.A != params.B ? params.FOO : params.BAR }}"
+    );
+  });
+});

--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -71,6 +71,16 @@ describe("Params value extraction", () => {
     expect(str.equals("asdf").value()).to.be.true;
     expect(str.equals(diffStr).value()).to.be.false;
     expect(str.equals("jkl;").value()).to.be.false;
+    expect(str.notEquals(diffStr).value()).to.be.true;
+    expect(str.notEquals("jkl;").value()).to.be.true;
+    expect(str.lessThan(diffStr).value()).to.be.true;
+    expect(str.lessThan("jkl;").value()).to.be.true;
+    expect(str.lessThanorEqualTo(diffStr).value()).to.be.true;
+    expect(str.lessThanorEqualTo("jkl;").value()).to.be.true;
+    expect(str.greaterThan(diffStr).value()).to.be.false;
+    expect(str.greaterThan("jkl;").value()).to.be.false;
+    expect(str.greaterThanOrEqualTo(diffStr).value()).to.be.false;
+    expect(str.greaterThanOrEqualTo("jkl;").value()).to.be.false;
 
     const int = params.defineInt("AN_INT");
     const sameInt = params.defineInt("SAME_INT");
@@ -79,6 +89,17 @@ describe("Params value extraction", () => {
     expect(int.equals(-11).value()).to.be.true;
     expect(int.equals(diffInt).value()).to.be.false;
     expect(int.equals(22).value()).to.be.false;
+
+    expect(int.notEquals(diffInt).value()).to.be.true;
+    expect(int.notEquals(22).value()).to.be.true;
+    expect(int.greaterThan(diffInt).value()).to.be.false;
+    expect(int.greaterThan(22).value()).to.be.false;
+    expect(int.greaterThanOrEqualTo(diffInt).value()).to.be.false;
+    expect(int.greaterThanOrEqualTo(22).value()).to.be.false;
+    expect(int.lessThan(diffInt).value()).to.be.true;
+    expect(int.lessThan(22).value()).to.be.true;
+    expect(int.lessThanorEqualTo(diffInt).value()).to.be.true;
+    expect(int.lessThanorEqualTo(22).value()).to.be.true;
   });
 
   it("can use all the comparison operators when explicitly requested", () => {

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -331,7 +331,7 @@ describe("loadStack", () => {
                 select: { options: [{ value: "a" }, { value: "b" }] },
               },
             },
-            { name: "AN_INT", type: "int", default: 22 },
+            { name: "AN_INT", type: "int", default: `{{ params.BAR == "qux" ? 0 : 1 }}` },
             {
               name: "ANOTHER_INT",
               type: "int",

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -47,10 +47,10 @@ function quoteIfString<T extends string | number | boolean | string[]>(literal: 
 }
 
 function valueOf<T extends string | number | boolean | string[]>(arg: T | Expression<T>): T {
-  return (arg instanceof Expression) ? arg.value() : arg;
+  return arg instanceof Expression ? arg.value() : arg;
 }
 function refOf<T extends string | number | boolean | string[]>(arg: T | Expression<T>): string {
-  return (arg instanceof Expression) ? arg.toString() : quoteIfString(arg).toString();
+  return arg instanceof Expression ? arg.toString() : quoteIfString(arg).toString();
 }
 
 /**
@@ -89,7 +89,11 @@ export class CompareExpression<
   lhs: Expression<T>;
   rhs: T | Expression<T>;
 
-  constructor(cmp: "==" | "!=" | ">" | ">=" | "<" | "<=", lhs: Expression<T>, rhs: T | Expression<T>) {
+  constructor(
+    cmp: "==" | "!=" | ">" | ">=" | "<" | "<=",
+    lhs: Expression<T>,
+    rhs: T | Expression<T>
+  ) {
     super();
     this.cmp = cmp;
     this.lhs = lhs;
@@ -122,7 +126,10 @@ export class CompareExpression<
     return `${this.lhs} ${this.cmp} ${rhsStr}`;
   }
 
-  then<retT extends string | number | boolean | string[]>(ifTrue: retT | Expression<retT>, ifFalse: retT | Expression<retT>) {
+  then<retT extends string | number | boolean | string[]>(
+    ifTrue: retT | Expression<retT>,
+    ifFalse: retT | Expression<retT>
+  ) {
     return new TernaryExpression<retT>(this, ifTrue, ifFalse);
   }
 }

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -209,6 +209,26 @@ export abstract class Param<T extends string | number | boolean | string[]> exte
     return this.cmp("==", rhs);
   }
 
+  notEquals(rhs: T | Expression<T>) {
+    return this.cmp("!=", rhs);
+  }
+
+  greaterThan(rhs: T | Expression<T>) {
+    return this.cmp(">", rhs);
+  }
+
+  greaterThanOrEqualTo(rhs: T | Expression<T>) {
+    return this.cmp(">=", rhs);
+  }
+
+  lessThan(rhs: T | Expression<T>) {
+    return this.cmp("<", rhs);
+  }
+
+  lessThanorEqualTo(rhs: T | Expression<T>) {
+    return this.cmp("<=", rhs);
+  }
+
   toString(): string {
     return `params.${this.name}`;
   }

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -257,7 +257,7 @@ export abstract class Param<T extends string | number | boolean | string[]> exte
 
     if (paramDefault instanceof Expression) {
       out.default = paramDefault.toCEL();
-    } else if (paramDefault) {
+    } else if (paramDefault !== undefined) {
       out.default = paramDefault;
     }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 import { Expression } from "../params";
-import { ParamSpec } from "../params/types";
+import { WireParamSpec } from "../params/types";
 
 /**
  * An definition of a function as appears in the Manifest.
@@ -90,7 +90,7 @@ export interface ManifestRequiredAPI {
  */
 export interface ManifestStack {
   specVersion: "v1alpha1";
-  params?: ParamSpec[];
+  params?: WireParamSpec<any>[];
   requiredAPIs: ManifestRequiredAPI[];
   endpoints: Record<string, ManifestEndpoint>;
 }

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -288,7 +288,7 @@ export function optionsToEndpoint(
  */
 export function __getSpec(): {
   globalOptions: GlobalOptions;
-  params: ParamSpec[];
+  params: ParamSpec<any>[];
 } {
   return {
     globalOptions: getGlobalOptions(),


### PR DESCRIPTION
Writing tests revealed, uh. A number. Of bugs in the current Expression implementation:

0) (big feature we forgot) **a param's default needs to be an Expression in addition to a literal**
1) (feature alignment) comparisons should be able to accept another Expression as the rhs
2) (feature alignment) ternary operators should be able to provide Expressions as the if_true/if_false values
3) (bug) ternary operators should not be forced to be of the same type as the params being compared (i.e `{{ params.INT2 == params.INT2 ? params.STRING : "foo" }}` was illegal)
4) (bug) boolean params would always evaluate to true no matter what string value the CLI passed in
5) (feature alignment) we should support != as a comparison