### PR TITLE
Fixes an emulator issue where snapshot.ref could not point to multiple databases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 - Allow Functions to specify vpcConnector as a string parameter (#1329)
 - Upgrade jsonwebtoken to version 9 (#1336)
 - Adds 'eventarcpublishing' as required API to custom event function
-- Fixes an emulator issue where functions could not point to multiple databases.
+- Fixes an emulator issue where snapshot.ref could not point to multiple databases (#1339).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Allow Functions to specify vpcConnector as a string parameter (#1329)
 - Upgrade jsonwebtoken to version 9 (#1336)
 - Adds 'eventarcpublishing' as required API to custom event function
+- Fixes an emulator issue where functions could not point to multiple databases.

--- a/src/common/providers/database.ts
+++ b/src/common/providers/database.ts
@@ -50,10 +50,7 @@ export class DataSnapshot implements database.DataSnapshot {
     instance?: string
   ) {
     const config = firebaseConfig();
-    if (app?.options?.databaseURL?.startsWith("http:")) {
-      // In this case we're dealing with an emulator
-      this.instance = app.options.databaseURL;
-    } else if (instance) {
+    if (instance) {
       // SDK always supplies instance, but user's unit tests may not
       this.instance = instance;
     } else if (app) {

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -465,7 +465,7 @@ export function onChangedOperation<Ref extends string>(
   // wrap the handler
   const func = (raw: CloudEvent<unknown>) => {
     const event = raw as RawRTDBCloudEvent;
-    const instanceUrl = `https://${event.instance}.${event.firebasedatabasehost}`;
+    const instanceUrl = getInstance(event);
     const params = makeParams(event, pathPattern, instancePattern) as unknown as ParamsOf<Ref>;
     const databaseEvent = makeChangedDatabaseEvent(event, instanceUrl, params);
     return wrapTraceContext(handler)(databaseEvent);
@@ -492,7 +492,7 @@ export function onOperation<Ref extends string>(
   // wrap the handler
   const func = (raw: CloudEvent<unknown>) => {
     const event = raw as RawRTDBCloudEvent;
-    const instanceUrl = `https://${event.instance}.${event.firebasedatabasehost}`;
+    const instanceUrl = getInstance(event);
     const params = makeParams(event, pathPattern, instancePattern) as unknown as ParamsOf<Ref>;
     const data = eventType === deletedEventType ? event.data.data : event.data.delta;
     const databaseEvent = makeDatabaseEvent(event, data, instanceUrl, params);
@@ -504,4 +504,9 @@ export function onOperation<Ref extends string>(
   func.__endpoint = makeEndpoint(eventType, opts, pathPattern, instancePattern);
 
   return func;
+}
+
+function getInstance(event: RawRTDBCloudEvent) {
+  const emuHost = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
+  return (emuHost) ? `http://${emuHost}/?ns=${event.instance}` : `https://${event.instance}.${event.firebasedatabasehost}`;
 }

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -508,5 +508,7 @@ export function onOperation<Ref extends string>(
 
 function getInstance(event: RawRTDBCloudEvent) {
   const emuHost = process.env.FIREBASE_DATABASE_EMULATOR_HOST;
-  return (emuHost) ? `http://${emuHost}/?ns=${event.instance}` : `https://${event.instance}.${event.firebasedatabasehost}`;
+  return emuHost
+    ? `http://${emuHost}/?ns=${event.instance}`
+    : `https://${event.instance}.${event.firebasedatabasehost}`;
 }


### PR DESCRIPTION
Per @fredzqm, we don't need the first condition of the snapshot constructor to figure out the instance. Fixes https://github.com/firebase/firebase-tools/issues/3961