### PR TITLE
Remove deletion of CloudEvent fields

### DIFF
--- a/spec/v2/providers/alerts/alerts.spec.ts
+++ b/spec/v2/providers/alerts/alerts.spec.ts
@@ -205,6 +205,8 @@ describe('alerts', () => {
 
       expect(converted).to.deep.eq({
         ...event,
+        alerttype: 'my-alert',
+        appid: 'my-app',
         alertType: 'my-alert',
         appId: 'my-app',
       });

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -283,11 +283,9 @@ export function convertAlertAndApp(
 
   if ('alerttype' in event) {
     (event as any).alertType = (event as any).alerttype;
-    delete (event as any).alerttype;
   }
   if ('appid' in event) {
     (event as any).appId = (event as any).appid;
-    delete (event as any).appid;
   }
 
   return event;


### PR DESCRIPTION
We can't remove fields on a non-breaking change release.