### PR TITLE
Allow actual RegExp objects in the regex field of a textInput

### DIFF
--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -9,6 +9,11 @@ describe("Params spec extraction", () => {
         .default
     ).to.equal(`{{ params.BAR != 22 ? "asdf" : "jkl;" }}`);
   });
+
+  it("converts RegExps in string validation parameters to strings", () => {
+    const foo = params.defineString("FOO", { input: { text: { validationRegex: /\d{5}/ } } });
+    expect(foo.toSpec().input).to.deep.equal({ text: { validationRegex: "\\d{5}" } });
+  });
 });
 
 describe("Params value extraction", () => {

--- a/spec/runtime/manifest.spec.ts
+++ b/spec/runtime/manifest.spec.ts
@@ -27,7 +27,7 @@ describe("stackToWire", () => {
           type: "string",
           input: {
             text: {
-              validationRegexp: "\\d{5}",
+              validationRegex: "\\d{5}",
             },
           },
         },

--- a/spec/runtime/manifest.spec.ts
+++ b/spec/runtime/manifest.spec.ts
@@ -7,6 +7,36 @@ describe("stackToWire", () => {
     params.clearParams();
   });
 
+  it("converts regular expressions used in param inputs", () => {
+    const regExpParam = params.defineString("foo", {
+      input: { text: { validationRegex: /\d{5}/ } },
+    });
+
+    const stack: ManifestStack = {
+      endpoints: {},
+      requiredAPIs: [],
+      params: [regExpParam.toSpec()],
+      specVersion: "v1alpha1",
+    };
+    const expected = {
+      endpoints: {},
+      requiredAPIs: [],
+      params: [
+        {
+          name: "foo",
+          type: "string",
+          input: {
+            text: {
+              validationRegexp: "\\d{5}",
+            },
+          },
+        },
+      ],
+      specVersion: "v1alpha1",
+    };
+    expect(stackToWire(stack)).to.deep.equal(expected);
+  });
+
   it("converts Expression types in endpoint options to CEL", () => {
     const intParam = params.defineInt("foo", { default: 11 });
     const stringParam = params.defineString("bar", {

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -261,6 +261,10 @@ export abstract class Param<T extends string | number | boolean | string[]> exte
       out.default = paramDefault;
     }
 
+    if (out.input && "text" in out.input && out.input.text.validationRegex instanceof RegExp) {
+      out.input.text.validationRegex = out.input.text.validationRegex.source;
+    }
+
     return out;
   }
 }

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -151,7 +151,7 @@ type ParamInput<T> =
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface TextInput<T = unknown> {
   example?: string;
-  validationRegex?: string;
+  validationRegex?: string | RegExp;
   validationErrorMessage?: string;
 }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -102,9 +102,11 @@ export interface ManifestStack {
  * @internal
  */
 export function stackToWire(stack: ManifestStack): Record<string, unknown> {
-  for (const param of stack.params) {
-    if ("text" in param.input && param.input.text.validationRegex instanceof RegExp) {
-      param.input.text.validationRegex = param.input.text.validationRegex.source;
+  if (stack.params) {
+    for (const param of stack.params) {
+      if ("text" in param.input && param.input.text.validationRegex instanceof RegExp) {
+        param.input.text.validationRegex = param.input.text.validationRegex.source;
+      }
     }
   }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -102,6 +102,12 @@ export interface ManifestStack {
  * @internal
  */
 export function stackToWire(stack: ManifestStack): Record<string, unknown> {
+  for (const param of stack.params) {
+    if ("text" in param.input && param.input.text.validationRegex instanceof RegExp) {
+      param.input.text.validationRegex = param.input.text.validationRegex.source;
+    }
+  }
+
   const wireStack = stack as any;
   const traverse = function traverse(obj: Record<string, unknown>) {
     for (const [key, val] of Object.entries(obj)) {

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -122,14 +122,6 @@ export interface ManifestStack {
  * @internal
  */
 export function stackToWire(stack: ManifestStack): Record<string, unknown> {
-  if (stack.params) {
-    for (const param of stack.params) {
-      if ("text" in param.input && param.input.text.validationRegex instanceof RegExp) {
-        param.input.text.validationRegex = param.input.text.validationRegex.source;
-      }
-    }
-  }
-
   const wireStack = stack as any;
   const traverse = function traverse(obj: Record<string, unknown>) {
     for (const [key, val] of Object.entries(obj)) {


### PR DESCRIPTION
I'm not....proud of this hack, but I was writing up some docs for params and frankly I couldn't get the slash escapes right in my head when typing them out, which means it's _really_ not reasonable to expect users to get them right either. Much better to just let them use the same JS regexps that they're used to using, and can copy-paste test.

Is this going to require APi review? The actual wire format hasn't changed.