### PR TITLE
removed duplicate key in package.json typesVersions

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,9 +90,6 @@
       "v1/https": [
         "lib/v1/providers/https"
       ],
-      "v1/https": [
-        "./lib/v1/providers/https"
-      ],
       "v1/pubsub": [
         "lib/v1/providers/pubsub"
       ],


### PR DESCRIPTION
### Description

It looks like my previous PR #1287  and this commit #1267 had a merge conflict that resulted in a duplicate key in the ```typesVersions``` object in ```package.json```

In this PR I deleted the wrong path for the ```v1/https``` key.
