### PR TITLE
Don't overwrite structured 'message' in logs with empty string.

### DIFF
--- a/spec/logger.spec.ts
+++ b/spec/logger.spec.ts
@@ -61,6 +61,24 @@ describe("logger", () => {
         message: "hello world null",
       });
     });
+
+    it("should overwrite a 'message' field in structured object if a message is provided", () => {
+      logger.log("this instead", { test: true, message: "not this" });
+      expectStdout({
+        severity: "INFO",
+        message: "this instead",
+        test: true,
+      });
+    });
+
+    it("should not overwrite a 'message' field in structured object if no other args are provided", () => {
+      logger.log({ test: true, message: "this" });
+      expectStdout({
+        severity: "INFO",
+        message: "this",
+        test: true,
+      });
+    });
   });
 
   describe("write", () => {

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -154,12 +154,15 @@ function entryFromArgs(severity: LogSeverity, args: any[]): LogEntry {
   if (severity === "ERROR" && !args.find((arg) => arg instanceof Error)) {
     message = new Error(message).stack || message;
   }
-  return {
+  const out: LogEntry = {
     "logging.googleapis.com/trace": ctx?.traceId
       ? `projects/${process.env.GCLOUD_PROJECT}/traces/${ctx.traceId}`
       : undefined,
     ...entry,
     severity,
-    message,
   };
+  if (message) {
+    out.message = message;
+  }
+  return out;
 }


### PR DESCRIPTION
Fixes #1404 where providing a `message` in the structured payload would be overwritten by an empty string. Confirmed via failing test fixed by change.