### PR TITLE
Adds v2 test lab triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
     "./v2/identity": "./lib/v2/providers/identity.js",
     "./v2/database": "./lib/v2/providers/database.js",
     "./v2/scheduler": "./lib/v2/providers/scheduler.js",
-    "./v2/remoteConfig": "./lib/v2/providers/remoteConfig.js"
+    "./v2/remoteConfig": "./lib/v2/providers/remoteConfig.js",
+    "./v2/testLab": "./lib/v2/providers/testLab.js"
   },
   "typesVersions": {
     "*": {
@@ -150,6 +151,9 @@
       ],
       "v2/remoteConfig": [
         "lib/v2/providers/remoteConfig"
+      ],
+      "v2/testLab": [
+        "lib/v2/providers/testLab"
       ]
     }
   },

--- a/spec/v2/providers/testLab.spec.ts
+++ b/spec/v2/providers/testLab.spec.ts
@@ -1,0 +1,74 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { expect } from "chai";
+import * as testLab from "../../../src/v2/providers/testLab";
+import * as options from "../../../src/v2/options";
+
+describe("onTestMatrixCompleted", () => {
+  afterEach(() => {
+    options.setGlobalOptions({});
+  });
+
+  it("should create a function with a handler", () => {
+    const fn = testLab.onTestMatrixCompleted(() => 2);
+
+    expect(fn.__endpoint).to.deep.eq({
+      platform: "gcfv2",
+      labels: {},
+      eventTrigger: {
+        eventType: testLab.eventType,
+        eventFilters: {},
+        retry: false,
+      },
+    });
+    expect(fn.run(1 as any)).to.eq(2);
+  });
+
+  it("should create a function with opts and a handler", () => {
+    options.setGlobalOptions({
+      memory: "512MiB",
+      region: "us-west1",
+    });
+
+    const fn = testLab.onTestMatrixCompleted(
+      {
+        region: "us-central1",
+        retry: true,
+      },
+      () => 2
+    );
+
+    expect(fn.__endpoint).to.deep.eq({
+      platform: "gcfv2",
+      availableMemoryMb: 512,
+      region: ["us-central1"],
+      labels: {},
+      eventTrigger: {
+        eventType: testLab.eventType,
+        eventFilters: {},
+        retry: true,
+      },
+    });
+    expect(fn.run(1 as any)).to.eq(2);
+  });
+});

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -39,6 +39,7 @@ import * as scheduler from "./providers/scheduler";
 import * as storage from "./providers/storage";
 import * as tasks from "./providers/tasks";
 import * as remoteConfig from "./providers/remoteConfig";
+import * as testLab from "./providers/testLab";
 
 export {
   alerts,
@@ -52,6 +53,7 @@ export {
   eventarc,
   scheduler,
   remoteConfig,
+  testLab,
 };
 
 export {

--- a/src/v2/providers/remoteConfig.ts
+++ b/src/v2/providers/remoteConfig.ts
@@ -27,61 +27,61 @@ import { EventHandlerOptions, getGlobalOptions, optionsToEndpoint } from "../opt
 /** @internal */
 export const eventType = "google.firebase.remoteconfig.remoteConfig.v1.updated";
 
-/* All the fields associated with the person/service account that wrote a Remote Config template. */
+/** All the fields associated with the person/service account that wrote a Remote Config template. */
 export interface ConfigUser {
-  /* Display name. */
+  /** Display name. */
   name: string;
 
-  /* Email address. */
+  /** Email address. */
   email: string;
 
-  /* Image URL. */
+  /** Image URL. */
   imageUrl: string;
 }
 
-/* What type of update was associated with the Remote Config template version. */
+/** What type of update was associated with the Remote Config template version. */
 export type ConfigUpdateOrigin =
-  /* Catch-all for unrecognized values. */
+  /** Catch-all for unrecognized values. */
   | "REMOTE_CONFIG_UPDATE_ORIGIN_UNSPECIFIED"
-  /* The update came from the Firebase UI. */
+  /** The update came from the Firebase UI. */
   | "CONSOLE"
-  /* The update came from the Remote Config REST API. */
+  /** The update came from the Remote Config REST API. */
   | "REST_API"
-  /* The update came from the Firebase Admin Node SDK. */
+  /** The update came from the Firebase Admin Node SDK. */
   | "ADMIN_SDK_NODE";
 
-/* Where the Remote Config update action originated. */
+/** Where the Remote Config update action originated. */
 export type ConfigUpdateType =
-  /* Catch-all for unrecognized enum values */
+  /** Catch-all for unrecognized enum values */
   | "REMOTE_CONFIG_UPDATE_TYPE_UNSPECIFIED"
-  /* A regular incremental update */
+  /** A regular incremental update */
   | "INCREMENTAL_UPDATE"
-  /* A forced update. The ETag was specified as "*" in an UpdateRemoteConfigRequest request or the "Force Update" button was pressed on the console */
+  /** A forced update. The ETag was specified as "*" in an UpdateRemoteConfigRequest request or the "Force Update" button was pressed on the console */
   | "FORCED_UPDATE"
-  /* A rollback to a previous Remote Config template */
+  /** A rollback to a previous Remote Config template */
   | "ROLLBACK";
 
-/* The data within Firebase Remote Config update events. */
+/** The data within Firebase Remote Config update events. */
 export interface ConfigUpdateData {
-  /* The version number of the version's corresponding Remote Config template. */
+  /** The version number of the version's corresponding Remote Config template. */
   versionNumber: number;
 
-  /* When the Remote Config template was written to the Remote Config server. */
+  /** When the Remote Config template was written to the Remote Config server. */
   updateTime: string;
 
-  /* Aggregation of all metadata fields about the account that performed the update. */
+  /** Aggregation of all metadata fields about the account that performed the update. */
   updateUser: ConfigUser;
 
-  /* The user-provided description of the corresponding Remote Config template. */
+  /** The user-provided description of the corresponding Remote Config template. */
   description: string;
 
-  /* Where the update action originated. */
+  /** Where the update action originated. */
   updateOrigin: ConfigUpdateOrigin;
 
-  /* What type of update was made. */
+  /** What type of update was made. */
   updateType: ConfigUpdateType;
 
-  /* Only present if this version is the result of a rollback, and will be the version number of the Remote Config template that was rolled-back to. */
+  /** Only present if this version is the result of a rollback, and will be the version number of the Remote Config template that was rolled-back to. */
   rollbackSource: number;
 }
 

--- a/src/v2/providers/remoteConfig.ts
+++ b/src/v2/providers/remoteConfig.ts
@@ -90,7 +90,6 @@ export interface ConfigUpdateData {
  *
  * @param handler - Event handler which is run every time a Remote Config update occurs.
  * @returns A Cloud Function that you can export and deploy.
- * @alpha
  */
 export function onConfigUpdated(
   handler: (event: CloudEvent<ConfigUpdateData>) => any | Promise<any>
@@ -102,7 +101,6 @@ export function onConfigUpdated(
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Remote Config update occurs.
  * @returns A Cloud Function that you can export and deploy.
- * @alpha
  */
 export function onConfigUpdated(
   opts: EventHandlerOptions,
@@ -115,7 +113,6 @@ export function onConfigUpdated(
  * @param optsOrHandler - Options or an event handler.
  * @param handler - Event handler which is run every time a Remote Config update occurs.
  * @returns A Cloud Function that you can export and deploy.
- * @alpha
  */
 export function onConfigUpdated(
   optsOrHandler:

--- a/src/v2/providers/testLab.ts
+++ b/src/v2/providers/testLab.ts
@@ -23,6 +23,7 @@
 import { ManifestEndpoint } from "../../runtime/manifest";
 import { CloudEvent, CloudFunction } from "../core";
 import { EventHandlerOptions, getGlobalOptions, optionsToEndpoint } from "../options";
+import { wrapTraceContext } from "../trace";
 
 /** @internal */
 export const eventType = "google.firebase.testlab.testMatrix.v1.completed";
@@ -189,7 +190,7 @@ export function onTestMatrixCompleted(
   const specificOpts = optionsToEndpoint(optsOrHandler);
 
   const func: any = (raw: CloudEvent<unknown>) => {
-    return handler(raw as CloudEvent<TestMatrixCompletedData>);
+    return wrapTraceContext(handler(raw as CloudEvent<TestMatrixCompletedData>));
   };
   func.run = handler;
 

--- a/src/v2/providers/testLab.ts
+++ b/src/v2/providers/testLab.ts
@@ -20,111 +20,194 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/* Possible test states for a test matrix. */
+import { ManifestEndpoint } from "../../runtime/manifest";
+import { CloudEvent, CloudFunction } from "../core";
+import { EventHandlerOptions, getGlobalOptions, optionsToEndpoint } from "../options";
+
+/** @internal */
+export const eventType = "google.firebase.testlab.testMatrix.v1.completed";
+
+/** Possible test states for a test matrix. */
 export type TestState =
-  // The default value. This value is used if the state is omitted.
+  /** The default value. This value is used if the state is omitted. */
   | "TEST_STATE_UNSPECIFIED"
 
-  // The test matrix is being validated.
+  /** The test matrix is being validated. */
   | "VALIDATING"
 
-  // The test matrix is waiting for resources to become available.
+  /** The test matrix is waiting for resources to become available. */
   | "PENDING"
 
-  // The test matrix has completed normally.
+  /** The test matrix has completed normally. */
   | "FINISHED"
 
-  // The test matrix has completed because of an infrastructure failure.
+  /** The test matrix has completed because of an infrastructure failure. */
   | "ERROR"
 
-  // The test matrix was not run because the provided inputs are not valid.
+  /** The test matrix was not run because the provided inputs are not valid. */
   | "INVALID";
 
-/* Outcome summary for a finished test matrix. */
+/** Outcome summary for a finished test matrix. */
 export type OutcomeSummary =
-  // The default value. This value is used if the state is omitted.
+  /** The default value. This value is used if the state is omitted. */
   | "OUTCOME_SUMMARY_UNSPECIFIED"
 
-  // The test matrix run was successful, for instance:
-  // - All test cases passed.
-  // - No crash of the application under test was detected.
+  /**
+   * The test matrix run was successful, for instance:
+   * - All test cases passed.
+   * - No crash of the application under test was detected.
+   */
   | "SUCCESS"
 
-  // A run failed, for instance:
-  // - One or more test case failed.
-  // - A test timed out.
-  // - The application under test crashed.
+  /**
+   * A run failed, for instance:
+   * - One or more test case failed.
+   * - A test timed out.
+   * - The application under test crashed.
+   */
   | "FAILURE"
 
-  // Something unexpected happened. The test run should still be considered
-  // unsuccessful but this is likely a transient problem and re-running the
-  // test might be successful.
+  /**
+   * Something unexpected happened. The test run should still be considered
+   * unsuccessful but this is likely a transient problem and re-running the
+   * test might be successful.
+   */
   | "INCONCLUSIVE"
 
-  // All tests were skipped.
+  /** All tests were skipped. */
   | "SKIPPED";
 
-/* Locations where test results are stored. */
+/** Locations where test results are stored. */
 export interface ResultStorage {
-  // Tool Results history resource containing test results. Format is
-  // `projects/{project_id}/histories/{history_id}`.
-  // See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
-  // for more information.
-  toolResultsHistory: string
+  /**
+   * Tool Results history resource containing test results. Format is
+   * `projects/{project_id}/histories/{history_id}`.
+   * See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
+   * for more information.
+   */
+  toolResultsHistory: string;
 
-  // Tool Results execution resource containing test results. Format is
-  // `projects/{project_id}/histories/{history_id}/executions/{execution_id}`.
-  // Optional, can be omitted in erroneous test states.
-  // See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
-  // for more information.
-  toolResultsExecution: string
+  /**
+   * Tool Results execution resource containing test results. Format is
+   * `projects/{project_id}/histories/{history_id}/executions/{execution_id}`.
+   * Optional, can be omitted in erroneous test states.
+   * See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
+   * for more information.
+   */
+  toolResultsExecution: string;
 
-  // URI to the test results in the Firebase Web Console.
-  resultsUri: string
+  /** URI to the test results in the Firebase Web Console. */
+  resultsUri: string;
 
-  // Location in Google Cloud Storage where test results are written to.
-  // In the form "gs://bucket/path/to/somewhere".
-  gcsPath: string
+  /**
+   * Location in Google Cloud Storage where test results are written to.
+   * In the form "gs://bucket/path/to/somewhere".
+   */
+  gcsPath: string;
 }
 
-/* Information about the client which invoked the test. */
+/** Information about the client which invoked the test. */
 export interface ClientInfo {
-  // Client name, such as "gcloud".
+  /** Client name, such as "gcloud". */
   client: string;
 
-  // Map of detailed information about the client.
+  /** Map of detailed information about the client. */
   details: Record<string, string>;
 }
 
-/* The data within all Firebase test matrix completed events. */
+/** The data within all Firebase test matrix completed events. */
 export interface TestMatrixCompletedData {
-  // Time the test matrix was created.
+  /** Time the test matrix was created. */
   createTime: string;
 
-  // State of the test matrix.
+  /** State of the test matrix. */
   state: TestState;
 
-  // Code that describes why the test matrix is considered invalid. Only set for
-  // matrices in the INVALID state.
+  /**
+   * Code that describes why the test matrix is considered invalid. Only set for
+   * matrices in the INVALID state.
+   */
   invalidMatrixDetails: string;
 
-  // Outcome summary of the test matrix.
+  /** Outcome summary of the test matrix. */
   outcomeSummary: OutcomeSummary;
 
-  // Locations where test results are stored.
+  /** Locations where test results are stored. */
   resultStorage: ResultStorage;
 
-  // Information provided by the client that created the test matrix.
+  /** Information provided by the client that created the test matrix. */
   clientInfo: ClientInfo;
 
-  // ID of the test matrix this event belongs to.
+  /** ID of the test matrix this event belongs to. */
   testMatrixId: string;
 }
 
+/**
+ * Event handler which triggers when a Firebase test matrix completes.
+ *
+ * @param handler - Event handler which is run every time a Firebase test matrix completes.
+ * @returns A Cloud Function that you can export and deploy.
+ * @alpha
+ */
+export function onTestMatrixCompleted(
+  handler: (event: CloudEvent<TestMatrixCompletedData>) => any | Promise<any>
+): CloudFunction<CloudEvent<TestMatrixCompletedData>>;
 
+/**
+ * Event handler which triggers when a Firebase test matrix completes.
+ *
+ * @param opts - Options that can be set on an individual event-handling function.
+ * @param handler - Event handler which is run every time a Firebase test matrix completes.
+ * @returns A Cloud Function that you can export and deploy.
+ * @alpha
+ */
+export function onTestMatrixCompleted(
+  opts: EventHandlerOptions,
+  handler: (event: CloudEvent<TestMatrixCompletedData>) => any | Promise<any>
+): CloudFunction<CloudEvent<TestMatrixCompletedData>>;
 
+/**
+ * Event handler which triggers when a Firebase test matrix completes.
+ *
+ * @param optsOrHandler - Options or an event handler.
+ * @param handler - Event handler which is run every time a Firebase test matrix completes.
+ * @returns A Cloud Function that you can export and deploy.
+ * @alpha
+ */
+export function onTestMatrixCompleted(
+  optsOrHandler:
+    | EventHandlerOptions
+    | ((event: CloudEvent<TestMatrixCompletedData>) => any | Promise<any>),
+  handler?: (event: CloudEvent<TestMatrixCompletedData>) => any | Promise<any>
+): CloudFunction<CloudEvent<TestMatrixCompletedData>> {
+  if (typeof optsOrHandler === "function") {
+    handler = optsOrHandler as (event: CloudEvent<TestMatrixCompletedData>) => any | Promise<any>;
+    optsOrHandler = {};
+  }
 
+  const baseOpts = optionsToEndpoint(getGlobalOptions());
+  const specificOpts = optionsToEndpoint(optsOrHandler);
 
+  const func: any = (raw: CloudEvent<unknown>) => {
+    return handler(raw as CloudEvent<TestMatrixCompletedData>);
+  };
+  func.run = handler;
 
+  const ep: ManifestEndpoint = {
+    platform: "gcfv2",
+    ...baseOpts,
+    ...specificOpts,
+    labels: {
+      ...baseOpts?.labels,
+      ...specificOpts?.labels,
+    },
+    eventTrigger: {
+      eventType,
+      eventFilters: {},
+      retry: !!optsOrHandler.retry,
+    },
+  };
+  func.__endpoint = ep;
 
-
+  return func;
+}

--- a/src/v2/providers/testLab.ts
+++ b/src/v2/providers/testLab.ts
@@ -1,0 +1,130 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/* Possible test states for a test matrix. */
+export type TestState =
+  // The default value. This value is used if the state is omitted.
+  | "TEST_STATE_UNSPECIFIED"
+
+  // The test matrix is being validated.
+  | "VALIDATING"
+
+  // The test matrix is waiting for resources to become available.
+  | "PENDING"
+
+  // The test matrix has completed normally.
+  | "FINISHED"
+
+  // The test matrix has completed because of an infrastructure failure.
+  | "ERROR"
+
+  // The test matrix was not run because the provided inputs are not valid.
+  | "INVALID";
+
+/* Outcome summary for a finished test matrix. */
+export type OutcomeSummary =
+  // The default value. This value is used if the state is omitted.
+  | "OUTCOME_SUMMARY_UNSPECIFIED"
+
+  // The test matrix run was successful, for instance:
+  // - All test cases passed.
+  // - No crash of the application under test was detected.
+  | "SUCCESS"
+
+  // A run failed, for instance:
+  // - One or more test case failed.
+  // - A test timed out.
+  // - The application under test crashed.
+  | "FAILURE"
+
+  // Something unexpected happened. The test run should still be considered
+  // unsuccessful but this is likely a transient problem and re-running the
+  // test might be successful.
+  | "INCONCLUSIVE"
+
+  // All tests were skipped.
+  | "SKIPPED";
+
+/* Locations where test results are stored. */
+export interface ResultStorage {
+  // Tool Results history resource containing test results. Format is
+  // `projects/{project_id}/histories/{history_id}`.
+  // See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
+  // for more information.
+  toolResultsHistory: string
+
+  // Tool Results execution resource containing test results. Format is
+  // `projects/{project_id}/histories/{history_id}/executions/{execution_id}`.
+  // Optional, can be omitted in erroneous test states.
+  // See https://firebase.google.com/docs/test-lab/reference/toolresults/rest
+  // for more information.
+  toolResultsExecution: string
+
+  // URI to the test results in the Firebase Web Console.
+  resultsUri: string
+
+  // Location in Google Cloud Storage where test results are written to.
+  // In the form "gs://bucket/path/to/somewhere".
+  gcsPath: string
+}
+
+/* Information about the client which invoked the test. */
+export interface ClientInfo {
+  // Client name, such as "gcloud".
+  client: string;
+
+  // Map of detailed information about the client.
+  details: Record<string, string>;
+}
+
+/* The data within all Firebase test matrix completed events. */
+export interface TestMatrixCompletedData {
+  // Time the test matrix was created.
+  createTime: string;
+
+  // State of the test matrix.
+  state: TestState;
+
+  // Code that describes why the test matrix is considered invalid. Only set for
+  // matrices in the INVALID state.
+  invalidMatrixDetails: string;
+
+  // Outcome summary of the test matrix.
+  outcomeSummary: OutcomeSummary;
+
+  // Locations where test results are stored.
+  resultStorage: ResultStorage;
+
+  // Information provided by the client that created the test matrix.
+  clientInfo: ClientInfo;
+
+  // ID of the test matrix this event belongs to.
+  testMatrixId: string;
+}
+
+
+
+
+
+
+
+

--- a/v2/testLab.js
+++ b/v2/testLab.js
@@ -1,0 +1,26 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This file is not part of the firebase-functions SDK. It is used to silence the
+// imports eslint plugin until it can understand import paths defined by node
+// package exports.
+// For more information, see github.com/import-js/eslint-plugin-import/issues/1810


### PR DESCRIPTION
This change adds test lab triggers to the v2 codebase and sneaks in some remote config changes. For remote config, we update the tsdoc strings for reference docs and remove @alpha tags since the public docs have been published. 

Test Lab functions:
```
import {
  onTestMatrixCompleted,
  TestMatrixCompletedData
} from "firebase-functions/v2/testLab";

// passing in a handler only
export const fn1 = onTestMatrixCompleted((event) => { ... });

// declaring options
export const fn2 = onTestMatrixCompleted(
  { region: "us-central1", retry: true },
  (event) => {  ...  }
);

```