### PR TITLE
Wrap 2nd gen onCall functions with trace context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Wrap 2nd gen onCall functions with trace context. (#1491)

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -366,7 +366,7 @@ export function onCall<T = any, Return = any | Promise<any>>(
   // onCallHandler sniffs the function length to determine which API to present.
   // fix the length to prevent api versions from being mismatched.
   const fixedLen = (req: CallableRequest<T>) => handler(req);
-  const func: any = onCallHandler(
+  let func: any = onCallHandler(
     {
       cors: { origin, methods: "POST" },
       enforceAppCheck: opts.enforceAppCheck ?? options.getGlobalOptions().enforceAppCheck,
@@ -374,6 +374,8 @@ export function onCall<T = any, Return = any | Promise<any>>(
     },
     fixedLen
   );
+
+  func = wrapTraceContext(func);
 
   Object.defineProperty(func, "__trigger", {
     get: () => {


### PR DESCRIPTION
2nd gen onCall functions are missing trace contexts. This PR wraps `onCall` handlers with the trace context the same way we do with `onRequest` handlers.

Fixes https://github.com/firebase/firebase-functions/issues/1487.