### PR TITLE
Converting alert type and app id to camel case in the CloudEvent

### DIFF
--- a/spec/v2/providers/alerts/alerts.spec.ts
+++ b/spec/v2/providers/alerts/alerts.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { CloudEvent } from '../../../../src/v2';
 import * as options from '../../../../src/v2/options';
 import * as alerts from '../../../../src/v2/providers/alerts';
 import { FULL_ENDPOINT, FULL_OPTIONS } from '../fixtures';
@@ -172,6 +173,41 @@ describe('alerts', () => {
       expect(opts).to.deep.equal({ region: 'us-west1' });
       expect(alertType).to.equal(myOpts.alertType);
       expect(appId).to.be.equal(myOpts.appId);
+    });
+  });
+
+  describe('convertAlertAndApp', () => {
+    const event: CloudEvent<string> = {
+      specversion: '1.0',
+      id: 'id',
+      source: 'source',
+      type: 'type',
+      time: 'now',
+      data: 'data',
+    };
+
+    it('should leave event unchanged if alerttype & appid are missing', () => {
+      const raw = { ...event };
+
+      const converted = alerts.convertAlertAndApp(raw);
+
+      expect(raw).to.deep.eq(converted);
+    });
+
+    it('should convert alerttype & appid when present', () => {
+      const raw = {
+        ...event,
+        alerttype: 'my-alert',
+        appid: 'my-app',
+      };
+
+      const converted = alerts.convertAlertAndApp(raw);
+
+      expect(converted).to.deep.eq({
+        ...event,
+        alertType: 'my-alert',
+        appId: 'my-app',
+      });
     });
   });
 });

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -207,7 +207,7 @@ export function onAlertPublished<T extends { ['@type']: string } = any>(
   const [opts, alertType, appId] = getOptsAndAlertTypeAndApp(alertTypeOrOpts);
 
   const func = (raw: CloudEvent<unknown>) => {
-    return handler(raw as AlertEvent<T>);
+    return handler(convertAlertAndApp(raw) as AlertEvent<T>);
   };
 
   func.run = handler;

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -271,3 +271,24 @@ export function getOptsAndAlertTypeAndApp(
   }
   return [opts, alertType, appId];
 }
+
+/**
+ * Helper function to covert alert type & app id in the CloudEvent to camel case.
+ * @internal
+ */
+export function convertAlertAndApp(
+  raw: CloudEvent<unknown>
+): CloudEvent<unknown> {
+  const event = { ...raw };
+
+  if ('alerttype' in event) {
+    (event as any).alertType = (event as any).alerttype;
+    delete (event as any).alerttype;
+  }
+  if ('appid' in event) {
+    (event as any).appId = (event as any).appid;
+    delete (event as any).appid;
+  }
+
+  return event;
+}

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -28,7 +28,11 @@
 import { CloudEvent, CloudFunction } from '../../core';
 import * as options from '../../options';
 import { Expression } from '../../params';
-import { FirebaseAlertData, getEndpointAnnotation } from './alerts';
+import {
+  convertAlertAndApp,
+  FirebaseAlertData,
+  getEndpointAnnotation,
+} from './alerts';
 
 /**
  * The internal payload object for adding a new tester device to app distribution.
@@ -253,7 +257,9 @@ export function onNewTesterIosDevicePublished(
   const [opts, appId] = getOptsAndApp(appIdOrOptsOrHandler);
 
   const func = (raw: CloudEvent<unknown>) => {
-    return handler(raw as AppDistributionEvent<NewTesterDevicePayload>);
+    return handler(
+      convertAlertAndApp(raw) as AppDistributionEvent<NewTesterDevicePayload>
+    );
   };
 
   func.run = handler;
@@ -326,7 +332,9 @@ export function onInAppFeedbackPublished(
   const [opts, appId] = getOptsAndApp(appIdOrOptsOrHandler);
 
   const func = (raw: CloudEvent<unknown>) => {
-    return handler(raw as AppDistributionEvent<InAppFeedbackPayload>);
+    return handler(
+      convertAlertAndApp(raw) as AppDistributionEvent<InAppFeedbackPayload>
+    );
   };
 
   func.run = handler;

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -25,9 +25,13 @@
  * @packageDocumentation
  */
 
-import { FirebaseAlertData, getEndpointAnnotation } from '.';
 import { CloudEvent, CloudFunction } from '../../core';
 import * as options from '../../options';
+import {
+  convertAlertAndApp,
+  FirebaseAlertData,
+  getEndpointAnnotation,
+} from './alerts';
 
 /**
  * The internal payload object for billing plan updates.
@@ -167,7 +171,7 @@ export function onOperation<T>(
   }
 
   const func = (raw: CloudEvent<unknown>) => {
-    return handler(raw as BillingEvent<T>);
+    return handler(convertAlertAndApp(raw) as BillingEvent<T>);
   };
 
   func.run = handler;

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -25,10 +25,14 @@
  * @packageDocumentation
  */
 
-import { FirebaseAlertData, getEndpointAnnotation } from '.';
 import { CloudEvent, CloudFunction } from '../../core';
 import * as options from '../../options';
 import { Expression } from '../../params';
+import {
+  convertAlertAndApp,
+  FirebaseAlertData,
+  getEndpointAnnotation,
+} from './alerts';
 
 /** Generic Crashlytics issue interface */
 export interface Issue {
@@ -631,7 +635,7 @@ export function onOperation<T>(
   );
 
   const func = (raw: CloudEvent<unknown>) => {
-    return handler(raw as CrashlyticsEvent<T>);
+    return handler(convertAlertAndApp(raw) as CrashlyticsEvent<T>);
   };
 
   func.run = handler;

--- a/src/v2/providers/alerts/performance.ts
+++ b/src/v2/providers/alerts/performance.ts
@@ -25,9 +25,13 @@
  * @packageDocumentation
  */
 
-import { FirebaseAlertData, getEndpointAnnotation } from '.';
 import { CloudEvent, CloudFunction } from '../../core';
 import { EventHandlerOptions } from '../../options';
+import {
+  convertAlertAndApp,
+  FirebaseAlertData,
+  getEndpointAnnotation,
+} from './alerts';
 
 /**
  * The internal payload object for a performance threshold alert.
@@ -142,7 +146,9 @@ export function onThresholdAlertPublished(
   const [opts, appId] = getOptsAndApp(appIdOrOptsOrHandler);
 
   const func = (raw: CloudEvent<unknown>) => {
-    const event = raw as PerformanceEvent<ThresholdAlertPayload>;
+    const event = convertAlertAndApp(raw) as PerformanceEvent<
+      ThresholdAlertPayload
+    >;
     const convertedPayload = convertPayload(event.data.payload);
     event.data.payload = convertedPayload;
     return handler(event);


### PR DESCRIPTION
Fixes a bug where the SDK expected camel cased fields, but eventarc did not, so we convert them before passing the event to the end users code.