### PR TITLE
Remove infinite wrapping of withInit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+Fix bug where 1st gen functions eventually fail with stack too deep (#1540)
+Make simple CORS options static for improved debugability (#1536)

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -367,6 +367,7 @@ export function makeCloudFunction<EventData>({
   service,
   triggerResource,
 }: MakeCloudFunctionArgs<EventData>): CloudFunction<EventData> {
+  handler = withInit(handler);
   const cloudFunction: any = (data: any, context: any) => {
     if (legacyEventType && context.eventType === legacyEventType) {
       /*
@@ -404,7 +405,6 @@ export function makeCloudFunction<EventData>({
       context.params = context.params || _makeParams(context, triggerResource);
     }
 
-    handler = withInit(handler);
     let promise;
     if (labels && labels["deployment-scheduled"]) {
       // Scheduled function do not have meaningful data, so exclude it


### PR DESCRIPTION
Possible fix for #1539.

I think what's happened here is that the raw handler is captured in `makeCloudFunction` and repeatedly wrapped during the boilerplate code that invokes the handler. This causes an unbounded call stack that eventually causes a crash. To fix, we wrap once during `makeCloudFunction` and pass the wrapped function to the lambda that actually gets executed.