### PR TITLE
Remove HTTP server shutdown message

### DIFF
--- a/src/bin/firebase-functions.ts
+++ b/src/bin/firebase-functions.ts
@@ -54,7 +54,7 @@ const app = express();
 
 function handleQuitquitquit(req: express.Request, res: express.Response) {
   res.send("ok");
-  server.close(() => console.log("shutdown requested via /__/quitquitquit"));
+  server.close();
 }
 
 app.get("/__/quitquitquit", handleQuitquitquit);


### PR DESCRIPTION
When the Firebase CLI finishes its communication with the SDK's HTTP server, it sends a shutdown request which is then logged by the SDK server. The message was previously only visible via the `--debug` flag, but when we turned on verbose output to help users identify issues more clearly, this was causing some confusion among users, so we're getting rid of it.

Fixes https://github.com/firebase/firebase-functions/issues/1456.