### PR TITLE
Expose generic types of @google-cloud/firestore

### DIFF
--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -43,8 +43,8 @@ export const service = 'firestore.googleapis.com';
 /** @hidden */
 export const defaultDatabase = '(default)';
 let firestoreInstance: any;
-export type DocumentSnapshot = firebase.firestore.DocumentSnapshot;
-export type QueryDocumentSnapshot = firebase.firestore.QueryDocumentSnapshot;
+export type DocumentSnapshot<T = firebase.firestore.DocumentData> = firebase.firestore.DocumentSnapshot<T>;
+export type QueryDocumentSnapshot<T = firebase.firestore.DocumentData> = firebase.firestore.QueryDocumentSnapshot<T>;
 
 /**
  * Select the Firestore document to listen to for events.

--- a/src/providers/firestore.ts
+++ b/src/providers/firestore.ts
@@ -43,8 +43,9 @@ export const service = 'firestore.googleapis.com';
 /** @hidden */
 export const defaultDatabase = '(default)';
 let firestoreInstance: any;
-export type DocumentSnapshot<T = firebase.firestore.DocumentData> = firebase.firestore.DocumentSnapshot<T>;
-export type QueryDocumentSnapshot<T = firebase.firestore.DocumentData> = firebase.firestore.QueryDocumentSnapshot<T>;
+export type DocumentData = firebase.firestore.DocumentData;
+export type DocumentSnapshot<T = DocumentData> = firebase.firestore.DocumentSnapshot<T>;
+export type QueryDocumentSnapshot<T = DocumentData> = firebase.firestore.QueryDocumentSnapshot<T>;
 
 /**
  * Select the Firestore document to listen to for events.


### PR DESCRIPTION
This exposes the already existing generic types of `@google-cloud/firestore` for `DocumentSnapshot` and `QueryDocumentSnapshot`.
I've also added the default to not introduce any breaking change and keep the typing optional. In regard to less readable documentation and a cleaner implementation  I've also added the default type `DocumentData` as an exposed type.

Currently you cannot even overwrite `QueryDocumentSnapshot` with the generic type of `@google-cloud/firestore` since the handler will not accept the same as it uses an internal reflected type of `QueryDocumentSnapshot`. Hence an explicit type cast needs to be placed during unwrapping. E.g.
```ts
import { firestore } from './src';
import { EventContext } from './src/cloud-functions';
import { QueryDocumentSnapshot } from './src/providers/firestore';

interface MyDocument {
    foo: string;
}

export const firebaseFunction = firestore
    .document('{collection}/{id}')
    .onCreate(async (data: QueryDocumentSnapshot, context: EventContext) => {
        // I don't want that 😥
        console.log('data: ' + (data.data() as MyDocument).foo);
    });
```

This change will enable the following implementation:
```ts
import { firestore } from './src';
import { EventContext } from './src/cloud-functions';
import { QueryDocumentSnapshot } from './src/providers/firestore';

interface MyDocument {
    foo: string;
}

export const firebaseFunction = firestore
    .document('{collection}/{id}')
    .onCreate(async (data: QueryDocumentSnapshot<MyDocument>, context: EventContext) => {
        // It works! 🥰
        console.log('data: ' + data.data().foo);
    });
```

If you need me to make any changes please let me know.

