### PR TITLE
Make storage bucket parameterizeable. Create const for bucket picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,4 @@
 - Fixes access on deeply nested, nonexistent property. (#1432)
 - Add IteratedDataSnapshot interface to match with firebase admin v12 (#1517).
+- Make bucket parameterizeable in storage functions (#1518)
+- Introduce helper library for select and multi-select input (#1518)

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -38,6 +38,8 @@ import {
   InternalExpression,
 } from "./types";
 
+export { BUCKET_PICKER } from "./types";
+
 export { ParamOptions, Expression };
 
 type SecretOrExpr = Param<any> | SecretParam;

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -38,7 +38,7 @@ import {
   InternalExpression,
 } from "./types";
 
-export { BUCKET_PICKER } from "./types";
+export { BUCKET_PICKER, SelectInput, SelectOptions, MultiSelectInput } from "./types";
 
 export { ParamOptions, Expression };
 

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -38,7 +38,15 @@ import {
   InternalExpression,
 } from "./types";
 
-export { BUCKET_PICKER, SelectInput, SelectOptions, MultiSelectInput } from "./types";
+export {
+  BUCKET_PICKER,
+  TextInput,
+  SelectInput,
+  SelectOptions,
+  MultiSelectInput,
+  select,
+  multiSelect,
+} from "./types";
 
 export { ParamOptions, Expression };
 

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -21,7 +21,6 @@
 // SOFTWARE.
 
 import * as logger from "../logger";
-import { Resource } from "../v1";
 
 /*
  * A CEL expression which can be evaluated during function deployment, and

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -231,7 +231,7 @@ export interface SelectInput<T = unknown> {
 export interface MultiSelectInput {
   multiSelect: {
     options: Array<SelectOptions<string>>;
-  }
+  };
 }
 
 /**

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 import * as logger from "../logger";
+import { Resource } from "../v1";
 
 /*
  * A CEL expression which can be evaluated during function deployment, and
@@ -209,7 +210,7 @@ export interface ResourceInput {
   };
 }
 
-export const BUCKET_PICKER: ParamInput<string> = {
+export const BUCKET_PICKER: ResourceInput = {
   resource: {
     type: "storage.googleapis.com/Bucket",
   },

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -174,8 +174,8 @@ type ParamValueType = "string" | "list" | "boolean" | "int" | "float" | "secret"
 type ParamInput<T> =
   | { text: TextInput<T> }
   | { select: SelectInput<T> }
-  | { multiSelect: MultiSelectInput }
-  | { resource: ResourceInput };
+  | (T extends unknown[] ? MultiSelectInput : never)
+  | (T extends string ? ResourceInput : never);
 
 /**
  * Specifies that a Param's value should be determined by prompting the user
@@ -205,9 +205,15 @@ export interface TextInput<T = unknown> {
  */
 export interface ResourceInput {
   resource: {
-    type: string;
+    type: "storage.googleapis.com/Bucket";
   };
 }
+
+export const BUCKET_PICKER: ParamInput<string> = {
+  resource: {
+    type: "storage.googleapis.com/Bucket",
+  },
+};
 
 /**
  * Specifies that a Param's value should be determined by having the user select
@@ -223,7 +229,9 @@ export interface SelectInput<T = unknown> {
  * Will result in errors if used on Params of type other than string[].
  */
 export interface MultiSelectInput {
-  options: Array<SelectOptions<string>>;
+  multiSelect: {
+    options: Array<SelectOptions<string>>;
+  }
 }
 
 /**

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -172,13 +172,13 @@ export class CompareExpression<
 type ParamValueType = "string" | "list" | "boolean" | "int" | "float" | "secret";
 
 /** Create a select input from a series of values. */
-export function select<T>(options: T[]): SelectInput;
+export function select<T>(options: T[]): SelectInput<T>;
 
 /** Create a select input from a map of labels to vaues. */
-export function select<T>(optionsWithLabels: Record<string, T>): SelectInput;
+export function select<T>(optionsWithLabels: Record<string, T>): SelectInput<T>;
 
 /** Create a select input from a series of values or a map of labels to values */
-export function select<T>(options: T[] | Record<string, T>): SelectInput {
+export function select<T>(options: T[] | Record<string, T>): SelectInput<T> {
   let wireOpts: SelectOptions<T>[];
   if (Array.isArray(options)) {
     wireOpts = options.map((opt) => ({ value: opt }));
@@ -216,7 +216,7 @@ export function multiSelect(options: string[] | Record<string, string>): MultiSe
 type ParamInput<T> =
   | TextInput<T>
   | SelectInput<T>
-  | (T extends unknown[] ? MultiSelectInput : never)
+  | (T extends string[] ? MultiSelectInput : never)
   | (T extends string ? ResourceInput : never);
 
 /**

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -171,9 +171,51 @@ export class CompareExpression<
 /** @hidden */
 type ParamValueType = "string" | "list" | "boolean" | "int" | "float" | "secret";
 
+/** Create a select input from a series of values. */
+export function select<T>(options: T[]): SelectInput;
+
+/** Create a select input from a map of labels to vaues. */
+export function select<T>(optionsWithLabels: Record<string, T>): SelectInput;
+
+/** Create a select input from a series of values or a map of labels to values */
+export function select<T>(options: T[] | Record<string, T>): SelectInput {
+  let wireOpts: SelectOptions<T>[];
+  if (Array.isArray(options)) {
+    wireOpts = options.map((opt) => ({ value: opt }));
+  } else {
+    wireOpts = Object.entries(options).map(([label, value]) => ({ label, value }));
+  }
+  return {
+    select: {
+      options: wireOpts,
+    },
+  };
+}
+
+/** Create a multi-select input from a series of values. */
+export function multiSelect(options: string[]): MultiSelectInput;
+
+/** Create a multi-select input from map of labels to values. */
+export function multiSelect(options: Record<string, string>): MultiSelectInput;
+
+/** Create a multi-select input from a series of values or map of labels to values. */
+export function multiSelect(options: string[] | Record<string, string>): MultiSelectInput {
+  let wireOpts: SelectOptions<string>[];
+  if (Array.isArray(options)) {
+    wireOpts = options.map((opt) => ({ value: opt }));
+  } else {
+    wireOpts = Object.entries(options).map(([label, value]) => ({ label, value }));
+  }
+  return {
+    multiSelect: {
+      options: wireOpts,
+    },
+  };
+}
+
 type ParamInput<T> =
-  | { text: TextInput<T> }
-  | { select: SelectInput<T> }
+  | TextInput<T>
+  | SelectInput<T>
   | (T extends unknown[] ? MultiSelectInput : never)
   | (T extends string ? ResourceInput : never);
 
@@ -184,18 +226,20 @@ type ParamInput<T> =
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface TextInput<T = unknown> {
-  example?: string;
-  /**
-   * A regular expression (or an escaped string to compile into a regular
-   * expression) which the prompted text must satisfy; the prompt will retry
-   * until input matching the regex is provided.
-   */
-  validationRegex?: string | RegExp;
-  /**
-   * A custom error message to display when retrying the prompt based on input
-   * failing to conform to the validationRegex,
-   */
-  validationErrorMessage?: string;
+  text: {
+    example?: string;
+    /**
+     * A regular expression (or an escaped string to compile into a regular
+     * expression) which the prompted text must satisfy; the prompt will retry
+     * until input matching the regex is provided.
+     */
+    validationRegex?: string | RegExp;
+    /**
+     * A custom error message to display when retrying the prompt based on input
+     * failing to conform to the validationRegex,
+     */
+    validationErrorMessage?: string;
+  };
 }
 
 /**
@@ -220,7 +264,9 @@ export const BUCKET_PICKER: ResourceInput = {
  * from a list of pre-canned options interactively at deploy-time.
  */
 export interface SelectInput<T = unknown> {
-  options: Array<SelectOptions<T>>;
+  select: {
+    options: Array<SelectOptions<T>>;
+  };
 }
 
 /**

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -201,7 +201,7 @@ export const metadataUpdatedEvent = "google.cloud.storage.object.v1.metadataUpda
 /** StorageOptions extend EventHandlerOptions with a bucket name  */
 export interface StorageOptions extends options.EventHandlerOptions {
   /** The name of the bucket containing this object. */
-  bucket?: string;
+  bucket?: string | Expression<string>;
 
   /**
    * If true, do not deploy or emulate this function.
@@ -324,7 +324,7 @@ export function onObjectArchived(
  * @param handler - Event handler which is run every time a Google Cloud Storage archival occurs.
  */
 export function onObjectArchived(
-  bucket: string,
+  bucket: string | Expression<string>,
   handler: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent>;
 
@@ -352,7 +352,11 @@ export function onObjectArchived(
  * @param handler - Event handler which is run every time a Google Cloud Storage archival occurs.
  */
 export function onObjectArchived(
-  bucketOrOptsOrHandler: string | StorageOptions | ((event: StorageEvent) => any | Promise<any>),
+  bucketOrOptsOrHandler:
+    | string
+    | Expression<string>
+    | StorageOptions
+    | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent> {
   return onOperation(archivedEvent, bucketOrOptsOrHandler, handler);
@@ -384,7 +388,7 @@ export function onObjectFinalized(
  * @param handler - Event handler which is run every time a Google Cloud Storage object creation occurs.
  */
 export function onObjectFinalized(
-  bucket: string,
+  bucket: string | Expression<string>,
   handler: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent>;
 
@@ -416,7 +420,11 @@ export function onObjectFinalized(
  * @param handler - Event handler which is run every time a Google Cloud Storage object creation occurs.
  */
 export function onObjectFinalized(
-  bucketOrOptsOrHandler: string | StorageOptions | ((event: StorageEvent) => any | Promise<any>),
+  bucketOrOptsOrHandler:
+    | string
+    | Expression<string>
+    | StorageOptions
+    | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent> {
   return onOperation(finalizedEvent, bucketOrOptsOrHandler, handler);
@@ -450,7 +458,7 @@ export function onObjectDeleted(
  * @param handler - Event handler which is run every time a Google Cloud Storage object deletion occurs.
  */
 export function onObjectDeleted(
-  bucket: string,
+  bucket: string | Expression<string>,
   handler: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent>;
 
@@ -484,7 +492,11 @@ export function onObjectDeleted(
  * @param handler - Event handler which is run every time a Google Cloud Storage object deletion occurs.
  */
 export function onObjectDeleted(
-  bucketOrOptsOrHandler: string | StorageOptions | ((event: StorageEvent) => any | Promise<any>),
+  bucketOrOptsOrHandler:
+    | string
+    | Expression<string>
+    | StorageOptions
+    | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent> {
   return onOperation(deletedEvent, bucketOrOptsOrHandler, handler);
@@ -509,7 +521,7 @@ export function onObjectMetadataUpdated(
  * @param handler - Event handler which is run every time a Google Cloud Storage object metadata update occurs.
  */
 export function onObjectMetadataUpdated(
-  bucket: string,
+  bucket: string | Expression<string>,
   handler: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent>;
 
@@ -533,7 +545,11 @@ export function onObjectMetadataUpdated(
  * @param handler - Event handler which is run every time a Google Cloud Storage object metadata update occurs.
  */
 export function onObjectMetadataUpdated(
-  bucketOrOptsOrHandler: string | StorageOptions | ((event: StorageEvent) => any | Promise<any>),
+  bucketOrOptsOrHandler:
+    | string
+    | Expression<string>
+    | StorageOptions
+    | ((event: StorageEvent) => any | Promise<any>),
   handler?: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent> {
   return onOperation(metadataUpdatedEvent, bucketOrOptsOrHandler, handler);
@@ -542,7 +558,11 @@ export function onObjectMetadataUpdated(
 /** @internal */
 export function onOperation(
   eventType: string,
-  bucketOrOptsOrHandler: string | StorageOptions | ((event: StorageEvent) => any | Promise<any>),
+  bucketOrOptsOrHandler:
+    | string
+    | Expression<string>
+    | StorageOptions
+    | ((event: StorageEvent) => any | Promise<any>),
   handler: (event: StorageEvent) => any | Promise<any>
 ): CloudFunction<StorageEvent> {
   if (typeof bucketOrOptsOrHandler === "function") {
@@ -616,11 +636,12 @@ export function onOperation(
 
 /** @internal */
 export function getOptsAndBucket(
-  bucketOrOpts: string | StorageOptions
-): [options.EventHandlerOptions, string] {
-  let bucket: string;
+  bucketOrOpts: string | Expression<string> | StorageOptions
+): [options.EventHandlerOptions, string | Expression<string>] {
+  let bucket: string | Expression<string>;
   let opts: options.EventHandlerOptions;
-  if (typeof bucketOrOpts === "string") {
+  // If bucket is a string or Expression<string>
+  if (typeof bucketOrOpts === "string" || "value" in bucketOrOpts) {
     bucket = bucketOrOpts;
     opts = {};
   } else {
@@ -635,7 +656,7 @@ export function getOptsAndBucket(
         " by providing bucket name directly in the event handler or by setting process.env.FIREBASE_CONFIG."
     );
   }
-  if (!/^[a-z\d][a-z\d\\._-]{1,230}[a-z\d]$/.test(bucket)) {
+  if (typeof bucket === "string" && !/^[a-z\d][a-z\d\\._-]{1,230}[a-z\d]$/.test(bucket)) {
     throw new Error(`Invalid bucket name ${bucket}`);
   }
 


### PR DESCRIPTION
API spec basically said to parameterize everything so I don't know why this was overlooked. Also, I've added a const BUCKET_PICKER so customers don't have to say `{ input: { resource: { type: "storage.googleapis.com/Bucket" } } }` and can instead say `{ input: BUCKET_PICKER }`. That const might need to go through API council review though.