### PR TITLE
Add @deprecated annotation on functions.config() API

### DIFF
--- a/src/v1/config.ts
+++ b/src/v1/config.ts
@@ -39,7 +39,7 @@ export function resetCache(): void {
  * Firebase CLI as described in
  * https://firebase.google.com/docs/functions/config-env.
  *
- * @deprecated Using Cloud Runtime Configuration API is discouraged. See https://firebase.google.com/docs/functions/config-env#migrating_from_environment_configuration
+ * @deprecated Using functions.config() is discouraged. See https://firebase.google.com/docs/functions/config-env.
  */
 export function config(): Record<string, any> {
   // K_CONFIGURATION is only set in GCFv2

--- a/src/v1/config.ts
+++ b/src/v1/config.ts
@@ -38,6 +38,8 @@ export function resetCache(): void {
  * keys or other settings. You can set configuration values using the
  * Firebase CLI as described in
  * https://firebase.google.com/docs/functions/config-env.
+ *
+ * @deprecated Using Cloud Runtime Configuration API is discouraged. See https://firebase.google.com/docs/functions/config-env#migrating_from_environment_configuration
  */
 export function config(): Record<string, any> {
   // K_CONFIGURATION is only set in GCFv2


### PR DESCRIPTION
Using Cloud Runtime Configuration API is discouraged due to the API's reliability .

See:

https://github.com/firebase/firebase-tools/issues/7428
https://github.com/firebase/firebase-tools/issues/7341