### PR TITLE
FIX: Add wrapTraceContext to onChangedOperation to enable traceId on onDocumentUpdated

### DIFF
--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -473,7 +473,7 @@ export function onChangedOperation<Document extends string>(
     const event = raw as RawFirestoreEvent;
     const params = makeParams(event.document, documentPattern) as unknown as ParamsOf<Document>;
     const firestoreEvent = makeChangedFirestoreEvent(event, params);
-    return handler(firestoreEvent);
+    return wrapTraceContext(handler)(firestoreEvent);
   };
 
   func.run = handler;


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

When using firebase-functions v2 `traceId` is missing for Firestore triggers like `onDocumentUpdated`. 

After a deep dive into the repository's code I've found that there's a difference. 

`onDocumentCreated` relies in the method `onOperation` which wraps the event handler with the function `wrapTraceContext` that injects the `trace` information.

<img width="901" alt="Screenshot 2024-03-04 at 14 14 44" src="https://github.com/firebase/firebase-functions/assets/7697196/7085255c-25b0-45cb-8d5f-3feebee2eadb">

On the other side, `onDocumentUpdated` relies in the method `onChangedOperation` which executes the event handler without using the `wrapTraceContext` function. **I don't know if this is intentional, but this is a problem of those who are heavy users of firebase functions under the v2 because in previous version the `traceId` was available**. 

<img width="903" alt="Screenshot 2024-03-04 at 14 14 59" src="https://github.com/firebase/firebase-functions/assets/7697196/278eb887-e720-483e-92b0-3fecf72ce609">

I've adapted the code to make `onChangedOperation` use the `wrapTraceContext` function. With that line I think we can solve the issue of missing `traceId` in `onDocumentUpdated`.
