### PR TITLE
Add RESET_VALUE configuration value as sentinel value to reset a config option.

### DIFF
--- a/spec/runtime/manifest.spec.ts
+++ b/spec/runtime/manifest.spec.ts
@@ -1,13 +1,15 @@
 import { expect } from "chai";
 import { stackToWire, ManifestStack } from "../../src/runtime/manifest";
 import * as params from "../../src/params";
+import * as optsv2 from "../../src/v2/options";
+import * as v1 from "../../src/v1";
 
 describe("stackToWire", () => {
   afterEach(() => {
     params.clearParams();
   });
 
-  it("converts stack with null values values", () => {
+  it("converts stack with null values", () => {
     const stack: ManifestStack = {
       endpoints: {
         v2http: {
@@ -23,6 +25,50 @@ describe("stackToWire", () => {
     };
     const expected = {
       endpoints: {
+        v2http: {
+          platform: "gcfv2",
+          entryPoint: "v2http",
+          labels: {},
+          httpsTrigger: {},
+          maxInstances: null,
+        },
+      },
+      requiredAPIs: [],
+      specVersion: "v1alpha1",
+    };
+    expect(stackToWire(stack)).to.deep.equal(expected);
+  });
+
+  it("converts stack with RESET_VALUES", () => {
+    const stack: ManifestStack = {
+      endpoints: {
+        v1http: {
+          platform: "gcfv1",
+          entryPoint: "v1http",
+          labels: {},
+          httpsTrigger: {},
+          maxInstances: v1.RESET_VALUE,
+        },
+        v2http: {
+          platform: "gcfv2",
+          entryPoint: "v2http",
+          labels: {},
+          httpsTrigger: {},
+          maxInstances: optsv2.RESET_VALUE,
+        },
+      },
+      requiredAPIs: [],
+      specVersion: "v1alpha1",
+    };
+    const expected = {
+      endpoints: {
+        v1http: {
+          platform: "gcfv1",
+          entryPoint: "v1http",
+          labels: {},
+          httpsTrigger: {},
+          maxInstances: null,
+        },
         v2http: {
           platform: "gcfv2",
           entryPoint: "v2http",

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -1,0 +1,36 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+/**
+ * Special configuration type to reset configuration to platform default.
+ * @alpha
+ */
+export class ResetValue {
+  toJSON(): null {
+    return null;
+  }
+}
+
+/**
+ * Special configuration value to reset configuration to platform default.
+ */
+export const RESET_VALUE = new ResetValue();

--- a/src/common/options.ts
+++ b/src/common/options.ts
@@ -22,15 +22,21 @@
 
 /**
  * Special configuration type to reset configuration to platform default.
+ *
  * @alpha
  */
 export class ResetValue {
   toJSON(): null {
     return null;
   }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  private constructor() {}
+  public static getInstance() {
+    return new ResetValue();
+  }
 }
 
 /**
  * Special configuration value to reset configuration to platform default.
  */
-export const RESET_VALUE = new ResetValue();
+export const RESET_VALUE = ResetValue.getInstance();

--- a/src/common/providers/tasks.ts
+++ b/src/common/providers/tasks.ts
@@ -26,6 +26,7 @@ import { DecodedIdToken } from "firebase-admin/auth";
 import * as logger from "../../logger";
 import * as https from "./https";
 import { Expression } from "../../params";
+import { ResetValue } from "../options";
 
 /** How a task should be retried in the event of a non-2xx return. */
 export interface RetryConfig {
@@ -33,31 +34,31 @@ export interface RetryConfig {
    * Maximum number of times a request should be attempted.
    * If left unspecified, will default to 3.
    */
-  maxAttempts?: number | Expression<number> | null;
+  maxAttempts?: number | Expression<number> | ResetValue;
 
   /**
    * Maximum amount of time for retrying failed task.
    * If left unspecified will retry indefinitely.
    */
-  maxRetrySeconds?: number | Expression<number> | null;
+  maxRetrySeconds?: number | Expression<number> | ResetValue;
 
   /**
    * The maximum amount of time to wait between attempts.
    * If left unspecified will default to 1hr.
    */
-  maxBackoffSeconds?: number | Expression<number> | null;
+  maxBackoffSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * The maximum number of times to double the backoff between
    * retries. If left unspecified will default to 16.
    */
-  maxDoublings?: number | Expression<number> | null;
+  maxDoublings?: number | Expression<number> | ResetValue;
 
   /**
    * The minimum time to wait between attempts. If left unspecified
    * will default to 100ms.
    */
-  minBackoffSeconds?: number | Expression<number> | null;
+  minBackoffSeconds?: number | Expression<number> | ResetValue;
 }
 
 /** How congestion control should be applied to the function. */
@@ -66,13 +67,13 @@ export interface RateLimits {
    * The maximum number of requests that can be outstanding at a time.
    * If left unspecified, will default to 1000.
    */
-  maxConcurrentDispatches?: number | Expression<number> | null;
+  maxConcurrentDispatches?: number | Expression<number> | ResetValue;
 
   /**
    * The maximum number of requests that can be invoked per second.
    * If left unspecified, will default to 500.
    */
-  maxDispatchesPerSecond?: number | Expression<number> | null;
+  maxDispatchesPerSecond?: number | Expression<number> | ResetValue;
 }
 
 /** Metadata about the authorization used to invoke a function. */

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -38,10 +38,10 @@ export interface ManifestEndpoint {
   timeoutSeconds?: number | Expression<number> | ResetValue;
   vpc?: {
     connector: string | Expression<string> | ResetValue;
-    egressSettings?: string;
+    egressSettings?: string | Expression<string> | ResetValue;
   };
-  ingressSettings?: string | ResetValue;
-  serviceAccountEmail?: string;
+  ingressSettings?: string | Expression<string> | ResetValue;
+  serviceAccountEmail?: string | Expression<string> | ResetValue;
   cpu?: number | "gcf_gen1";
   labels?: Record<string, string>;
   environmentVariables?: Record<string, string>;
@@ -63,8 +63,22 @@ export interface ManifestEndpoint {
     serviceAccountEmail?: string | ResetValue;
   };
 
+  taskQueueTrigger?: {
+    retryConfig?: {
+      maxAttempts?: number | Expression<number> | ResetValue;
+      maxRetrySeconds?: number | Expression<number> | ResetValue;
+      maxBackoffSeconds?: number | Expression<number> | ResetValue;
+      maxDoublings?: number | Expression<number> | ResetValue;
+      minBackoffSeconds?: number | Expression<number> | ResetValue;
+    };
+    rateLimits?: {
+      maxConcurrentDispatches?: number | Expression<number> | ResetValue;
+      maxDispatchesPerSecond?: number | Expression<number> | ResetValue;
+    };
+  };
+
   scheduleTrigger?: {
-    schedule?: string | Expression<string>;
+    schedule: string | Expression<string>;
     timeZone?: string | Expression<string> | ResetValue;
     retryConfig?: {
       retryCount?: number | Expression<number> | ResetValue;
@@ -72,6 +86,10 @@ export interface ManifestEndpoint {
       minBackoffSeconds?: string | Expression<string> | ResetValue;
       maxBackoffSeconds?: string | Expression<string> | ResetValue;
       maxDoublings?: number | Expression<number> | ResetValue;
+      // Note: v1 schedule functions use *Duration instead of *Seconds
+      maxRetryDuration?: string | Expression<string> | ResetValue;
+      minBackoffDuration?: string | Expression<string> | ResetValue;
+      maxBackoffDuration?: string | Expression<string> | ResetValue;
     };
   };
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -40,10 +40,10 @@ export interface ManifestEndpoint {
     connector: string | Expression<string> | ResetValue;
     egressSettings?: string | Expression<string> | ResetValue;
   };
-  ingressSettings?: string | Expression<string> | ResetValue;
   serviceAccountEmail?: string | Expression<string> | ResetValue;
   cpu?: number | "gcf_gen1";
   labels?: Record<string, string>;
+  ingressSettings?: string | Expression<string> | ResetValue;
   environmentVariables?: Record<string, string>;
   secretEnvironmentVariables?: Array<{ key: string; secret?: string }>;
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { ResetValue } from "../common/options";
 import { Expression } from "../params";
 import { WireParamSpec } from "../params/types";
 
@@ -30,19 +31,19 @@ export interface ManifestEndpoint {
   entryPoint?: string;
   region?: string[];
   platform?: string;
-  availableMemoryMb?: number | Expression<number>;
-  maxInstances?: number | Expression<number>;
-  minInstances?: number | Expression<number>;
-  concurrency?: number | Expression<number>;
-  serviceAccountEmail?: string;
-  timeoutSeconds?: number | Expression<number>;
-  cpu?: number | "gcf_gen1";
+  availableMemoryMb?: number | Expression<number> | ResetValue;
+  maxInstances?: number | Expression<number> | ResetValue;
+  minInstances?: number | Expression<number> | ResetValue;
+  concurrency?: number | Expression<number> | ResetValue;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
   vpc?: {
-    connector: string | Expression<string>;
+    connector: string | Expression<string> | ResetValue;
     egressSettings?: string;
   };
+  ingressSettings?: string | ResetValue;
+  serviceAccountEmail?: string;
+  cpu?: number | "gcf_gen1";
   labels?: Record<string, string>;
-  ingressSettings?: string;
   environmentVariables?: Record<string, string>;
   secretEnvironmentVariables?: Array<{ key: string; secret?: string }>;
 
@@ -57,20 +58,20 @@ export interface ManifestEndpoint {
     eventFilterPathPatterns?: Record<string, string | Expression<string>>;
     channel?: string;
     eventType: string;
-    retry: boolean | Expression<boolean>;
+    retry: boolean | Expression<boolean> | ResetValue;
     region?: string;
-    serviceAccountEmail?: string;
+    serviceAccountEmail?: string | ResetValue;
   };
 
   scheduleTrigger?: {
     schedule?: string | Expression<string>;
-    timeZone?: string | Expression<string>;
+    timeZone?: string | Expression<string> | ResetValue;
     retryConfig?: {
-      retryCount?: number | Expression<number>;
-      maxRetrySeconds?: string | Expression<string>;
-      minBackoffSeconds?: string | Expression<string>;
-      maxBackoffSeconds?: string | Expression<string>;
-      maxDoublings?: number | Expression<number>;
+      retryCount?: number | Expression<number> | ResetValue;
+      maxRetrySeconds?: string | Expression<string> | ResetValue;
+      minBackoffSeconds?: string | Expression<string> | ResetValue;
+      maxBackoffSeconds?: string | Expression<string> | ResetValue;
+      maxDoublings?: number | Expression<number> | ResetValue;
     };
   };
 
@@ -107,6 +108,8 @@ export function stackToWire(stack: ManifestStack): Record<string, unknown> {
     for (const [key, val] of Object.entries(obj)) {
       if (val instanceof Expression) {
         obj[key] = val.toCEL();
+      } else if (val instanceof ResetValue) {
+        obj[key] = val.toJSON();
       } else if (typeof val === "object" && val !== null) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         traverse(val as any);

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -472,7 +472,7 @@ export function optionsToEndpoint(options: DeploymentOptions): ManifestEndpoint 
   convertIfPresent(endpoint, options, "secretEnvironmentVariables", "secrets", (secrets) =>
     secrets.map((secret) => ({ key: secret }))
   );
-  if (options.vpcConnector !== undefined) {
+  if (options?.vpcConnector !== undefined) {
     if (options.vpcConnector === null || options.vpcConnector instanceof ResetValue) {
       endpoint.vpc = null;
     } else {

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -26,6 +26,7 @@ import { DeploymentOptions } from "./function-configuration";
 export { Request, Response };
 import { convertIfPresent, copyIfPresent } from "../common/encoding";
 import { ManifestEndpoint, ManifestRequiredAPI } from "../runtime/manifest";
+import { ResetValue } from "../common/options";
 
 export { Change } from "../common/change";
 
@@ -372,7 +373,7 @@ export function makeCloudFunction<EventData>({
       };
 
       if (options.schedule) {
-        endpoint.scheduleTrigger = options.schedule;
+        endpoint.scheduleTrigger = options.schedule as any;
       } else {
         endpoint.eventTrigger = {
           eventType: legacyEventType || provider + "." + eventType,
@@ -471,9 +472,14 @@ export function optionsToEndpoint(options: DeploymentOptions): ManifestEndpoint 
   convertIfPresent(endpoint, options, "secretEnvironmentVariables", "secrets", (secrets) =>
     secrets.map((secret) => ({ key: secret }))
   );
-  if (options?.vpcConnector) {
-    endpoint.vpc = { connector: options.vpcConnector };
-    convertIfPresent(endpoint.vpc, options, "egressSettings", "vpcConnectorEgressSettings");
+  if (options.vpcConnector !== undefined) {
+    if (options.vpcConnector === null || options.vpcConnector instanceof ResetValue) {
+      endpoint.vpc = null;
+    } else {
+      const vpc: ManifestEndpoint["vpc"] = { connector: options.vpcConnector };
+      convertIfPresent(vpc, options, "egressSettings", "vpcConnectorEgressSettings");
+      endpoint.vpc = vpc;
+    }
   }
   convertIfPresent(endpoint, options, "availableMemoryMb", "memory", (mem) => {
     const memoryLookup = {
@@ -485,7 +491,7 @@ export function optionsToEndpoint(options: DeploymentOptions): ManifestEndpoint 
       "4GB": 4096,
       "8GB": 8192,
     };
-    return memoryLookup[mem];
+    return typeof mem === "object" ? mem : memoryLookup[mem];
   });
   return endpoint;
 }

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -22,7 +22,7 @@
 
 import { Request, Response } from "express";
 import { warn } from "../logger";
-import { DeploymentOptions } from "./function-configuration";
+import { DeploymentOptions, RESET_VALUE } from "./function-configuration";
 export { Request, Response };
 import { convertIfPresent, copyIfPresent } from "../common/encoding";
 import { ManifestEndpoint, ManifestRequiredAPI } from "../runtime/manifest";
@@ -474,7 +474,7 @@ export function optionsToEndpoint(options: DeploymentOptions): ManifestEndpoint 
   );
   if (options?.vpcConnector !== undefined) {
     if (options.vpcConnector === null || options.vpcConnector instanceof ResetValue) {
-      endpoint.vpc = null;
+      endpoint.vpc = { connector: RESET_VALUE, egressSettings: RESET_VALUE };
     } else {
       const vpc: ManifestEndpoint["vpc"] = { connector: options.vpcConnector };
       convertIfPresent(vpc, options, "egressSettings", "vpcConnectorEgressSettings");

--- a/src/v1/function-builder.ts
+++ b/src/v1/function-builder.ts
@@ -22,6 +22,7 @@
 
 import * as express from "express";
 
+import { ResetValue } from "../common/options";
 import { EventContext } from "./cloud-functions";
 import {
   DeploymentOptions,
@@ -50,7 +51,8 @@ import * as testLab from "./providers/testLab";
  * @throws { Error } Memory and TimeoutSeconds values must be valid.
  */
 function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
-  if (runtimeOptions.memory && !VALID_MEMORY_OPTIONS.includes(runtimeOptions.memory)) {
+  const mem = runtimeOptions.memory;
+  if (mem && !(mem instanceof ResetValue) && !VALID_MEMORY_OPTIONS.includes(mem)) {
     throw new Error(
       `The only valid memory allocation values are: ${VALID_MEMORY_OPTIONS.join(", ")}`
     );
@@ -80,10 +82,12 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
   }
 
   validateFailurePolicy(runtimeOptions.failurePolicy);
+  const serviceAccount = runtimeOptions.serviceAccount;
   if (
-    runtimeOptions.serviceAccount &&
-    runtimeOptions.serviceAccount !== "default" &&
-    !runtimeOptions.serviceAccount.includes("@")
+    serviceAccount &&
+    serviceAccount !== "default" &&
+    !(serviceAccount instanceof ResetValue) &&
+    !serviceAccount.includes("@")
   ) {
     throw new Error(
       `serviceAccount must be set to 'default', a service account email, or '{serviceAccountName}@'`

--- a/src/v1/function-builder.ts
+++ b/src/v1/function-builder.ts
@@ -63,6 +63,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
 
   if (
     runtimeOptions.ingressSettings &&
+    !(runtimeOptions.ingressSettings instanceof ResetValue) &&
     !INGRESS_SETTINGS_OPTIONS.includes(runtimeOptions.ingressSettings)
   ) {
     throw new Error(
@@ -72,6 +73,7 @@ function assertRuntimeOptionsValid(runtimeOptions: RuntimeOptions): boolean {
 
   if (
     runtimeOptions.vpcConnectorEgressSettings &&
+    !(runtimeOptions.vpcConnectorEgressSettings instanceof ResetValue) &&
     !VPC_EGRESS_SETTINGS_OPTIONS.includes(runtimeOptions.vpcConnectorEgressSettings)
   ) {
     throw new Error(

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -1,7 +1,7 @@
 import { Expression } from "../params";
 import { ResetValue } from "../common/options";
 
-export { RESET_VALUE } from "../common/options";
+export { RESET_VALUE, ResetValue } from "../common/options";
 
 /**
  * List of all regions supported by Cloud Functions.

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -82,7 +82,7 @@ export interface ScheduleRetryConfig {
    *
    * @defaultValue 0 (infinite retry)
    */
-  retryCount?: number | Expression<number> | ResetValue | null;
+  retryCount?: number | Expression<number> | ResetValue;
   /**
    * The time limit for retrying a failed job, measured from time when an execution was first attempted.
    *
@@ -90,25 +90,25 @@ export interface ScheduleRetryConfig {
    *
    * @defaultValue 0
    */
-  maxRetryDuration?: string | Expression<string> | ResetValue | null;
+  maxRetryDuration?: string | Expression<string> | ResetValue;
   /**
    * The minimum amount of time to wait before retrying a job after it fails.
    *
    * @defaultValue 5 seconds
    */
-  minBackoffDuration?: string | Expression<string> | ResetValue | null;
+  minBackoffDuration?: string | Expression<string> | ResetValue;
   /**
    * The maximum amount of time to wait before retrying a job after it fails.
    *
    * @defaultValue 1 hour
    */
-  maxBackoffDuration?: string | Expression<string> | ResetValue | null;
+  maxBackoffDuration?: string | Expression<string> | ResetValue;
   /**
    * The max number of backoff doubling applied at each retry.
    *
    * @defaultValue 5
    */
-  maxDoublings?: number | Expression<number> | ResetValue | null;
+  maxDoublings?: number | Expression<number> | ResetValue;
 }
 
 /**
@@ -139,11 +139,11 @@ export interface Schedule {
    *
    * The value of this field must be a time zone name from the tz database.
    */
-  timeZone?: string | ResetValue | null;
+  timeZone?: string | ResetValue;
   /**
    * Settings that determine the retry behavior.
    */
-  retryConfig?: ScheduleRetryConfig | ResetValue | null;
+  retryConfig?: ScheduleRetryConfig | ResetValue;
 }
 
 /**
@@ -173,32 +173,34 @@ export interface RuntimeOptions {
    * Failure policy of the function, with boolean `true` being equivalent to
    * providing an empty retry object.
    */
-  failurePolicy?: FailurePolicy | boolean | ResetValue | null;
+  failurePolicy?: FailurePolicy | boolean | ResetValue;
   /**
    * Amount of memory to allocate to the function.
    */
-  memory?: typeof VALID_MEMORY_OPTIONS[number] | ResetValue | null;
+  memory?: typeof VALID_MEMORY_OPTIONS[number] | ResetValue;
   /**
    * Timeout for the function in seconds, possible values are 0 to 540.
    */
-  timeoutSeconds?: number | ResetValue | null;
+  timeoutSeconds?: number | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
    */
-  minInstances?: number | ResetValue | null;
+  minInstances?: number | ResetValue;
 
   /**
    * Max number of actual instances allowed to be running in parallel.
    */
-  maxInstances?: number | ResetValue | null;
+  maxInstances?: number | ResetValue;
 
   /**
    * Connect cloud function to specified VPC connector.
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
@@ -208,7 +210,7 @@ export interface RuntimeOptions {
   /**
    * Specific service account for the function to run as.
    */
-  serviceAccount?: "default" | string | ResetValue | null;
+  serviceAccount?: "default" | string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
@@ -232,6 +234,8 @@ export interface RuntimeOptions {
 
   /**
    * Determines whether Firebase AppCheck is enforced.
+   *
+   * @remarks
    * When true, requests with invalid tokens autorespond with a 401
    * (Unauthorized) error.
    * When false, requests with invalid tokens set context.app to undefiend.

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -143,7 +143,7 @@ export interface Schedule {
   /**
    * Settings that determine the retry behavior.
    */
-  retryConfig?: ScheduleRetryConfig | ResetValue;
+  retryConfig?: ScheduleRetryConfig;
 }
 
 /**
@@ -173,7 +173,7 @@ export interface RuntimeOptions {
    * Failure policy of the function, with boolean `true` being equivalent to
    * providing an empty retry object.
    */
-  failurePolicy?: FailurePolicy | boolean | ResetValue;
+  failurePolicy?: FailurePolicy | boolean;
   /**
    * Amount of memory to allocate to the function.
    */

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -1,4 +1,7 @@
 import { Expression } from "../params";
+import { ResetValue } from "../common/options";
+
+export { RESET_VALUE } from "../common/options";
 
 /**
  * List of all regions supported by Cloud Functions.
@@ -79,7 +82,7 @@ export interface ScheduleRetryConfig {
    *
    * @defaultValue 0 (infinite retry)
    */
-  retryCount?: number | Expression<number> | null;
+  retryCount?: number | Expression<number> | ResetValue | null;
   /**
    * The time limit for retrying a failed job, measured from time when an execution was first attempted.
    *
@@ -87,25 +90,25 @@ export interface ScheduleRetryConfig {
    *
    * @defaultValue 0
    */
-  maxRetryDuration?: string | Expression<string> | null;
+  maxRetryDuration?: string | Expression<string> | ResetValue | null;
   /**
    * The minimum amount of time to wait before retrying a job after it fails.
    *
    * @defaultValue 5 seconds
    */
-  minBackoffDuration?: string | Expression<string> | null;
+  minBackoffDuration?: string | Expression<string> | ResetValue | null;
   /**
    * The maximum amount of time to wait before retrying a job after it fails.
    *
    * @defaultValue 1 hour
    */
-  maxBackoffDuration?: string | Expression<string> | null;
+  maxBackoffDuration?: string | Expression<string> | ResetValue | null;
   /**
    * The max number of backoff doubling applied at each retry.
    *
    * @defaultValue 5
    */
-  maxDoublings?: number | Expression<number> | null;
+  maxDoublings?: number | Expression<number> | ResetValue | null;
 }
 
 /**
@@ -136,11 +139,11 @@ export interface Schedule {
    *
    * The value of this field must be a time zone name from the tz database.
    */
-  timeZone?: string;
+  timeZone?: string | ResetValue | null;
   /**
    * Settings that determine the retry behavior.
    */
-  retryConfig?: ScheduleRetryConfig;
+  retryConfig?: ScheduleRetryConfig | ResetValue | null;
 }
 
 /**
@@ -170,32 +173,32 @@ export interface RuntimeOptions {
    * Failure policy of the function, with boolean `true` being equivalent to
    * providing an empty retry object.
    */
-  failurePolicy?: FailurePolicy | boolean;
+  failurePolicy?: FailurePolicy | boolean | ResetValue | null;
   /**
    * Amount of memory to allocate to the function.
    */
-  memory?: typeof VALID_MEMORY_OPTIONS[number];
+  memory?: typeof VALID_MEMORY_OPTIONS[number] | ResetValue | null;
   /**
    * Timeout for the function in seconds, possible values are 0 to 540.
    */
-  timeoutSeconds?: number;
+  timeoutSeconds?: number | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
    */
-  minInstances?: number;
+  minInstances?: number | ResetValue | null;
 
   /**
    * Max number of actual instances allowed to be running in parallel.
    */
-  maxInstances?: number;
+  maxInstances?: number | ResetValue | null;
 
   /**
    * Connect cloud function to specified VPC connector.
    */
-  vpcConnector?: string;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
@@ -205,7 +208,7 @@ export interface RuntimeOptions {
   /**
    * Specific service account for the function to run as.
    */
-  serviceAccount?: "default" | string;
+  serviceAccount?: "default" | string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -1,7 +1,7 @@
 import { Expression } from "../params";
 import { ResetValue } from "../common/options";
 
-export { RESET_VALUE, ResetValue } from "../common/options";
+export { RESET_VALUE } from "../common/options";
 
 /**
  * List of all regions supported by Cloud Functions.

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -205,7 +205,7 @@ export interface RuntimeOptions {
   /**
    * Egress settings for VPC connector.
    */
-  vpcConnectorEgressSettings?: typeof VPC_EGRESS_SETTINGS_OPTIONS[number];
+  vpcConnectorEgressSettings?: typeof VPC_EGRESS_SETTINGS_OPTIONS[number] | ResetValue;
 
   /**
    * Specific service account for the function to run as.
@@ -215,7 +215,7 @@ export interface RuntimeOptions {
   /**
    * Ingress settings which control where this function can be called from.
    */
-  ingressSettings?: typeof INGRESS_SETTINGS_OPTIONS[number];
+  ingressSettings?: typeof INGRESS_SETTINGS_OPTIONS[number] | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -27,13 +27,13 @@
 
 import { convertIfPresent, copyIfPresent } from "../common/encoding";
 import { ResetValue } from "../common/options";
-import * as logger from "../logger";
 import { ManifestEndpoint } from "../runtime/manifest";
 import { declaredParams, Expression } from "../params";
 import { ParamSpec } from "../params/types";
 import { HttpsOptions } from "./providers/https";
+import * as logger from "../logger";
 
-export { RESET_VALUE } from "../common/options";
+export { RESET_VALUE, ResetValue } from "../common/options";
 
 /**
  * List of all regions supported by Cloud Functions v2

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -169,6 +169,11 @@ export interface GlobalOptions {
   ingressSettings?: IngressSetting | ResetValue;
 
   /**
+   * Invoker to set access control on https functions.
+   */
+  invoker?: "public" | "private" | string | string[];
+
+  /**
    * User labels to set on the function.
    */
   labels?: Record<string, string>;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -26,11 +26,14 @@
  */
 
 import { convertIfPresent, copyIfPresent } from "../common/encoding";
+import { ResetValue } from "../common/options";
 import * as logger from "../logger";
 import { ManifestEndpoint } from "../runtime/manifest";
 import { declaredParams, Expression } from "../params";
 import { ParamSpec } from "../params/types";
 import { HttpsOptions } from "./providers/https";
+
+export { RESET_VALUE } from "../common/options";
 
 /**
  * List of all regions supported by Cloud Functions v2
@@ -95,7 +98,7 @@ export interface GlobalOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: MemoryOption | Expression<number> | null;
+  memory?: MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -107,7 +110,7 @@ export interface GlobalOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -115,13 +118,13 @@ export interface GlobalOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -130,7 +133,7 @@ export interface GlobalOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -140,31 +143,31 @@ export interface GlobalOptions {
    * To revert to the CPU amounts used in gcloud or in Cloud Functions generation 1, set this
    * to the value "gcf_gen1"
    */
-  cpu?: number | "gcf_gen1";
+  cpu?: number | "gcf_gen1" | ResetValue;
 
   /**
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: IngressSetting | null;
+  ingressSettings?: IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.
@@ -255,17 +258,23 @@ export function optionsToEndpoint(
     "cpu"
   );
   convertIfPresent(endpoint, opts, "serviceAccountEmail", "serviceAccount");
-  if (opts.vpcConnector) {
-    const vpc: ManifestEndpoint["vpc"] = { connector: opts.vpcConnector };
-    convertIfPresent(vpc, opts, "egressSettings", "vpcConnectorEgressSettings");
-    endpoint.vpc = vpc;
+  if (opts.vpcConnector !== undefined) {
+    if (opts.vpcConnector === null || opts.vpcConnector instanceof ResetValue) {
+      endpoint.vpc = null;
+    } else {
+      const vpc: ManifestEndpoint["vpc"] = { connector: opts.vpcConnector };
+      convertIfPresent(vpc, opts, "egressSettings", "vpcConnectorEgressSettings");
+      endpoint.vpc = vpc;
+    }
   }
   convertIfPresent(
     endpoint,
     opts,
     "availableMemoryMb",
     "memory",
-    (mem: MemoryOption | Expression<number>): number | Expression<number> => {
+    (
+      mem: MemoryOption | Expression<number> | null | ResetValue
+    ): number | Expression<number> | null | ResetValue => {
       return typeof mem === "object" ? mem : MemoryOptionToMB[mem];
     }
   );

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -33,7 +33,7 @@ import { ParamSpec } from "../params/types";
 import { HttpsOptions } from "./providers/https";
 import * as logger from "../logger";
 
-export { RESET_VALUE, ResetValue } from "../common/options";
+export { RESET_VALUE } from "../common/options";
 
 /**
  * List of all regions supported by Cloud Functions v2

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -178,9 +178,6 @@ export interface GlobalOptions {
    */
   secrets?: string[];
 
-  /** Whether failed executions should be delivered again. */
-  retry?: boolean | Expression<boolean> | ResetValue;
-
   /**
    * Determines whether Firebase AppCheck is enforced.
    * When true, requests with invalid tokens autorespond with a 401

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -143,7 +143,7 @@ export interface GlobalOptions {
    * To revert to the CPU amounts used in gcloud or in Cloud Functions generation 1, set this
    * to the value "gcf_gen1"
    */
-  cpu?: number | "gcf_gen1" | ResetValue;
+  cpu?: number | "gcf_gen1";
 
   /**
    * Connect cloud function to specified VPC connector.
@@ -225,14 +225,14 @@ export interface EventHandlerOptions extends Omit<GlobalOptions, "enforceAppChec
   eventFilterPathPatterns?: Record<string, string | Expression<string>>;
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean | Expression<boolean> | null;
+  retry?: boolean | Expression<boolean> | ResetValue | null;
 
   /** Region of the EventArc trigger. */
   // region?: string | Expression<string> | null;
   region?: string;
 
   /** The service account that EventArc should use to invoke this function. Requires the P4SA to have ActAs permission on this service account. */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /** The name of the channel where the function receives events. */
   channel?: string;
@@ -273,7 +273,7 @@ export function optionsToEndpoint(
     "availableMemoryMb",
     "memory",
     (
-      mem: MemoryOption | Expression<number> | null | ResetValue
+      mem: MemoryOption | Expression<number> | ResetValue | null
     ): number | Expression<number> | null | ResetValue => {
       return typeof mem === "object" ? mem : MemoryOptionToMB[mem];
     }

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -90,53 +90,56 @@ export type IngressSetting = "ALLOW_ALL" | "ALLOW_INTERNAL_ONLY" | "ALLOW_INTERN
 export interface GlobalOptions {
   /**
    * Region where functions should be deployed.
-   * HTTP functions can override and specify more than one region.
    */
   region?: SupportedRegion | string;
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: MemoryOption | Expression<number> | ResetValue | null;
+  memory?: MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -147,42 +150,36 @@ export interface GlobalOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: IngressSetting | ResetValue | null;
+  ingressSettings?: IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.
    */
   labels?: Record<string, string>;
 
-  /**
-   * Invoker to set access control on https functions.
-   */
-  invoker?: "public" | "private" | string | string[];
-
   /*
    * Secrets to bind to a function.
    */
   secrets?: string[];
+
+  /** Whether failed executions should be delivered again. */
+  retry?: boolean | Expression<boolean> | ResetValue;
 
   /**
    * Determines whether Firebase AppCheck is enforced.
@@ -225,14 +222,14 @@ export interface EventHandlerOptions extends Omit<GlobalOptions, "enforceAppChec
   eventFilterPathPatterns?: Record<string, string | Expression<string>>;
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean | Expression<boolean> | ResetValue | null;
+  retry?: boolean | Expression<boolean> | ResetValue;
 
   /** Region of the EventArc trigger. */
   // region?: string | Expression<string> | null;
   region?: string;
 
   /** The service account that EventArc should use to invoke this function. Requires the P4SA to have ActAs permission on this service account. */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /** The name of the channel where the function receives events. */
   channel?: string;

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -176,7 +176,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -21,10 +21,11 @@
 // SOFTWARE.
 
 import { ManifestEndpoint } from "../../../runtime/manifest";
+import { ResetValue } from "../../../common/options";
 import { CloudEvent, CloudFunction } from "../../core";
+import { Expression } from "../../../params";
 import { wrapTraceContext } from "../../trace";
 import * as options from "../../options";
-import { Expression } from "../../../params";
 
 /**
  * The CloudEvent data emitted by Firebase Alerts.
@@ -93,7 +94,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -105,7 +106,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -113,13 +114,13 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -128,7 +129,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -144,25 +145,25 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -94,7 +94,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -106,7 +106,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -114,13 +114,13 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
@@ -129,7 +129,7 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -145,25 +145,25 @@ export interface FirebaseAlertOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -105,47 +105,51 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -156,27 +160,23 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -25,11 +25,12 @@
  * @packageDocumentation
  */
 
+import { ResetValue } from "../../../common/options";
+import { Expression } from "../../../params";
 import { CloudEvent, CloudFunction } from "../../core";
-import * as options from "../../options";
 import { wrapTraceContext } from "../../trace";
 import { convertAlertAndApp, FirebaseAlertData, getEndpointAnnotation } from "./alerts";
-import { Expression } from "../../../params";
+import * as options from "../../options";
 
 /**
  * The internal payload object for adding a new tester device to app distribution.
@@ -106,7 +107,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -118,7 +119,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -126,13 +127,13 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -141,7 +142,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -157,25 +158,25 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -189,7 +189,7 @@ export interface AppDistributionOptions extends options.EventHandlerOptions {
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -183,47 +183,51 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -234,27 +238,23 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -25,11 +25,12 @@
  * @packageDocumentation
  */
 
+import { ResetValue } from "../../../common/options";
+import { Expression } from "../../../params";
 import { CloudEvent, CloudFunction } from "../../core";
 import { wrapTraceContext } from "../../trace";
-import * as options from "../../options";
-import { Expression } from "../../../params";
 import { convertAlertAndApp, FirebaseAlertData, getEndpointAnnotation } from "./alerts";
+import * as options from "../../options";
 
 /** Generic Crashlytics issue interface */
 export interface Issue {
@@ -184,7 +185,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -196,7 +197,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -204,13 +205,13 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -219,7 +220,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -235,25 +236,25 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/alerts/crashlytics.ts
+++ b/src/v2/providers/alerts/crashlytics.ts
@@ -267,7 +267,7 @@ export interface CrashlyticsOptions extends options.EventHandlerOptions {
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -104,47 +104,51 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -155,27 +159,23 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.
@@ -188,7 +188,7 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean | Expression<boolean> | ResetValue | null;
+  retry?: boolean;
 }
 
 /**

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -23,15 +23,16 @@
 import { getApp } from "../../common/app";
 import { Change } from "../../common/change";
 import { ParamsOf } from "../../common/params";
+import { ResetValue } from "../../common/options";
 import { DataSnapshot } from "../../common/providers/database";
 import { normalizePath } from "../../common/utilities/path";
 import { PathPattern } from "../../common/utilities/path-pattern";
 import { applyChange } from "../../common/utilities/utils";
 import { ManifestEndpoint } from "../../runtime/manifest";
 import { CloudEvent, CloudFunction } from "../core";
+import { Expression } from "../../params";
 import { wrapTraceContext } from "../trace";
 import * as options from "../options";
-import { Expression } from "../../params";
 
 export { DataSnapshot };
 
@@ -105,7 +106,7 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -117,7 +118,7 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -125,13 +126,13 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -140,7 +141,7 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -156,25 +157,25 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.
@@ -187,7 +188,7 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean | Expression<boolean> | null;
+  retry?: boolean | Expression<boolean> | ResetValue | null;
 }
 
 /**

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -188,7 +188,7 @@ export interface ReferenceOptions<Ref extends string = string> extends options.E
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/eventarc.ts
+++ b/src/v2/providers/eventarc.ts
@@ -26,11 +26,12 @@
  */
 
 import { convertIfPresent, copyIfPresent } from "../../common/encoding";
+import { ResetValue } from "../../common/options";
 import { ManifestEndpoint } from "../../runtime/manifest";
 import { CloudEvent, CloudFunction } from "../core";
 import { wrapTraceContext } from "../trace";
-import * as options from "../options";
 import { Expression } from "../../params";
+import * as options from "../options";
 
 /** Options that can be set on an Eventarc trigger. */
 export interface EventarcTriggerOptions extends options.EventHandlerOptions {
@@ -69,7 +70,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -81,7 +82,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -89,13 +90,13 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -104,7 +105,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -120,25 +121,25 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/eventarc.ts
+++ b/src/v2/providers/eventarc.ts
@@ -68,47 +68,51 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -119,27 +123,23 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/eventarc.ts
+++ b/src/v2/providers/eventarc.ts
@@ -152,7 +152,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /** Handles an Eventarc event published on the default channel.

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -148,9 +148,6 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
    * Invoker to set access control on https functions.
    */
   invoker?: "public" | "private" | string | string[];
-
-  /** Whether failed executions should be delivered again. */
-  retry?: boolean;
 }
 
 /**

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -30,6 +30,7 @@ import * as express from "express";
 import { convertIfPresent, convertInvoker } from "../../common/encoding";
 import { wrapTraceContext } from "../trace";
 import { isDebugFeatureEnabled } from "../../common/debug";
+import { ResetValue } from "../../common/options";
 import {
   CallableRequest,
   FunctionsErrorCode,
@@ -61,7 +62,7 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -73,7 +74,7 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -81,13 +82,13 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -96,7 +97,7 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -112,25 +113,25 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -51,6 +51,7 @@ export { Request, CallableRequest, FunctionsErrorCode, HttpsError };
 export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
   /** HTTP functions can override global options and can specify multiple regions to deploy to. */
   region?: SupportedRegion | string | Array<SupportedRegion | string>;
+
   /** If true, allows CORS on requests to this function.
    * If this is a `string` or `RegExp`, allows requests from domains that match the provided value.
    * If this is an `Array`, allows requests from domains matching at least one entry of the array.
@@ -60,47 +61,51 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -111,42 +116,38 @@ export interface HttpsOptions extends Omit<GlobalOptions, "region"> {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.
    */
   labels?: Record<string, string>;
 
-  /**
-   * Invoker to set access control on https functions.
-   */
-  invoker?: "public" | "private" | string | string[];
-
   /*
    * Secrets to bind to a function.
    */
   secrets?: string[];
+
+  /**
+   * Invoker to set access control on https functions.
+   */
+  invoker?: "public" | "private" | string | string[];
 
   /** Whether failed executions should be delivered again. */
   retry?: boolean;

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -151,9 +151,6 @@ export interface BlockingOptions {
    * Secrets to bind to a function.
    */
   secrets?: string[];
-
-  /** Whether failed executions should be delivered again. */
-  retry?: boolean;
 }
 
 /**

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -69,47 +69,51 @@ export interface BlockingOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -120,27 +124,23 @@ export interface BlockingOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.
@@ -151,6 +151,9 @@ export interface BlockingOptions {
    * Secrets to bind to a function.
    */
   secrets?: string[];
+
+  /** Whether failed executions should be delivered again. */
+  retry?: boolean;
 }
 
 /**

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -24,6 +24,7 @@
  * Cloud functions to handle events from Google Cloud Identity Platform.
  * @packageDocumentation
  */
+import { ResetValue } from "../../common/options";
 import {
   AuthBlockingEvent,
   AuthBlockingEventType,
@@ -70,7 +71,7 @@ export interface BlockingOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -82,7 +83,7 @@ export interface BlockingOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -90,13 +91,13 @@ export interface BlockingOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -105,7 +106,7 @@ export interface BlockingOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -121,25 +122,25 @@ export interface BlockingOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -161,47 +161,51 @@ export interface PubSubOptions extends options.EventHandlerOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -212,27 +216,23 @@ export interface PubSubOptions extends options.EventHandlerOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -245,7 +245,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -26,11 +26,12 @@
  */
 
 import { copyIfPresent } from "../../common/encoding";
+import { ResetValue } from "../../common/options";
 import { ManifestEndpoint } from "../../runtime/manifest";
 import { CloudEvent, CloudFunction } from "../core";
 import { wrapTraceContext } from "../trace";
-import * as options from "../options";
 import { Expression } from "../../params";
+import * as options from "../options";
 
 /**
  * Google Cloud Pub/Sub is a globally distributed message bus that automatically scales as you need it.
@@ -162,7 +163,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -174,7 +175,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -182,13 +183,13 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -197,7 +198,7 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -213,25 +214,25 @@ export interface PubSubOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/scheduler.ts
+++ b/src/v2/providers/scheduler.ts
@@ -23,22 +23,24 @@
 import * as express from "express";
 
 import { copyIfPresent } from "../../common/encoding";
+import { ResetValue } from "../../common/options";
 import { timezone } from "../../common/timezone";
 import { ManifestEndpoint, ManifestRequiredAPI } from "../../runtime/manifest";
 import { HttpsFunction } from "./https";
 import { wrapTraceContext } from "../trace";
+import { Expression } from "../../params";
 import * as logger from "../../logger";
 import * as options from "../options";
 
 /** @hidden */
 interface ScheduleArgs {
-  schedule: string;
-  timeZone?: timezone;
-  retryCount?: number;
-  maxRetrySeconds?: number;
-  minBackoffSeconds?: number;
-  maxBackoffSeconds?: number;
-  maxDoublings?: number;
+  schedule: string | Expression<string>;
+  timeZone?: timezone | Expression<string> | ResetValue;
+  retryCount?: number | Expression<number> | ResetValue;
+  maxRetrySeconds?: number | Expression<number> | ResetValue;
+  minBackoffSeconds?: number | Expression<number> | ResetValue;
+  maxBackoffSeconds?: number | Expression<number> | ResetValue;
+  maxDoublings?: number | Expression<number> | ResetValue;
   opts: options.GlobalOptions;
 }
 
@@ -97,22 +99,22 @@ export interface ScheduleOptions extends options.GlobalOptions {
   schedule: string;
 
   /** The timezone that the schedule executes in. */
-  timeZone?: timezone;
+  timeZone?: timezone | Expression<string> | ResetValue;
 
   /** The number of retry attempts for a failed run. */
-  retryCount?: number;
+  retryCount?: number | Expression<number> | ResetValue;
 
   /** The time limit for retrying. */
-  maxRetrySeconds?: number;
+  maxRetrySeconds?: number | Expression<number> | ResetValue;
 
   /** The minimum time to wait before retying. */
-  minBackoffSeconds?: number;
+  minBackoffSeconds?: number | Expression<number> | ResetValue;
 
   /** The maximum time to wait before retrying. */
-  maxBackoffSeconds?: number;
+  maxBackoffSeconds?: number | Expression<number> | ResetValue;
 
   /** The time between will double max doublings times. */
-  maxDoublings?: number;
+  maxDoublings?: number | Expression<number> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -209,47 +209,51 @@ export interface StorageOptions extends options.EventHandlerOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -260,27 +264,23 @@ export interface StorageOptions extends options.EventHandlerOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -293,7 +293,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
   secrets?: string[];
 
   /** Whether failed executions should be delivered again. */
-  retry?: boolean;
+  retry?: boolean | Expression<boolean> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -27,11 +27,12 @@
 
 import { firebaseConfig } from "../../common/config";
 import { copyIfPresent } from "../../common/encoding";
+import { ResetValue } from "../../common/options";
 import { ManifestEndpoint } from "../../runtime/manifest";
 import { CloudEvent, CloudFunction } from "../core";
 import { wrapTraceContext } from "../trace";
-import * as options from "../options";
 import { Expression } from "../../params";
+import * as options from "../options";
 
 /**
  * An object within Google Cloud Storage.
@@ -210,7 +211,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -222,7 +223,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -230,13 +231,13 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -245,7 +246,7 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -261,25 +262,25 @@ export interface StorageOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -147,9 +147,6 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Secrets to bind to a function.
    */
   secrets?: string[];
-
-  /** Whether failed executions should be delivered again. */
-  retry?: boolean;
 }
 
 /**

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -26,6 +26,7 @@
  */
 
 import { convertIfPresent, convertInvoker, copyIfPresent } from "../../common/encoding";
+import { ResetValue } from "../../common/options";
 import {
   AuthData,
   onDispatchHandler,
@@ -64,7 +65,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Amount of memory to allocate to a function.
    * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
@@ -76,7 +77,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue | null;
 
   /**
    * Min number of actual instances to be running at a given time.
@@ -84,13 +85,13 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * while idle.
    * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | null;
+  minInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Max number of instances to be running in parallel.
    * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | null;
+  maxInstances?: number | Expression<number> | ResetValue | null;
 
   /**
    * Number of requests a function can serve at once.
@@ -99,7 +100,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | null;
+  concurrency?: number | Expression<number> | ResetValue | null;
 
   /**
    * Fractional number of CPUs to allocate to a function.
@@ -115,25 +116,25 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Connect cloud function to specified VPC connector.
    * A value of null removes the VPC connector
    */
-  vpcConnector?: string | null;
+  vpcConnector?: string | ResetValue | null;
 
   /**
    * Egress settings for VPC connector.
    * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
 
   /**
    * Specific service account for the function to run as.
    * A value of null restores the default service account.
    */
-  serviceAccount?: string | null;
+  serviceAccount?: string | ResetValue | null;
 
   /**
    * Ingress settings which control where this function can be called from.
    * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | null;
+  ingressSettings?: options.IngressSetting | ResetValue | null;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -50,6 +50,8 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
 
   /**
    * Who can enqueue tasks for this function.
+   *
+   * @remakrs
    * If left unspecified, only service accounts which have
    * `roles/cloudtasks.enqueuer` and `roles/cloudfunctions.invoker`
    * will have permissions.
@@ -63,47 +65,51 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
 
   /**
    * Amount of memory to allocate to a function.
-   * A value of null restores the defaults of 256MB.
    */
-  memory?: options.MemoryOption | Expression<number> | ResetValue | null;
+  memory?: options.MemoryOption | Expression<number> | ResetValue;
 
   /**
    * Timeout for the function in sections, possible values are 0 to 540.
    * HTTPS functions can specify a higher timeout.
-   * A value of null restores the default of 60s
+   *
+   * @remarks
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
    * maximum timeout of 36,00s (1 hour). Task queue functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
-  timeoutSeconds?: number | Expression<number> | ResetValue | null;
+  timeoutSeconds?: number | Expression<number> | ResetValue;
 
   /**
    * Min number of actual instances to be running at a given time.
+   *
+   * @remarks
    * Instances will be billed for memory allocation and 10% of CPU allocation
    * while idle.
-   * A value of null restores the default min instances.
    */
-  minInstances?: number | Expression<number> | ResetValue | null;
+  minInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Max number of instances to be running in parallel.
-   * A value of null restores the default max instances.
    */
-  maxInstances?: number | Expression<number> | ResetValue | null;
+  maxInstances?: number | Expression<number> | ResetValue;
 
   /**
    * Number of requests a function can serve at once.
+   *
+   * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
    * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
-  concurrency?: number | Expression<number> | ResetValue | null;
+  concurrency?: number | Expression<number> | ResetValue;
 
   /**
    * Fractional number of CPUs to allocate to a function.
+   *
+   * @remarks
    * Defaults to 1 for functions with <= 2GB RAM and increases for larger memory sizes.
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
@@ -114,27 +120,23 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
 
   /**
    * Connect cloud function to specified VPC connector.
-   * A value of null removes the VPC connector
    */
-  vpcConnector?: string | ResetValue | null;
+  vpcConnector?: string | ResetValue;
 
   /**
    * Egress settings for VPC connector.
-   * A value of null turns off VPC connector egress settings
    */
-  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue | null;
+  vpcConnectorEgressSettings?: options.VpcEgressSetting | ResetValue;
 
   /**
    * Specific service account for the function to run as.
-   * A value of null restores the default service account.
    */
-  serviceAccount?: string | ResetValue | null;
+  serviceAccount?: string | ResetValue;
 
   /**
    * Ingress settings which control where this function can be called from.
-   * A value of null turns off ingress settings.
    */
-  ingressSettings?: options.IngressSetting | ResetValue | null;
+  ingressSettings?: options.IngressSetting | ResetValue;
 
   /**
    * User labels to set on the function.

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -147,6 +147,9 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * Secrets to bind to a function.
    */
   secrets?: string[];
+
+  /** Whether failed executions should be delivered again. */
+  retry?: boolean;
 }
 
 /**


### PR DESCRIPTION
Instead of allowing `null`s to reset a configuration value, we are introducing a new sentinel value, `RESET_VALUE` to make it clear the intention of resetting the config value to platform default:

```js
import * as functions from "firebase-functions/v1";
import { onRequest } from "firebase-functions/v2/https";
import { RESET_VALUE } from "firebase-functions/v2/options";

export const v1Req = functions
  .runWith({
    minInstances: functions.RESET_VALUE,
    memory: functions.RESET_VALUE,
    serviceAccount: RESET_VALUE
  }).https.onRequest(
    (req, res) => {
      res.sendStatus(200)
    },
);

export const v2Req = onRequest(
  {
   memory: RESET_VALUE,
   minInstances: RESET_VALUE,
  },
  (req, res) => {
    res.sendStatus(200)
  },
);
```

Majority of this PR concerns fixing/updating typings on various configuration options.

Recall that in v2, we inlined/repeat all function options in each respective providers to make reference doc more clear. This unfortunately bloated up this PR since I had to repeat the changes in each and every provider.