### PR TITLE
Add new 2nd gen Firestore auth context triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add new 2nd gen Firestore auth context triggers. (#1519)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
+        "node-fetch": "^2.6.7",
         "protobufjs": "^7.2.2"
       },
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "@types/express": "4.17.3",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "node-fetch": "^2.6.7",
         "protobufjs": "^7.2.2"
       },
       "bin": {

--- a/spec/v2/providers/firestore.spec.ts
+++ b/spec/v2/providers/firestore.spec.ts
@@ -558,6 +558,23 @@ describe("firestore", () => {
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
     });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentWrittenWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
+    });
   });
 
   describe("onDocumentCreatedWithAuthContext", () => {
@@ -604,6 +621,23 @@ describe("firestore", () => {
 
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentCreatedWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
     });
   });
 
@@ -652,6 +686,23 @@ describe("firestore", () => {
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
     });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentUpdatedWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
+    });
   });
 
   describe("onDocumentDeletedWithAuthContext", () => {
@@ -698,6 +749,23 @@ describe("firestore", () => {
 
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentDeletedWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
     });
   });
 

--- a/spec/v2/providers/firestore.spec.ts
+++ b/spec/v2/providers/firestore.spec.ts
@@ -558,23 +558,6 @@ describe("firestore", () => {
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
     });
-
-    it("calls init function", async () => {
-      const event: firestore.RawFirestoreEvent = {
-        ...eventBase,
-        datacontenttype: "application/json",
-        data: {
-          oldValue: null,
-          value: null,
-        },
-      };
-
-      let hello;
-      onInit(() => (hello = "world"));
-      expect(hello).to.be.undefined;
-      await firestore.onDocumentWrittenWithAuthContext("path", () => null)(event);
-      expect(hello).to.equal("world");
-    });
   });
 
   describe("onDocumentCreatedWithAuthContext", () => {
@@ -621,23 +604,6 @@ describe("firestore", () => {
 
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
-    });
-
-    it("calls init function", async () => {
-      const event: firestore.RawFirestoreEvent = {
-        ...eventBase,
-        datacontenttype: "application/json",
-        data: {
-          oldValue: null,
-          value: null,
-        },
-      };
-
-      let hello;
-      onInit(() => (hello = "world"));
-      expect(hello).to.be.undefined;
-      await firestore.onDocumentCreatedWithAuthContext("path", () => null)(event);
-      expect(hello).to.equal("world");
     });
   });
 
@@ -686,23 +652,6 @@ describe("firestore", () => {
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
     });
-
-    it("calls init function", async () => {
-      const event: firestore.RawFirestoreEvent = {
-        ...eventBase,
-        datacontenttype: "application/json",
-        data: {
-          oldValue: null,
-          value: null,
-        },
-      };
-
-      let hello;
-      onInit(() => (hello = "world"));
-      expect(hello).to.be.undefined;
-      await firestore.onDocumentUpdatedWithAuthContext("path", () => null)(event);
-      expect(hello).to.equal("world");
-    });
   });
 
   describe("onDocumentDeletedWithAuthContext", () => {
@@ -749,23 +698,6 @@ describe("firestore", () => {
 
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
-    });
-
-    it("calls init function", async () => {
-      const event: firestore.RawFirestoreEvent = {
-        ...eventBase,
-        datacontenttype: "application/json",
-        data: {
-          oldValue: null,
-          value: null,
-        },
-      };
-
-      let hello;
-      onInit(() => (hello = "world"));
-      expect(hello).to.be.undefined;
-      await firestore.onDocumentDeletedWithAuthContext("path", () => null)(event);
-      expect(hello).to.equal("world");
     });
   });
 

--- a/spec/v2/providers/firestore.spec.ts
+++ b/spec/v2/providers/firestore.spec.ts
@@ -565,6 +565,23 @@ describe("firestore", () => {
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
     });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentWrittenWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
+    });
   });
 
   describe("onDocumentCreatedWithAuthContext", () => {
@@ -611,6 +628,23 @@ describe("firestore", () => {
 
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentCreatedWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
     });
   });
 
@@ -659,6 +693,23 @@ describe("firestore", () => {
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
     });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentUpdatedWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
+    });
   });
 
   describe("onDocumentDeletedWithAuthContext", () => {
@@ -705,6 +756,23 @@ describe("firestore", () => {
 
       expect(func.run(true as any)).to.eq(2);
       expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("calls init function", async () => {
+      const event: firestore.RawFirestoreEvent = {
+        ...eventBase,
+        datacontenttype: "application/json",
+        data: {
+          oldValue: null,
+          value: null,
+        },
+      };
+
+      let hello;
+      onInit(() => (hello = "world"));
+      expect(hello).to.be.undefined;
+      await firestore.onDocumentDeletedWithAuthContext("path", () => null)(event);
+      expect(hello).to.equal("world");
     });
   });
 

--- a/spec/v2/providers/firestore.spec.ts
+++ b/spec/v2/providers/firestore.spec.ts
@@ -40,6 +40,8 @@ const eventBase = {
   datacontenttype: "application/protobuf",
   dataschema:
     "https://github.com/googleapis/google-cloudevents/blob/main/proto/google/events/cloud/firestore/v1/data.proto",
+  authtype: "unknown",
+  authid: "1234",
   id: "379ad868-5ef9-4c84-a8ba-f75f1b056663",
   source: "projects/my-project/databases/my-db/documents/d",
   subject: "documents/foo/fGRodw71mHutZ4wGDuT8",
@@ -508,6 +510,194 @@ describe("firestore", () => {
       expect(hello).to.be.undefined;
       await firestore.onDocumentDeleted("path", () => null)(event);
       expect(hello).to.equal("world");
+    });
+  });
+
+  describe("onDocumentWrittenWithAuthContext", () => {
+    it("should create a func", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.writtenEventWithAuthContextType,
+        {
+          database: "(default)",
+          namespace: "(default)",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+
+      const func = firestore.onDocumentWrittenWithAuthContext("foo/{bar}", () => 2);
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("should create a func with opts", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.writtenEventWithAuthContextType,
+        {
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+      expectedEp["region"] = ["us-central1"];
+
+      const func = firestore.onDocumentWrittenWithAuthContext(
+        {
+          region: "us-central1",
+          document: "foo/{bar}",
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        () => 2
+      );
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+  });
+
+  describe("onDocumentCreatedWithAuthContext", () => {
+    it("should create a func", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.createdEventWithAuthContextType,
+        {
+          database: "(default)",
+          namespace: "(default)",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+
+      const func = firestore.onDocumentCreatedWithAuthContext("foo/{bar}", () => 2);
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("should create a func with opts", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.createdEventWithAuthContextType,
+        {
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+      expectedEp["region"] = ["us-central1"];
+
+      const func = firestore.onDocumentCreatedWithAuthContext(
+        {
+          region: "us-central1",
+          document: "foo/{bar}",
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        () => 2
+      );
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+  });
+
+  describe("onDocumentUpdatedWithAuthContext", () => {
+    it("should create a func", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.updatedEventWithAuthContextType,
+        {
+          database: "(default)",
+          namespace: "(default)",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+
+      const func = firestore.onDocumentUpdatedWithAuthContext("foo/{bar}", () => 2);
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("should create a func with opts", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.updatedEventWithAuthContextType,
+        {
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+      expectedEp["region"] = ["us-central1"];
+
+      const func = firestore.onDocumentUpdatedWithAuthContext(
+        {
+          region: "us-central1",
+          document: "foo/{bar}",
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        () => 2
+      );
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+  });
+
+  describe("onDocumentDeletedWithAuthContext", () => {
+    it("should create a func", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.deletedEventWithAuthContextType,
+        {
+          database: "(default)",
+          namespace: "(default)",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+
+      const func = firestore.onDocumentDeletedWithAuthContext("foo/{bar}", () => 2);
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
+    });
+
+    it("should create a func with opts", () => {
+      const expectedEp = makeExpectedEp(
+        firestore.deletedEventWithAuthContextType,
+        {
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        {
+          document: "foo/{bar}",
+        }
+      );
+      expectedEp["region"] = ["us-central1"];
+
+      const func = firestore.onDocumentDeletedWithAuthContext(
+        {
+          region: "us-central1",
+          document: "foo/{bar}",
+          database: "my-db",
+          namespace: "my-ns",
+        },
+        () => 2
+      );
+
+      expect(func.run(true as any)).to.eq(2);
+      expect(func.__endpoint).to.deep.eq(expectedEp);
     });
   });
 

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -125,20 +125,15 @@ export interface FirestoreEvent<T, Params = Record<string, string>> extends Clou
   namespace: string;
   /** The document path */
   document: string;
+  /** The type of principal that triggered the event */
+  authType?: AuthType;
+  /** The unique identifier for the principal */
+  authId?: string;
   /**
    * An object containing the values of the path patterns.
    * Only named capture groups will be populated - {key}, {key=*}, {key=**}
    */
   params: Params;
-}
-
-/** A CloudEvent that extends the Firestore event with auth context fields. */
-export interface FirestoreEventWithAuthContext<T, Params = Record<string, string>>
-  extends FirestoreEvent<T, Params> {
-  /** The type of principal that triggered the event */
-  authType: AuthType;
-  /** The unique identifier for the principal */
-  authId?: string;
 }
 
 /** DocumentOptions extend EventHandlerOptions with provided document and optional database and namespace.  */
@@ -202,11 +197,10 @@ export function onDocumentWritten<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
+
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  * This trigger also provides the authentication context of the principal who triggered the event.
@@ -217,11 +211,9 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
@@ -233,16 +225,10 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   documentorOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
-> {
-  return onChangedWithAuthContextOperation(
-    writtenEventWithAuthContextType,
-    documentorOpts,
-    handler
-  );
+): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>> {
+  return onChangedOperation(writtenEventWithAuthContextType, documentorOpts, handler);
 }
 
 /**
@@ -296,11 +282,9 @@ export function onDocumentCreated<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created in Firestore.
@@ -312,11 +296,9 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created in Firestore.
@@ -327,11 +309,9 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
-> {
+): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
   return onOperation(createdEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -385,14 +365,9 @@ export function onDocumentUpdated<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEventWithAuthContext<
-      Change<QueryDocumentSnapshot> | undefined,
-      ParamsOf<Document>
-    >
+    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 /**
  * Event handler that triggers when a document is updated in Firestore.
  * This trigger also provides the authentication context of the principal who triggered the event.
@@ -403,14 +378,9 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<
-      Change<QueryDocumentSnapshot> | undefined,
-      ParamsOf<Document>
-    >
+    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is updated in Firestore.
@@ -421,19 +391,10 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<
-      Change<QueryDocumentSnapshot> | undefined,
-      ParamsOf<Document>
-    >
+    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
-> {
-  return onChangedWithAuthContextOperation(
-    updatedEventWithAuthContextType,
-    documentOrOpts,
-    handler
-  );
+): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>> {
+  return onChangedOperation(updatedEventWithAuthContextType, documentOrOpts, handler);
 }
 
 /**
@@ -487,11 +448,9 @@ export function onDocumentDeleted<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
@@ -503,11 +462,9 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
->;
+): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
@@ -518,11 +475,9 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<
-  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
-> {
+): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
   return onOperation(deletedEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -613,9 +568,7 @@ export function makeFirestoreEvent<Params>(
   eventType: string,
   event: RawFirestoreEvent,
   params: Params
-):
-  | FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, Params>
-  | FirestoreEvent<QueryDocumentSnapshot | undefined, Params> {
+): FirestoreEvent<QueryDocumentSnapshot | undefined, Params> {
   const data = event.data
     ? eventType === createdEventType
       ? createSnapshot(event)
@@ -625,20 +578,11 @@ export function makeFirestoreEvent<Params>(
     ...event,
     params,
     data,
+    authType: event.authtype as AuthType,
+    authId: event.authid,
   };
   delete (firestoreEvent as any).datacontenttype;
   delete (firestoreEvent as any).dataschema;
-
-  if (event.authtype) {
-    const eventWithAuthContext = {
-      ...firestoreEvent,
-      authType: event.authtype as AuthType,
-      authId: event.authid,
-    };
-    delete (eventWithAuthContext as any).authtype;
-    delete (eventWithAuthContext as any).authid;
-    return eventWithAuthContext;
-  }
   return firestoreEvent;
 }
 
@@ -654,34 +598,11 @@ export function makeChangedFirestoreEvent<Params>(
     ...event,
     params,
     data,
-  };
-  delete (firestoreEvent as any).datacontenttype;
-  delete (firestoreEvent as any).dataschema;
-  return firestoreEvent;
-}
-
-/** @internal */
-export function makeChangedFirestoreEventWithAuthContext<Params>(
-  event: RawFirestoreEvent,
-  params: Params
-): FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, Params> {
-  const data = event.data
-    ? Change.fromObjects(createBeforeSnapshot(event), createSnapshot(event))
-    : undefined;
-  const firestoreEvent: FirestoreEventWithAuthContext<
-    Change<QueryDocumentSnapshot> | undefined,
-    Params
-  > = {
-    ...event,
-    params,
-    data,
     authType: event.authtype as AuthType,
     authId: event.authid,
   };
   delete (firestoreEvent as any).datacontenttype;
   delete (firestoreEvent as any).dataschema;
-  delete (firestoreEvent as any).authtype;
-  delete (firestoreEvent as any).authid;
   return firestoreEvent;
 }
 
@@ -771,34 +692,6 @@ export function onChangedOperation<Document extends string>(
     );
     const params = makeParams(event.document, documentPattern) as unknown as ParamsOf<Document>;
     const firestoreEvent = makeChangedFirestoreEvent(event, params);
-    return wrapTraceContext(withInit(handler))(firestoreEvent);
-  };
-
-  func.run = handler;
-
-  func.__endpoint = makeEndpoint(eventType, opts, document, database, namespace);
-
-  return func;
-}
-
-/** @internal */
-export function onChangedWithAuthContextOperation<Document extends string>(
-  eventType: string,
-  documentOrOpts: Document | DocumentOptions<Document>,
-  handler: (
-    event: FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot>, ParamsOf<Document>>
-  ) => any | Promise<any>
-): CloudFunction<FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot>, ParamsOf<Document>>> {
-  const { document, database, namespace, opts } = getOpts(documentOrOpts);
-
-  // wrap the handler
-  const func = (raw: CloudEvent<unknown>) => {
-    const event = raw as RawFirestoreEvent;
-    const documentPattern = new PathPattern(
-      typeof document === "string" ? document : document.value()
-    );
-    const params = makeParams(event.document, documentPattern) as unknown as ParamsOf<Document>;
-    const firestoreEvent = makeChangedFirestoreEventWithAuthContext(event, params);
     return wrapTraceContext(withInit(handler))(firestoreEvent);
   };
 

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -125,15 +125,20 @@ export interface FirestoreEvent<T, Params = Record<string, string>> extends Clou
   namespace: string;
   /** The document path */
   document: string;
-  /** The type of principal that triggered the event */
-  authType?: AuthType;
-  /** The unique identifier for the principal */
-  authId?: string;
   /**
    * An object containing the values of the path patterns.
    * Only named capture groups will be populated - {key}, {key=*}, {key=**}
    */
   params: Params;
+}
+
+/** A CloudEvent that extends the Firestore event with auth context fields. */
+export interface FirestoreEventWithAuthContext<T, Params = Record<string, string>>
+  extends FirestoreEvent<T, Params> {
+  /** The type of principal that triggered the event */
+  authType: AuthType;
+  /** The unique identifier for the principal */
+  authId?: string;
 }
 
 /** DocumentOptions extend EventHandlerOptions with provided document and optional database and namespace.  */
@@ -197,10 +202,11 @@ export function onDocumentWritten<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
-
+): CloudFunction<
+  FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+>;
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  * This trigger also provides the authentication context of the principal who triggered the event.
@@ -211,9 +217,11 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+>;
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
@@ -225,10 +233,16 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   documentorOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>> {
-  return onChangedOperation(writtenEventWithAuthContextType, documentorOpts, handler);
+): CloudFunction<
+  FirestoreEventWithAuthContext<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+> {
+  return onChangedWithAuthContextOperation(
+    writtenEventWithAuthContextType,
+    documentorOpts,
+    handler
+  );
 }
 
 /**
@@ -282,9 +296,11 @@ export function onDocumentCreated<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+>;
 
 /**
  * Event handler that triggers when a document is created in Firestore.
@@ -296,9 +312,11 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+>;
 
 /**
  * Event handler that triggers when a document is created in Firestore.
@@ -309,9 +327,11 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
+): CloudFunction<
+  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+> {
   return onOperation(createdEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -365,9 +385,14 @@ export function onDocumentUpdated<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<
+      Change<QueryDocumentSnapshot> | undefined,
+      ParamsOf<Document>
+    >
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+>;
 /**
  * Event handler that triggers when a document is updated in Firestore.
  * This trigger also provides the authentication context of the principal who triggered the event.
@@ -378,9 +403,14 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<
+      Change<QueryDocumentSnapshot> | undefined,
+      ParamsOf<Document>
+    >
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+>;
 
 /**
  * Event handler that triggers when a document is updated in Firestore.
@@ -391,10 +421,19 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<
+      Change<QueryDocumentSnapshot> | undefined,
+      ParamsOf<Document>
+    >
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>> {
-  return onChangedOperation(updatedEventWithAuthContextType, documentOrOpts, handler);
+): CloudFunction<
+  FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+> {
+  return onChangedWithAuthContextOperation(
+    updatedEventWithAuthContextType,
+    documentOrOpts,
+    handler
+  );
 }
 
 /**
@@ -448,9 +487,11 @@ export function onDocumentDeleted<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+>;
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
@@ -462,9 +503,11 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<
+  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+>;
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
@@ -475,9 +518,11 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
+): CloudFunction<
+  FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+> {
   return onOperation(deletedEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -568,7 +613,9 @@ export function makeFirestoreEvent<Params>(
   eventType: string,
   event: RawFirestoreEvent,
   params: Params
-): FirestoreEvent<QueryDocumentSnapshot | undefined, Params> {
+):
+  | FirestoreEventWithAuthContext<QueryDocumentSnapshot | undefined, Params>
+  | FirestoreEvent<QueryDocumentSnapshot | undefined, Params> {
   const data = event.data
     ? eventType === createdEventType
       ? createSnapshot(event)
@@ -578,11 +625,20 @@ export function makeFirestoreEvent<Params>(
     ...event,
     params,
     data,
-    authType: event.authtype as AuthType,
-    authId: event.authid,
   };
   delete (firestoreEvent as any).datacontenttype;
   delete (firestoreEvent as any).dataschema;
+
+  if (event.authtype) {
+    const eventWithAuthContext = {
+      ...firestoreEvent,
+      authType: event.authtype as AuthType,
+      authId: event.authid,
+    };
+    delete (eventWithAuthContext as any).authtype;
+    delete (eventWithAuthContext as any).authid;
+    return eventWithAuthContext;
+  }
   return firestoreEvent;
 }
 
@@ -598,11 +654,34 @@ export function makeChangedFirestoreEvent<Params>(
     ...event,
     params,
     data,
+  };
+  delete (firestoreEvent as any).datacontenttype;
+  delete (firestoreEvent as any).dataschema;
+  return firestoreEvent;
+}
+
+/** @internal */
+export function makeChangedFirestoreEventWithAuthContext<Params>(
+  event: RawFirestoreEvent,
+  params: Params
+): FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot> | undefined, Params> {
+  const data = event.data
+    ? Change.fromObjects(createBeforeSnapshot(event), createSnapshot(event))
+    : undefined;
+  const firestoreEvent: FirestoreEventWithAuthContext<
+    Change<QueryDocumentSnapshot> | undefined,
+    Params
+  > = {
+    ...event,
+    params,
+    data,
     authType: event.authtype as AuthType,
     authId: event.authid,
   };
   delete (firestoreEvent as any).datacontenttype;
   delete (firestoreEvent as any).dataschema;
+  delete (firestoreEvent as any).authtype;
+  delete (firestoreEvent as any).authid;
   return firestoreEvent;
 }
 
@@ -692,6 +771,34 @@ export function onChangedOperation<Document extends string>(
     );
     const params = makeParams(event.document, documentPattern) as unknown as ParamsOf<Document>;
     const firestoreEvent = makeChangedFirestoreEvent(event, params);
+    return wrapTraceContext(withInit(handler))(firestoreEvent);
+  };
+
+  func.run = handler;
+
+  func.__endpoint = makeEndpoint(eventType, opts, document, database, namespace);
+
+  return func;
+}
+
+/** @internal */
+export function onChangedWithAuthContextOperation<Document extends string>(
+  eventType: string,
+  documentOrOpts: Document | DocumentOptions<Document>,
+  handler: (
+    event: FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot>, ParamsOf<Document>>
+  ) => any | Promise<any>
+): CloudFunction<FirestoreEventWithAuthContext<Change<QueryDocumentSnapshot>, ParamsOf<Document>>> {
+  const { document, database, namespace, opts } = getOpts(documentOrOpts);
+
+  // wrap the handler
+  const func = (raw: CloudEvent<unknown>) => {
+    const event = raw as RawFirestoreEvent;
+    const documentPattern = new PathPattern(
+      typeof document === "string" ? document : document.value()
+    );
+    const params = makeParams(event.document, documentPattern) as unknown as ParamsOf<Document>;
+    const firestoreEvent = makeChangedFirestoreEventWithAuthContext(event, params);
     return wrapTraceContext(withInit(handler))(firestoreEvent);
   };
 

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -103,7 +103,15 @@ export type DocumentSnapshot = firestore.DocumentSnapshot;
 /** A Firestore QueryDocumentSnapshot */
 export type QueryDocumentSnapshot = firestore.QueryDocumentSnapshot;
 
-type AuthType = "service_account" | "api_key" | "system" | "unauthenticated" | "unknown";
+/**
+ * AuthType defines the possible values for the authType field in a Firestore event with auth context.
+ * - service_account: a non-user principal used to identify a workload or machine user.
+ * - api_key: a non-user client API key.
+ * - system: an obscured identity used when Cloud Platform or another system triggered the event. Examples include a database record which was deleted based on a TTL.
+ * - unauthenticated: an unauthenticated action.
+ * - unknown: a general type to capture all other principals not captured in the other auth types.
+ */
+export type AuthType = "service_account" | "api_key" | "system" | "unauthenticated" | "unknown";
 
 /** A CloudEvent that contains a DocumentSnapshot or a Change<DocumentSnapshot> */
 export interface FirestoreEvent<T, Params = Record<string, string>> extends CloudEvent<T> {

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -139,7 +139,7 @@ export interface DocumentOptions<Document extends string = string> extends Event
 }
 
 /**
- * Event handler which triggers when a document is created, updated, or deleted in Firestore.
+ * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
@@ -152,7 +152,7 @@ export function onDocumentWritten<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created, updated, or deleted in Firestore.
+ * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
@@ -165,7 +165,7 @@ export function onDocumentWritten<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created, updated, or deleted in Firestore.
+ * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
@@ -180,7 +180,7 @@ export function onDocumentWritten<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is created, updated, or deleted in Firestore.
+ * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
@@ -194,7 +194,7 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created, updated, or deleted in Firestore.
+ * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
@@ -208,7 +208,7 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created, updated, or deleted in Firestore.
+ * Event handler that triggers when a document is created, updated, or deleted in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param opts - Options or a string document path.
@@ -224,7 +224,7 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is created in Firestore.
+ * Event handler that triggers when a document is created in Firestore.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore create occurs.
@@ -237,7 +237,7 @@ export function onDocumentCreated<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created in Firestore.
+ * Event handler that triggers when a document is created in Firestore.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore create occurs.
@@ -250,7 +250,7 @@ export function onDocumentCreated<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created in Firestore.
+ * Event handler that triggers when a document is created in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore create occurs.
@@ -265,7 +265,7 @@ export function onDocumentCreated<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is created in Firestore.
+ * Event handler that triggers when a document is created in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
@@ -279,7 +279,7 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created in Firestore.
+ * Event handler that triggers when a document is created in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
@@ -293,7 +293,7 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is created in Firestore.
+ * Event handler that triggers when a document is created in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore create occurs.
@@ -308,7 +308,7 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is updated in Firestore.
+ * Event handler that triggers when a document is updated in Firestore.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore update occurs.
@@ -320,7 +320,7 @@ export function onDocumentUpdated<Document extends string>(
   ) => any | Promise<any>
 ): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 /**
- * Event handler which triggers when a document is updated in Firestore.
+ * Event handler that triggers when a document is updated in Firestore.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore update occurs.
@@ -333,7 +333,7 @@ export function onDocumentUpdated<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is updated in Firestore.
+ * Event handler that triggers when a document is updated in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore update occurs.
@@ -348,7 +348,7 @@ export function onDocumentUpdated<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is updated in Firestore.
+ * Event handler that triggers when a document is updated in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
@@ -361,7 +361,7 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
   ) => any | Promise<any>
 ): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 /**
- * Event handler which triggers when a document is updated in Firestore.
+ * Event handler that triggers when a document is updated in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
@@ -375,7 +375,7 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is updated in Firestore.
+ * Event handler that triggers when a document is updated in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore update occurs.
@@ -390,7 +390,7 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is deleted in Firestore.
+ * Event handler that triggers when a document is deleted in Firestore.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore delete occurs.
@@ -403,7 +403,7 @@ export function onDocumentDeleted<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is deleted in Firestore.
+ * Event handler that triggers when a document is deleted in Firestore.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore delete occurs.
@@ -416,7 +416,7 @@ export function onDocumentDeleted<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is deleted in Firestore.
+ * Event handler that triggers when a document is deleted in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore delete occurs.
@@ -431,7 +431,7 @@ export function onDocumentDeleted<Document extends string>(
 }
 
 /**
- * Event handler which triggers when a document is deleted in Firestore.
+ * Event handler that triggers when a document is deleted in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
@@ -445,7 +445,7 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is deleted in Firestore.
+ * Event handler that triggers when a document is deleted in Firestore.
  * This trigger will also provide the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
@@ -459,7 +459,7 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
- * Event handler which triggers when a document is deleted in Firestore.
+ * Event handler that triggers when a document is deleted in Firestore.
  *
  * @param documentOrOpts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore delete occurs.

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -93,7 +93,11 @@ export interface RawFirestoreEvent extends CloudEvent<Uint8Array | RawFirestoreD
   document: string;
   datacontenttype?: string;
   dataschema: string;
-  authtype?: string;
+}
+
+/** @internal */
+export interface RawFirestoreAuthEvent extends RawFirestoreEvent {
+  authtype?: AuthType;
   authid?: string;
 }
 
@@ -125,15 +129,19 @@ export interface FirestoreEvent<T, Params = Record<string, string>> extends Clou
   namespace: string;
   /** The document path */
   document: string;
-  /** The type of principal that triggered the event */
-  authType?: AuthType;
-  /** The unique identifier for the principal */
-  authId?: string;
   /**
    * An object containing the values of the path patterns.
    * Only named capture groups will be populated - {key}, {key=*}, {key=**}
    */
   params: Params;
+}
+
+export interface FirestoreAuthEvent<T, Params = Record<string, string>>
+  extends FirestoreEvent<T, Params> {
+  /** The type of principal that triggered the event */
+  authType: AuthType;
+  /** The unique identifier for the principal */
+  authId?: string;
 }
 
 /** DocumentOptions extend EventHandlerOptions with provided document and optional database and namespace.  */
@@ -197,9 +205,9 @@ export function onDocumentWritten<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
@@ -211,9 +219,9 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 export function onDocumentWrittenWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
@@ -223,12 +231,19 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
  */
 export function onDocumentWrittenWithAuthContext<Document extends string>(
-  documentorOpts: Document | DocumentOptions<Document>,
+  documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>> {
-  return onChangedOperation(writtenEventWithAuthContextType, documentorOpts, handler);
+): CloudFunction<FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>> {
+  // const fn = (
+  //   event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>> & {
+  //     foo: string;
+  //   }
+  // ): any => {
+  //   return event;
+  // };
+  return onChangedOperation(writtenEventWithAuthContextType, documentOrOpts, handler);
 }
 
 /**
@@ -282,9 +297,9 @@ export function onDocumentCreated<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created in Firestore.
@@ -296,9 +311,9 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is created in Firestore.
@@ -309,9 +324,9 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 export function onDocumentCreatedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
+): CloudFunction<FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
   return onOperation(createdEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -365,9 +380,10 @@ export function onDocumentUpdated<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
+
 /**
  * Event handler that triggers when a document is updated in Firestore.
  * This trigger also provides the authentication context of the principal who triggered the event.
@@ -378,9 +394,9 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is updated in Firestore.
@@ -391,9 +407,11 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 export function onDocumentUpdatedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>> {
+): CloudFunction<
+  FirestoreAuthEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>
+> {
   return onChangedOperation(updatedEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -448,9 +466,9 @@ export function onDocumentDeleted<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   document: Document,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
@@ -462,9 +480,9 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   opts: DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
+): CloudFunction<FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>>;
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
@@ -475,9 +493,9 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 export function onDocumentDeletedWithAuthContext<Document extends string>(
   documentOrOpts: Document | DocumentOptions<Document>,
   handler: (
-    event: FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
+    event: FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
+): CloudFunction<FirestoreAuthEvent<QueryDocumentSnapshot | undefined, ParamsOf<Document>>> {
   return onOperation(deletedEventWithAuthContextType, documentOrOpts, handler);
 }
 
@@ -566,11 +584,13 @@ export function makeParams(document: string, documentPattern: PathPattern) {
 /** @internal */
 export function makeFirestoreEvent<Params>(
   eventType: string,
-  event: RawFirestoreEvent,
+  event: RawFirestoreEvent | RawFirestoreAuthEvent,
   params: Params
-): FirestoreEvent<QueryDocumentSnapshot | undefined, Params> {
+):
+  | FirestoreEvent<QueryDocumentSnapshot | undefined, Params>
+  | FirestoreAuthEvent<QueryDocumentSnapshot | undefined, Params> {
   const data = event.data
-    ? eventType === createdEventType
+    ? eventType === createdEventType || eventType === createdEventWithAuthContextType
       ? createSnapshot(event)
       : createBeforeSnapshot(event)
     : undefined;
@@ -578,19 +598,32 @@ export function makeFirestoreEvent<Params>(
     ...event,
     params,
     data,
-    authType: event.authtype as AuthType,
-    authId: event.authid,
   };
+
   delete (firestoreEvent as any).datacontenttype;
   delete (firestoreEvent as any).dataschema;
+
+  if ("authtype" in event) {
+    const eventWithAuth = {
+      ...firestoreEvent,
+      authType: event.authtype,
+      authId: event.authid,
+    };
+    delete (eventWithAuth as any).authtype;
+    delete (eventWithAuth as any).authid;
+    return eventWithAuth;
+  }
+
   return firestoreEvent;
 }
 
 /** @internal */
 export function makeChangedFirestoreEvent<Params>(
-  event: RawFirestoreEvent,
+  event: RawFirestoreEvent | RawFirestoreAuthEvent,
   params: Params
-): FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, Params> {
+):
+  | FirestoreEvent<Change<DocumentSnapshot> | undefined, Params>
+  | FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, Params> {
   const data = event.data
     ? Change.fromObjects(createBeforeSnapshot(event), createSnapshot(event))
     : undefined;
@@ -598,11 +631,21 @@ export function makeChangedFirestoreEvent<Params>(
     ...event,
     params,
     data,
-    authType: event.authtype as AuthType,
-    authId: event.authid,
   };
   delete (firestoreEvent as any).datacontenttype;
   delete (firestoreEvent as any).dataschema;
+
+  if ("authtype" in event) {
+    const eventWithAuth = {
+      ...firestoreEvent,
+      authType: event.authtype,
+      authId: event.authid,
+    };
+    delete (eventWithAuth as any).authtype;
+    delete (eventWithAuth as any).authid;
+    return eventWithAuth;
+  }
+
   return firestoreEvent;
 }
 
@@ -649,16 +692,19 @@ export function makeEndpoint(
 }
 
 /** @internal */
-export function onOperation<Document extends string>(
+export function onOperation<
+  Document extends string,
+  Event extends FirestoreEvent<QueryDocumentSnapshot, ParamsOf<Document>>
+>(
   eventType: string,
   documentOrOpts: Document | DocumentOptions<Document>,
-  handler: (event: FirestoreEvent<QueryDocumentSnapshot, ParamsOf<Document>>) => any | Promise<any>
-): CloudFunction<FirestoreEvent<QueryDocumentSnapshot, ParamsOf<Document>>> {
+  handler: (event: Event) => any | Promise<any>
+): CloudFunction<Event> {
   const { document, database, namespace, opts } = getOpts(documentOrOpts);
 
   // wrap the handler
   const func = (raw: CloudEvent<unknown>) => {
-    const event = raw as RawFirestoreEvent;
+    const event = raw as RawFirestoreEvent | RawFirestoreAuthEvent;
     const documentPattern = new PathPattern(
       typeof document === "string" ? document : document.value()
     );
@@ -675,18 +721,19 @@ export function onOperation<Document extends string>(
 }
 
 /** @internal */
-export function onChangedOperation<Document extends string>(
+export function onChangedOperation<
+  Document extends string,
+  Event extends FirestoreEvent<Change<DocumentSnapshot>, ParamsOf<Document>>
+>(
   eventType: string,
   documentOrOpts: Document | DocumentOptions<Document>,
-  handler: (
-    event: FirestoreEvent<Change<QueryDocumentSnapshot>, ParamsOf<Document>>
-  ) => any | Promise<any>
-): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot>, ParamsOf<Document>>> {
+  handler: (event: Event) => any | Promise<any>
+): CloudFunction<Event> {
   const { document, database, namespace, opts } = getOpts(documentOrOpts);
 
   // wrap the handler
   const func = (raw: CloudEvent<unknown>) => {
-    const event = raw as RawFirestoreEvent;
+    const event = raw as RawFirestoreEvent | RawFirestoreAuthEvent;
     const documentPattern = new PathPattern(
       typeof document === "string" ? document : document.value()
     );

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -181,7 +181,7 @@ export function onDocumentWritten<Document extends string>(
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
@@ -195,7 +195,7 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
@@ -209,7 +209,7 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
 
 /**
  * Event handler that triggers when a document is created, updated, or deleted in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param opts - Options or a string document path.
  * @param handler - Event handler which is run every time a Firestore create, update, or delete occurs.
@@ -266,7 +266,7 @@ export function onDocumentCreated<Document extends string>(
 
 /**
  * Event handler that triggers when a document is created in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore create occurs.
@@ -280,7 +280,7 @@ export function onDocumentCreatedWithAuthContext<Document extends string>(
 
 /**
  * Event handler that triggers when a document is created in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore create occurs.
@@ -349,7 +349,7 @@ export function onDocumentUpdated<Document extends string>(
 
 /**
  * Event handler that triggers when a document is updated in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore update occurs.
@@ -362,7 +362,7 @@ export function onDocumentUpdatedWithAuthContext<Document extends string>(
 ): CloudFunction<FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>>>;
 /**
  * Event handler that triggers when a document is updated in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore update occurs.
@@ -432,7 +432,7 @@ export function onDocumentDeleted<Document extends string>(
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param document - The Firestore document path to trigger on.
  * @param handler - Event handler which is run every time a Firestore delete occurs.
@@ -446,7 +446,7 @@ export function onDocumentDeletedWithAuthContext<Document extends string>(
 
 /**
  * Event handler that triggers when a document is deleted in Firestore.
- * This trigger will also provide the authentication context of the principal who triggered the event.
+ * This trigger also provides the authentication context of the principal who triggered the event.
  *
  * @param opts - Options that can be set on an individual event-handling function.
  * @param handler - Event handler which is run every time a Firestore delete occurs.

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -236,13 +236,6 @@ export function onDocumentWrittenWithAuthContext<Document extends string>(
     event: FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>
   ) => any | Promise<any>
 ): CloudFunction<FirestoreAuthEvent<Change<DocumentSnapshot> | undefined, ParamsOf<Document>>> {
-  // const fn = (
-  //   event: FirestoreEvent<Change<QueryDocumentSnapshot> | undefined, ParamsOf<Document>> & {
-  //     foo: string;
-  //   }
-  // ): any => {
-  //   return event;
-  // };
   return onChangedOperation(writtenEventWithAuthContextType, documentOrOpts, handler);
 }
 


### PR DESCRIPTION
Auth context support has only been available for RTDB 1st gen functions — until now! The Firestore and Eventarc teams have recently added support for Firestore Cloud Events to include event actor information, adding four new event types. These changes enable us to offer four new 2nd gen Firestore trigger types whose events will additionally contain the auth context along with the existing event data:

- `onDocumentWrittenWithAuthContext`
- `onDocumentUpdatedWithAuthContext`
- `onDocumentCreatedWithAuthContext`
- `onDocumentDeletedWithAuthContext`

The API is very similar to the existing 2nd gen Firestore triggers API; however, users should take special care to avoid event loss when migrating from the original 2nd gen Firestore trigger to the auth-context trigger. See the [migration guide](link) for more details about best practices. (TODO: link migration guide when available)