### PR TITLE
Fix combination of params and captures

### DIFF
--- a/spec/common/params.spec.ts
+++ b/spec/common/params.spec.ts
@@ -95,5 +95,15 @@ describe("Params namespace", () => {
         log: "world",
       } as const);
     });
+
+    it("extracts strings with params interpolated", () => {
+      // NOTE: be wary of this test. Hover over the types to see what they're
+      // parsing as. When doing TDD this test surprisingly passed. That's
+      // because ParamsOf was returning the empty interface because it did
+      // not special case for Record<string, never>. This meant that any input
+      // would pass the test. Fixing this issue in the test suite is as copmlex
+      // as fixing the bug to begin with and would probably share implementations.
+      expectType<ParamsOf<`${string}/{uid}`>>({ uid: "uid" });
+    });
   });
 });

--- a/src/common/params.ts
+++ b/src/common/params.ts
@@ -36,7 +36,10 @@ export type Split<S extends string, D extends string> =
     S extends `${D}${infer Tail}`
     ? [...Split<Tail, D>]
     : S extends `${infer Head}${D}${infer Tail}`
-    ? [Head, ...Split<Tail, D>]
+    ? // Drop types that are exactly string; they'll eat up literal string types
+      string extends Head
+      ? [...Split<Tail, D>]
+      : [Head, ...Split<Tail, D>]
     : // A string without delimiters splits into an array of itself
       [S];
 


### PR DESCRIPTION
Found while writing a demo. The following code didn't work because `event.params` was `{}`

```
const collection = defineString("COLLECTION");

export const uppercase(`${collection}/{id}`, (event) => {
  console.log("Uppercasing message", event.params.id);
  return event.data.ref.update({uppercase: event.data.original.toUpperCase()});
}
```

Turns out you can have a string that's only partially literal 🤯
Broke our code because we had bugs, but this is a really cool feature because it means we don't lose captures when customers interpolate params!