### PR TITLE
Expose functions.config in the v2 namespace to avoid breaking the Functions Emulator

### DIFF
--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -73,3 +73,7 @@ export { Change } from "../common/change";
 // NOTE: Equivalent to `export * as params from "../params"` but api-extractor doesn't support that syntax.
 import * as params from "../params";
 export { params };
+
+// NOTE: Required to support the Functions Emulator which monkey patches `functions.config()`
+// TODO(danielylee): Remove in next major release.
+export { config } from "../v1/config";


### PR DESCRIPTION
Unforutnately, Functions Emulator monkey-patches the `functions.config()` method. 

Not exposing the `config()` method in the default namespace crashes the functions emulator 😢 .

https://github.com/firebase/firebase-tools/blob/0e2ab54c522d40ec9fe874e108332427e4886e0a/src/emulator/functionsEmulatorRuntime.ts#L717

In the near future, we'll make monkey-patching robust in the emulator to not crash when `functions.config()` method is missing