### PR TITLE
Exporting Param classes to allow their import from firebase-functions/params

### DIFF
--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -38,7 +38,7 @@ import {
   InternalExpression,
 } from "./types";
 
-export { ParamOptions, Expression };
+export { ParamOptions, Expression, BooleanParam, FloatParam, IntParam, SecretParam, StringParam, ListParam };
 
 type SecretOrExpr = Param<any> | SecretParam;
 export const declaredParams: SecretOrExpr[] = [];


### PR DESCRIPTION
### Description

Exported Param classes: `BooleanParam`, `FloatParam`, `IntParam`, `SecretParam`, `StringParam`, and `ListParam`.

Upon creating stubs using various tools to test my cloud functions which use firebase-functions, I faced an issue where I could not mock `defineSecret` as it was called too early. I could stub it before importing the function file, but it would impair the coding conventions, and cause more effort.

As a result, I tried to import `SecretParam` and tried to stub its prototype. Upon running, I had an error `Package subpath './lib/params/types' is not defined by "exports"` which is reasonable as it is not exported by default and rather used as a local class.

Despite presumably being a DX choice (to avoid wrongfully creating params), it causes trouble and limits the users' ability to interact with the library.

This PR doesn't break any existing code.

### Code sample

Here's an example in TypeScript of creating a stub with the `sinon` library

```ts
import { params } from "firebase-functions";
import * as sinon from "sinon";

const fakeSecrets = {
     "secret1":  "secr3t.value"
};

sinon.stub(params.SecretParam.prototype, "value").callsFake(function (this: params.SecretParam) {
     return fakeSecrets[this.name];
});


const secret = defineSecret("secret1");
console.log(secret.value());   // "secr3t.value"
```
