### PR TITLE
fix(params): exporting additional type information

### DIFF
--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -27,7 +27,6 @@
 
 import {
   BooleanParam,
-  Expression,
   FloatParam,
   IntParam,
   Param,
@@ -38,7 +37,18 @@ import {
   InternalExpression,
 } from "./types";
 
-export { ParamOptions, Expression };
+export {
+  BooleanParam,
+  Expression,
+  FloatParam,
+  IntParam,
+  Param,
+  ParamOptions,
+  SecretParam,
+  StringParam,
+  ListParam,
+  InternalExpression,
+} from "./types";
 
 type SecretOrExpr = Param<any> | SecretParam;
 export const declaredParams: SecretOrExpr[] = [];


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

As per [this](https://firebase.google.com/docs/functions/config-env#secret_parameters) doc, I've been using the `defineSecret` function. The return type `SecretParam` was not available for direct use.

```ts
import { SecretParam } from 'firebase-functions/params'; // fails
import { SecretParam } from 'firebase-functions/params/types.d'; // fails
```

This PR fixes it.

closes #1549

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

With this PR we can do the following:

```ts
import { SecretParam } from 'firebase-functions/params'
```