### PR TITLE
Hide documentation for in-app feedback

### DIFF
--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -53,6 +53,8 @@ export interface NewTesterDevicePayload {
 /**
  * The internal payload object for receiving in-app feedback from a tester.
  * Payload is wrapped inside a `FirebaseAlertData` object.
+ *
+ * @internal
  */
 export interface InAppFeedbackPayload {
   ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.AppDistroInAppFeedbackPayload';
@@ -272,6 +274,8 @@ export function onNewTesterIosDevicePublished(
  * Declares a function that can handle receiving new in-app feedback from a tester.
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
+ *
+ * @internal
  */
 export function onInAppFeedbackPublished(
   handler: (
@@ -284,6 +288,8 @@ export function onInAppFeedbackPublished(
  * @param appId - A specific application the handler will trigger on.
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
+ *
+ * @internal
  */
 export function onInAppFeedbackPublished(
   appId: string,
@@ -297,6 +303,8 @@ export function onInAppFeedbackPublished(
  * @param opts - Options that can be set on the function.
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
+ *
+ * @internal
  */
 export function onInAppFeedbackPublished(
   opts: AppDistributionOptions,
@@ -310,6 +318,8 @@ export function onInAppFeedbackPublished(
  * @param appIdOrOptsOrHandler - A specific application, options, or an event-handling function.
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
+ *
+ * @internal
  */
 export function onInAppFeedbackPublished(
   appIdOrOptsOrHandler:

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -54,7 +54,7 @@ export interface NewTesterDevicePayload {
  * The internal payload object for receiving in-app feedback from a tester.
  * Payload is wrapped inside a `FirebaseAlertData` object.
  *
- * @internal
+ * @alpha
  */
 export interface InAppFeedbackPayload {
   ['@type']: 'type.googleapis.com/google.events.firebase.firebasealerts.v1.AppDistroInAppFeedbackPayload';
@@ -275,7 +275,7 @@ export function onNewTesterIosDevicePublished(
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
  *
- * @internal
+ * @alpha
  */
 export function onInAppFeedbackPublished(
   handler: (
@@ -289,7 +289,7 @@ export function onInAppFeedbackPublished(
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
  *
- * @internal
+ * @alpha
  */
 export function onInAppFeedbackPublished(
   appId: string,
@@ -304,7 +304,7 @@ export function onInAppFeedbackPublished(
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
  *
- * @internal
+ * @alpha
  */
 export function onInAppFeedbackPublished(
   opts: AppDistributionOptions,
@@ -319,7 +319,7 @@ export function onInAppFeedbackPublished(
  * @param handler - Event handler which is run every time new feedback is received.
  * @returns A function that you can export and deploy.
  *
- * @internal
+ * @alpha
  */
 export function onInAppFeedbackPublished(
   appIdOrOptsOrHandler:


### PR DESCRIPTION
should be reverted once the feature is launched
