### PR TITLE
Re-export manifest types for use by internal packages.

### DIFF
--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -226,8 +226,14 @@ export type ParamSpec<T extends string | number | boolean | string[]> = {
   input?: ParamInput<T>;
 };
 
-// N.B: a WireParamSpec is just a ParamSpec with default expressions converted into a CEL literal
-/** @internal */
+/**
+ * Representation of parameters for the stack over the wire.
+ *
+ * @remarks
+ * N.B: a WireParamSpec is just a ParamSpec with default expressions converted into a CEL literal
+ *
+ * @alpha
+ */
 export type WireParamSpec<T extends string | number | boolean | string[]> = {
   name: string;
   default?: T | string;

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -27,7 +27,7 @@ import { WireParamSpec } from "../params/types";
 /**
  * An definition of a function as appears in the Manifest.
  *
- * @internal
+ * @alpha
  */
 export interface ManifestEndpoint {
   entryPoint?: string;
@@ -102,7 +102,10 @@ export interface ManifestEndpoint {
   };
 }
 
-/** @internal */
+/**
+ * Description of API required for this stack.
+ * @alpha
+ */
 export interface ManifestRequiredAPI {
   api: string;
   reason: string;
@@ -110,7 +113,7 @@ export interface ManifestRequiredAPI {
 
 /**
  * An definition of a function deployment as appears in the Manifest.
- * @internal
+ * @alpha
  */
 export interface ManifestStack {
   specVersion: "v1alpha1";
@@ -123,7 +126,8 @@ export interface ManifestStack {
  * Returns the JSON representation of a ManifestStack, which has CEL
  * expressions in its options as object types, with its expressions
  * transformed into the actual CEL strings.
- * @internal
+ *
+ * @alpha
  */
 export function stackToWire(stack: ManifestStack): Record<string, unknown> {
   const wireStack = stack as any;

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -239,10 +239,10 @@ export interface Runnable<T> {
 export interface HttpsFunction {
   (req: Request, resp: Response): void | Promise<void>;
 
-  /** @internal */
+  /** @alpha */
   __endpoint: ManifestEndpoint;
 
-  /** @internal */
+  /** @alpha */
   __requiredAPIs?: ManifestRequiredAPI[];
 }
 
@@ -259,10 +259,10 @@ export interface BlockingFunction {
   /** @public */
   (req: Request, resp: Response): void | Promise<void>;
 
-  /** @internal */
+  /** @alpha */
   __endpoint: ManifestEndpoint;
 
-  /** @internal */
+  /** @alpha */
   __requiredAPIs?: ManifestRequiredAPI[];
 }
 
@@ -276,10 +276,10 @@ export interface BlockingFunction {
 export interface CloudFunction<T> extends Runnable<T> {
   (input: any, context?: any): PromiseLike<any> | any;
 
-  /** @internal */
+  /** @alpha */
   __endpoint: ManifestEndpoint;
 
-  /** @internal */
+  /** @alpha */
   __requiredAPIs?: ManifestRequiredAPI[];
 }
 

--- a/src/v1/providers/tasks.ts
+++ b/src/v1/providers/tasks.ts
@@ -65,10 +65,10 @@ export interface TaskQueueOptions {
 export interface TaskQueueFunction {
   (req: Request, res: express.Response): Promise<void>;
 
-  /** @internal */
+  /** @alpha */
   __endpoint: ManifestEndpoint;
 
-  /** @internal */
+  /** @alpha */
   __requiredAPIs?: ManifestRequiredAPI[];
 
   /**

--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -70,7 +70,7 @@ export interface CloudEvent<T> {
 export interface CloudFunction<EventType extends CloudEvent<unknown>> {
   (raw: CloudEvent<unknown>): any | Promise<any>;
 
-  /** @internal */
+  /** @alpha */
   __endpoint: ManifestEndpoint;
 
   /**

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -173,7 +173,7 @@ export type HttpsFunction = ((
   /** An Express response object, for this function to respond to callers. */
   res: express.Response
 ) => void | Promise<void>) & {
-  /** @internal */
+  /** @alpha */
   __endpoint: ManifestEndpoint;
 };
 


### PR DESCRIPTION
Reverts https://github.com/firebase/firebase-functions/pull/1259 - instead do it the "right" way.