### PR TITLE
Update release script to support making release candidates

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -88,10 +88,10 @@ npm run build:release
 echo "Ran publish build."
 
 echo "Making a $VERSION version..."
-if [[ $PRE_RELEASE == "" ]]; then
-  npm version $VERSION
-else
+if [[ $PRE_RELEASE != "" ]]; then
   npm version pre$VERSION --preid=rc
+else
+  npm version $VERSION
 fi
 NEW_VERSION=$(jq -r ".version" package.json)
 echo "Made a $NEW_VERSION version."
@@ -105,11 +105,11 @@ cat CHANGELOG.md >> "${RELEASE_NOTES_FILE}"
 echo "Made the release notes."
 
 echo "Publishing to npm..."
-if [[ $DRY_RUN == "" ]]; then
-  npm publish
-else
+if [[ $DRY_RUN != "" ]]; then
   echo "DRY RUN: running publish with --dry-run"
   npm publish --dry-run
+else
+  npm publish
 fi
 echo "Published to npm."
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,14 +2,12 @@
 set -e
 
 printusage() {
-  echo "publish.sh <version> [--prerelease]"
+  echo "publish.sh <version>"
   echo "REPOSITORY_ORG and REPOSITORY_NAME should be set in the environment."
   echo "e.g. REPOSITORY_ORG=user, REPOSITORY_NAME=repo"
   echo ""
   echo "Arguments:"
   echo "  version: 'patch', 'minor', or 'major'."
-  echo "Flags:"
-  echo "  --prerelease: Set to publish a prerelease version (e.g. 4.0.1-rc.0)"
 }
 
 VERSION=$1
@@ -19,11 +17,6 @@ if [[ $VERSION == "" ]]; then
 elif [[ ! ($VERSION == "patch" || $VERSION == "minor" || $VERSION == "major") ]]; then
   printusage
   exit 1
-fi
-
-PRERELEASE=false
-if [[ $2 == "--prerelease" || $2 == "-p" ]]; then
-  PRERELEASE=true
 fi
 
 if [[ $REPOSITORY_ORG == "" ]]; then
@@ -95,10 +88,10 @@ npm run build:release
 echo "Ran publish build."
 
 echo "Making a $VERSION version..."
-if [[ "$PRERELEASE" = true ]]; then
-  npm version pre$VERSION --preid=rc
-else
+if [[ $PRE_RELEASE == "" ]]; then
   npm version $VERSION
+else
+  npm version pre$VERSION --preid=rc
 fi
 NEW_VERSION=$(jq -r ".version" package.json)
 echo "Made a $NEW_VERSION version."
@@ -119,6 +112,11 @@ else
   npm publish --dry-run
 fi
 echo "Published to npm."
+
+if [[ $PRE_RELEASE != "" ]]; then
+  echo "Published a pre-release version. Skipping post-release actions."
+  exit
+fi
 
 if [[ $DRY_RUN != "" ]]; then
   echo "All other commands are mutations, and we are doing a dry run."

--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -94,11 +94,12 @@ steps:
   # Publish the package.
   - name: "gcr.io/$PROJECT_ID/package-builder"
     dir: "${_REPOSITORY_NAME}"
-    args: ["bash", "./scripts/publish.sh", "${_VERSION}", "${_PRERELEASE}"]
+    args: ["bash", "./scripts/publish.sh", "${_VERSION}"]
     env:
       - "REPOSITORY_ORG=${_REPOSITORY_ORG}"
       - "REPOSITORY_NAME=${_REPOSITORY_NAME}"
       - "DRY_RUN=${_DRY_RUN}"
+      - "PRE_RELEASE=${_PRE_RELEASE}"
 
 options:
   volumes:
@@ -107,7 +108,7 @@ options:
 
 substitutions:
   _VERSION: ""
-  _PRERELEASE: ""
+  _PRE_RELEASE: ""
   _DRY_RUN: ""
   _KEY_RING: "npm-publish-keyring"
   _KEY_NAME: "publish"

--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -94,7 +94,7 @@ steps:
   # Publish the package.
   - name: "gcr.io/$PROJECT_ID/package-builder"
     dir: "${_REPOSITORY_NAME}"
-    args: ["bash", "./scripts/publish.sh", "${_VERSION}"]
+    args: ["bash", "./scripts/publish.sh", "${_VERSION}", "${_PRERELEASE}"]
     env:
       - "REPOSITORY_ORG=${_REPOSITORY_ORG}"
       - "REPOSITORY_NAME=${_REPOSITORY_NAME}"
@@ -107,6 +107,7 @@ options:
 
 substitutions:
   _VERSION: ""
+  _PRERELEASE: ""
   _DRY_RUN: ""
   _KEY_RING: "npm-publish-keyring"
   _KEY_NAME: "publish"


### PR DESCRIPTION
Adding a new flag to allow us to create a release candidates with versions like `4.0.0-rc.0`.

Instructions added on go/publish-via-cloud-build.