### PR TITLE
Fix release script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "docgen:v2:gen": "api-documenter-fire markdown -i docgen/v2 -o docgen/v2/markdown --project functions && npm run docgen:v2:toc",
     "docgen:v2": "npm run build && npm run docgen:v2:extract && npm run docgen:v2:gen",
     "build:pack": "rm -rf lib && npm install && tsc -p tsconfig.release.json && npm pack",
-    "build:release": "npm ci && npm install --no-save typescript && tsc -p tsconfig.release.json",
+    "build:release": "npm ci --production && npm install --no-save typescript && tsc -p tsconfig.release.json",
     "build": "tsc -p tsconfig.release.json",
     "build:watch": "npm run build -- -w",
     "format": "npm run format:ts && npm run format:other",

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "docgen:v2:gen": "api-documenter-fire markdown -i docgen/v2 -o docgen/v2/markdown --project functions && npm run docgen:v2:toc",
     "docgen:v2": "npm run build && npm run docgen:v2:extract && npm run docgen:v2:gen",
     "build:pack": "rm -rf lib && npm install && tsc -p tsconfig.release.json && npm pack",
-    "build:release": "npm ci --production && npm install --no-save typescript firebase-admin && tsc -p tsconfig.release.json",
+    "build:release": "npm ci && npm install --no-save typescript && tsc -p tsconfig.release.json",
     "build": "tsc -p tsconfig.release.json",
     "build:watch": "npm run build -- -w",
     "format": "npm run format:ts && npm run format:other",


### PR DESCRIPTION
Today, release script is broken with error message:

```
node_modules/google-gax/build/src/fallback.d.ts:20:34 - error TS2724: '"google-auth-library"' has no exported member named 'AnyAuthClient'. Did you mean 'AuthClient'?

20 import { GoogleAuth, AuthClient, AnyAuthClient } from 'google-auth-library';
```

It looks like the issue is related to some odd type incompatibility issue in an upstream package (google-gax). Rather than wait for the issue to be resolved, the change here removes command to install firebase-admin which isn't needed to build the release package anyway.