### PR TITLE
Print failure to load customer code to stderr

### DIFF
--- a/src/bin/firebase-functions.ts
+++ b/src/bin/firebase-functions.ts
@@ -67,6 +67,7 @@ if (process.env.FUNCTIONS_CONTROL_API === "true") {
       res.setHeader("content-type", "text/yaml");
       res.send(JSON.stringify(stackToWire(stack)));
     } catch (e) {
+      console.error(e);
       res.status(400).send(`Failed to generate manifest from function source: ${e}`);
     }
   });


### PR DESCRIPTION
Couples with changes in the CLI to print stack traces if HTTP discovery fails