### PR TITLE
booleanParams need thenElse too

### DIFF
--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -277,13 +277,13 @@ describe("Params as CEL", () => {
     const booleanExpr = params.defineBoolean("BOOL");
     const cmpExpr = params.defineInt("A").cmp("!=", params.defineInt("B"));
 
-    expect(booleanExpr.then("asdf", "jkl;").toCEL()).to.equal(
+    expect(booleanExpr.thenElse("asdf", "jkl;").toCEL()).to.equal(
       '{{ params.BOOL ? "asdf" : "jkl;" }}'
     );
-    expect(booleanExpr.then(-11, 22).toCEL()).to.equal("{{ params.BOOL ? -11 : 22 }}");
-    expect(booleanExpr.then(false, true).toCEL()).to.equal("{{ params.BOOL ? false : true }}");
+    expect(booleanExpr.thenElse(-11, 22).toCEL()).to.equal("{{ params.BOOL ? -11 : 22 }}");
+    expect(booleanExpr.thenElse(false, true).toCEL()).to.equal("{{ params.BOOL ? false : true }}");
     expect(
-      booleanExpr.then(params.defineString("FOO"), params.defineString("BAR")).toCEL()
+      booleanExpr.thenElse(params.defineString("FOO"), params.defineString("BAR")).toCEL()
     ).to.equal("{{ params.BOOL ? params.FOO : params.BAR }}");
     expect(cmpExpr.thenElse("asdf", "jkl;").toCEL()).to.equal(
       '{{ params.A != params.B ? "asdf" : "jkl;" }}'

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -452,7 +452,15 @@ export class BooleanParam extends Param<boolean> {
     return !!process.env[this.name] && process.env[this.name] === "true";
   }
 
+  /** @deprecated */
   then<T extends string | number | boolean>(ifTrue: T | Expression<T>, ifFalse: T | Expression<T>) {
+    return this.thenElse(ifTrue, ifFalse);
+  }
+
+  thenElse<T extends string | number | boolean>(
+    ifTrue: T | Expression<T>,
+    ifFalse: T | Expression<T>
+  ) {
     return new TernaryExpression(this, ifTrue, ifFalse);
   }
 }


### PR DESCRIPTION
The ternary operator for params is defined in two different places (one covering explicitly defined params, and the other covering synthetic params of boolean type) and #1268 changed the function name only for the latter.