### PR TITLE
FEAT: Add logger compat module for v2 restoring fully v1 behavior when using standard console

### DIFF
--- a/src/logger/v2/compat.ts
+++ b/src/logger/v2/compat.ts
@@ -1,0 +1,44 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { format } from "util";
+import * as logger from "../";
+import { CONSOLE_SEVERITY } from "../common";
+
+/** @hidden */
+function patchedConsole(severity: string): (data: any, ...args: any[]) => void {
+  return function (data: any, ...args: any[]): void {
+    let message = format(data, ...args);
+    if (severity === "ERROR") {
+      message = new Error(message).stack || message;
+    }
+
+    logger[CONSOLE_SEVERITY[severity]](message);
+  };
+}
+
+// IMPORTANT -- "../logger" must be imported before monkeypatching!
+console.debug = patchedConsole("DEBUG");
+console.info = patchedConsole("INFO");
+console.log = patchedConsole("INFO");
+console.warn = patchedConsole("WARNING");
+console.error = patchedConsole("ERROR");


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

In firebase-functions v1 when using the standard `console` you'd visualize logs under cloud run with a `traceId`. 

In v2 that behavior has gone, there's a module to patch the `console` but that method only makes console work again by adjusting the way it logs the user inserted messages. 

<img width="1019" alt="Screenshot 2024-03-04 at 14 30 04" src="https://github.com/firebase/firebase-functions/assets/7697196/507d6d19-c6ec-41df-9ed0-644ada2ac52b">

If we want to have the trace attached to each log emitted by a function we need to use the firebase logger module which is provided by firebase functions. 

Since the **logger compat** module doesn't restore the behavior under v1, I've made an adaptation to ensure it works as expected and keeps the `traceId`. 

**The code is a draft, I've added a `v2` folder inside the `logger` folder which I think is wrong but I've done so we can start discussing if this adjustment is possible and where it should go.** 
