### PR TITLE
Fix bug where auth metadata in the auth blocking tokens are assumed to be seconds not miliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 - Remove HTTP server shutdown message. (#1457)
 - Add features to task queue functions. (#1423)
 - Add traces to V2 Firestore trigger logs. (#1440)
+- Fix incorrectly parsed timestamps in auth blocking functions. (#1472)

--- a/scripts/bin-test/run.sh
+++ b/scripts/bin-test/run.sh
@@ -12,7 +12,10 @@ for f in scripts/bin-test/sources/*; do
     fi
 done
 
-## DEBUG
+# Make sure firebase-functions binary is executable
+chmox +x ./lib/bin/firebase-functions.js
+
+# DEBUG
 ls -la scripts/bin-test/sources/commonjs/node_modules
 
 mocha \

--- a/spec/common/providers/identity.spec.ts
+++ b/spec/common/providers/identity.spec.ts
@@ -207,8 +207,8 @@ describe("identity", () => {
 
   describe("parseMetadata", () => {
     const decodedMetadata = {
-      last_sign_in_time: 1476235905,
-      creation_time: 1476136676,
+      last_sign_in_time: 1476235905000,
+      creation_time: 1476136676000,
     };
     const metadata = {
       lastSignInTime: new Date(1476235905000).toUTCString(),
@@ -374,8 +374,8 @@ describe("identity", () => {
       photo_url: "https://lh3.googleusercontent.com/1234567890/photo.jpg",
       tokens_valid_after_time: 1476136676,
       metadata: {
-        last_sign_in_time: 1476235905,
-        creation_time: 1476136676,
+        last_sign_in_time: 1476235905000,
+        creation_time: 1476136676000,
       },
       custom_claims: {
         admin: true,
@@ -632,8 +632,8 @@ describe("identity", () => {
           photo_url: "https://lh3.googleusercontent.com/1234567890/photo.jpg",
           tokens_valid_after_time: 1476136676,
           metadata: {
-            last_sign_in_time: 1476235905,
-            creation_time: 1476136676,
+            last_sign_in_time: 1476235905000,
+            creation_time: 1476136676000,
           },
           custom_claims: {
             admin: true,

--- a/src/common/providers/identity.ts
+++ b/src/common/providers/identity.ts
@@ -489,10 +489,10 @@ function unsafeDecodeAuthBlockingToken(token: string): DecodedPayload {
  */
 export function parseMetadata(metadata: DecodedPayloadUserRecordMetadata): AuthUserMetadata {
   const creationTime = metadata?.creation_time
-    ? new Date(metadata.creation_time * 1000).toUTCString()
+    ? new Date(metadata.creation_time).toUTCString()
     : null;
   const lastSignInTime = metadata?.last_sign_in_time
-    ? new Date(metadata.last_sign_in_time * 1000).toUTCString()
+    ? new Date(metadata.last_sign_in_time).toUTCString()
     : null;
   return {
     creationTime,


### PR DESCRIPTION
Auth metadata included in the JWT sent to Auth Blocking functions may include fields `last_sign_in_time` and `creation_time`.

Values of these fields are sent as _miliseconds_ since epoch. The SDK incorrectly assumes that they are _seconds_ since epoch.

Unfortunately, this information is not publicly documented, but I was able to verify the fix in production.

Fixes: https://github.com/firebase/firebase-functions/issues/1468