### PR TITLE
Allow emitting eventarc channels as params

### DIFF
--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -61,7 +61,7 @@ export interface ManifestEndpoint {
   eventTrigger?: {
     eventFilters: Record<string, string | Expression<string>>;
     eventFilterPathPatterns?: Record<string, string | Expression<string>>;
-    channel?: string;
+    channel?: string | Expression<string>;
     eventType: string;
     retry: boolean | Expression<boolean> | ResetValue;
     region?: string;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -258,7 +258,7 @@ export interface EventHandlerOptions extends Omit<GlobalOptions, "enforceAppChec
   serviceAccount?: string | ResetValue;
 
   /** The name of the channel where the function receives events. */
-  channel?: string;
+  channel?: string | Expression<string>;
 }
 
 /**

--- a/src/v2/providers/eventarc.ts
+++ b/src/v2/providers/eventarc.ts
@@ -55,7 +55,7 @@ export interface EventarcTriggerOptions extends options.EventHandlerOptions {
    * If not specified, the default Firebase channel will be used:
    * `projects/{project}/locations/us-central1/channels/firebase`
    */
-  channel?: string;
+  channel?: string | Expression<string>;
 
   /**
    * Eventarc event exact match filter.


### PR DESCRIPTION
As far as interesting PRs go, this ain't it, chief.

Though I have to say it's a little surprising that we define channel as a possible field on the base EventOptions class, despite it only being meaningful to have in one type of Event trigger option? That seems like not how classes should work, unless I'm really missing something about Typescript?