### PR TITLE
Fix bug where function configuration with null couldn't be deployed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 - Fix reference docs for performance monitoring.
+- Fix bug where function configuration wil null values couldn't be deployed. (#1246)

--- a/spec/runtime/manifest.spec.ts
+++ b/spec/runtime/manifest.spec.ts
@@ -7,6 +7,36 @@ describe('stackToWire', () => {
     params.clearParams();
   });
 
+  it('converts stack with null values values', () => {
+    const stack: ManifestStack = {
+      endpoints: {
+        v2http: {
+          platform: 'gcfv2',
+          entryPoint: 'v2http',
+          labels: {},
+          httpsTrigger: {},
+          maxInstances: null,
+        },
+      },
+      requiredAPIs: [],
+      specVersion: 'v1alpha1',
+    };
+    const expected = {
+      endpoints: {
+        v2http: {
+          platform: 'gcfv2',
+          entryPoint: 'v2http',
+          labels: {},
+          httpsTrigger: {},
+          maxInstances: null,
+        },
+      },
+      requiredAPIs: [],
+      specVersion: 'v1alpha1',
+    };
+    expect(stackToWire(stack)).to.deep.equal(expected);
+  });
+
   it('converts Expression types in endpoint options to CEL', () => {
     const intParam = params.defineInt('foo', { default: 11 });
     const stringParam = params.defineString('bar', {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -107,7 +107,7 @@ export function stackToWire(stack: ManifestStack): Object {
     for (const [key, val] of Object.entries(obj)) {
       if (val instanceof Expression) {
         obj[key] = val.toCEL();
-      } else if (typeof val === 'object') {
+      } else if (typeof val === 'object' && val !== null) {
         traverse(val);
       }
     }


### PR DESCRIPTION
```
> (typeof null === "object")
true
```