### PR TITLE
Remove manifest types from API.

### DIFF
--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -426,17 +426,3 @@ export class BooleanParam extends Param<boolean> {
     return new TernaryExpression(this, ifTrue, ifFalse);
   }
 }
-
-/** @hidden */
-export class ListParam extends Param<string[]> {
-  static type: ParamValueType = "list";
-
-  /** @internal */
-  runtimeValue(): string[] {
-    throw new Error("Not implemented");
-  }
-
-  toSpec(): WireParamSpec<string[]> {
-    throw new Error("Not implemented");
-  }
-}

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -26,6 +26,8 @@ import { WireParamSpec } from "../params/types";
 
 /**
  * An definition of a function as appears in the Manifest.
+ *
+ * @internal
  */
 export interface ManifestEndpoint {
   entryPoint?: string;
@@ -100,6 +102,7 @@ export interface ManifestEndpoint {
   };
 }
 
+/** @internal */
 export interface ManifestRequiredAPI {
   api: string;
   reason: string;
@@ -107,6 +110,7 @@ export interface ManifestRequiredAPI {
 
 /**
  * An definition of a function deployment as appears in the Manifest.
+ * @internal
  */
 export interface ManifestStack {
   specVersion: "v1alpha1";

--- a/src/v1/providers/tasks.ts
+++ b/src/v1/providers/tasks.ts
@@ -65,10 +65,10 @@ export interface TaskQueueOptions {
 export interface TaskQueueFunction {
   (req: Request, res: express.Response): Promise<void>;
 
-  /** @alpha */
+  /** @internal */
   __endpoint: ManifestEndpoint;
 
-  /** @alpha */
+  /** @internal */
   __requiredAPIs?: ManifestRequiredAPI[];
 
   /**

--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -70,7 +70,7 @@ export interface CloudEvent<T> {
 export interface CloudFunction<EventType extends CloudEvent<unknown>> {
   (raw: CloudEvent<unknown>): any | Promise<any>;
 
-  /** @alpha */
+  /** @internal */
   __endpoint: ManifestEndpoint;
 
   /**

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -173,7 +173,7 @@ export type HttpsFunction = ((
   /** An Express response object, for this function to respond to callers. */
   res: express.Response
 ) => void | Promise<void>) & {
-  /** @alpha */
+  /** @internal */
   __endpoint: ManifestEndpoint;
 };
 


### PR DESCRIPTION
Right now, `launch.next` has some issues with inconsistently exposing types that concerns the container contract manifest.

This is sweep to make all Manifest-related types internal. Developers shouldn't need these types for their daily uses anyway.