### PR TITLE
Fix bug where SDK returned annonymous function instead of return value specified in user code to the Functions Framework.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Fix bug where some FireAlerts v2 functions didn't correctly return values back to Functions Framework. (#1324)

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -215,7 +215,7 @@ export function onAlertPublished<T extends { ["@type"]: string } = any>(
   const [opts, alertType, appId] = getOptsAndAlertTypeAndApp(alertTypeOrOpts);
 
   const func = (raw: CloudEvent<unknown>) => {
-    return wrapTraceContext(handler(convertAlertAndApp(raw) as AlertEvent<T>));
+    return wrapTraceContext(handler)(convertAlertAndApp(raw) as AlertEvent<T>);
   };
 
   func.run = handler;

--- a/src/v2/providers/alerts/appDistribution.ts
+++ b/src/v2/providers/alerts/appDistribution.ts
@@ -250,8 +250,8 @@ export function onNewTesterIosDevicePublished(
   const [opts, appId] = getOptsAndApp(appIdOrOptsOrHandler);
 
   const func = (raw: CloudEvent<unknown>) => {
-    return wrapTraceContext(
-      handler(convertAlertAndApp(raw) as AppDistributionEvent<NewTesterDevicePayload>)
+    return wrapTraceContext(handler)(
+      convertAlertAndApp(raw) as AppDistributionEvent<NewTesterDevicePayload>
     );
   };
 
@@ -315,8 +315,8 @@ export function onInAppFeedbackPublished(
   const [opts, appId] = getOptsAndApp(appIdOrOptsOrHandler);
 
   const func = (raw: CloudEvent<unknown>) => {
-    return wrapTraceContext(
-      handler(convertAlertAndApp(raw) as AppDistributionEvent<InAppFeedbackPayload>)
+    return wrapTraceContext(handler)(
+      convertAlertAndApp(raw) as AppDistributionEvent<InAppFeedbackPayload>
     );
   };
 

--- a/src/v2/providers/alerts/billing.ts
+++ b/src/v2/providers/alerts/billing.ts
@@ -152,7 +152,7 @@ export function onOperation<T>(
   }
 
   const func = (raw: CloudEvent<unknown>) => {
-    return wrapTraceContext(handler(convertAlertAndApp(raw) as BillingEvent<T>));
+    return wrapTraceContext(handler)(convertAlertAndApp(raw) as BillingEvent<T>);
   };
 
   func.run = handler;

--- a/src/v2/providers/testLab.ts
+++ b/src/v2/providers/testLab.ts
@@ -190,7 +190,7 @@ export function onTestMatrixCompleted(
   const specificOpts = optionsToEndpoint(optsOrHandler);
 
   const func: any = (raw: CloudEvent<unknown>) => {
-    return wrapTraceContext(handler(raw as CloudEvent<TestMatrixCompletedData>));
+    return wrapTraceContext(handler)(raw as CloudEvent<TestMatrixCompletedData>);
   };
   func.run = handler;
 

--- a/src/v2/trace.ts
+++ b/src/v2/trace.ts
@@ -28,6 +28,6 @@ export function wrapTraceContext(
       // eslint-disable-next-line prefer-spread
       return handler.apply(null, args);
     }
-    traceContext.run(traceParent, handler, ...args);
+    return traceContext.run(traceParent, handler, ...args);
   };
 }


### PR DESCRIPTION
Given a FireAlerts-triggered function:

```
export const x = onInAppFeedbackPublished((event) => true);
```

Users will see following error logs:

> x: Error serializing return value: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array or an Array-like Object. Received type function ([Function (anonymous)])

While the error log isn't indicative of real errors (user code still runs and background function's return value are thrown away anyway), it's still annoying.

The root issue turned out to be that the `wrapTraceContext` that is suppose to wrap user-defined handler was called incorrectly in couple of places. 