### PR TITLE
Send the port on which the server was opened back to the parent process

### DIFF
--- a/src/bin/firebase-functions.ts
+++ b/src/bin/firebase-functions.ts
@@ -78,4 +78,9 @@ if (process.env.PORT) {
 }
 
 console.log("Serving at port", port);
-server = app.listen(port);
+server = app.listen(port, () => {
+  const address = server.address();
+  if (process.send && typeof address === "object") {
+    process.send(address.port);
+  }
+});


### PR DESCRIPTION
### Description

Send the port on which the server was opened back to the parent process, if this process was opened with an (node) IPC channel. If no such channel exists, nothing is changed.

### Code sample

```
      childProcess.on("message", (port: Serializable) => {
        if (typeof port === "number") {
          // port is the port number of the child process.
        } else {
          // handle error
        }
      });
```
