### PR TITLE
Improve callable function for long running requests.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@types/nock": "^10.0.3",
         "@types/node": "^14.18.24",
         "@types/node-fetch": "^3.0.3",
-        "@types/sinon": "^7.0.13",
+        "@types/sinon": "^9.0.11",
         "@typescript-eslint/eslint-plugin": "^5.33.1",
         "@typescript-eslint/parser": "^5.33.1",
         "api-extractor-model-me": "^0.1.1",
@@ -56,7 +56,7 @@
         "prettier": "^2.7.1",
         "protobufjs-cli": "^1.1.1",
         "semver": "^7.3.5",
-        "sinon": "^7.3.2",
+        "sinon": "^9.2.4",
         "ts-node": "^10.4.0",
         "typescript": "^4.3.5",
         "yargs": "^15.3.1"
@@ -1011,31 +1011,30 @@
         "type-detect": "4.0.8"
       }
     },
-    "node_modules/@sinonjs/formatio": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
-      "integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz",
+      "integrity": "sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1",
-        "@sinonjs/samsam": "^3.1.0"
+        "@sinonjs/commons": "^1.7.0"
       }
     },
     "node_modules/@sinonjs/samsam": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
-      "integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.3.1.tgz",
+      "integrity": "sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.3.0",
-        "array-from": "^2.1.1",
-        "lodash": "^4.17.15"
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
       }
     },
     "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.3.tgz",
+      "integrity": "sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==",
       "dev": true
     },
     "node_modules/@tootallnate/once": {
@@ -1287,9 +1286,18 @@
       }
     },
     "node_modules/@types/sinon": {
-      "version": "7.5.2",
-      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
-      "integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
+      "version": "9.0.11",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-9.0.11.tgz",
+      "integrity": "sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
     "node_modules/@types/tough-cookie": {
@@ -1756,12 +1764,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
-    },
-    "node_modules/array-from": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
-      "integrity": "sha512-GQTc6Uupx1FCavi5mPzBvVT7nEOeWMmUA9P95wpfpW1XwMSKs+KaymD5C2Up7KAUKg/mYwbsUYzdZWcoajlNZg==",
-      "dev": true
     },
     "node_modules/array-union": {
       "version": "2.1.0",
@@ -4475,12 +4477,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lolex": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
-      "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
-      "dev": true
-    },
     "node_modules/long": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/long/-/long-5.2.3.tgz",
@@ -4967,31 +4963,22 @@
       }
     },
     "node_modules/nise": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
-      "integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.1.0.tgz",
+      "integrity": "sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==",
       "dev": true,
       "dependencies": {
-        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
         "@sinonjs/text-encoding": "^0.7.1",
         "just-extend": "^4.0.2",
-        "lolex": "^5.0.1",
         "path-to-regexp": "^1.7.0"
       }
     },
-    "node_modules/nise/node_modules/lolex": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
-      "integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^1.7.0"
-      }
-    },
     "node_modules/nise/node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+      "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
       "dev": true,
       "dependencies": {
         "isarray": "0.0.1"
@@ -6162,48 +6149,31 @@
       }
     },
     "node_modules/sinon": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
-      "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "version": "9.2.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.4.tgz",
+      "integrity": "sha512-zljcULZQsJxVra28qIAL6ow1Z9tpattkCTEJR4RBP3TGc00FcttsP5pK284Nas5WjMZU5Yzy3kAIp3B3KRf5Yg==",
+      "deprecated": "16.1.1",
       "dev": true,
       "dependencies": {
-        "@sinonjs/commons": "^1.4.0",
-        "@sinonjs/formatio": "^3.2.1",
-        "@sinonjs/samsam": "^3.3.3",
-        "diff": "^3.5.0",
-        "lolex": "^4.2.0",
-        "nise": "^1.5.2",
-        "supports-color": "^5.5.0"
+        "@sinonjs/commons": "^1.8.1",
+        "@sinonjs/fake-timers": "^6.0.1",
+        "@sinonjs/samsam": "^5.3.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.4",
+        "supports-color": "^7.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
       }
     },
     "node_modules/sinon/node_modules/diff": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "dev": true,
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/sinon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/sinon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/slash": {

--- a/package.json
+++ b/package.json
@@ -287,7 +287,7 @@
     "@types/nock": "^10.0.3",
     "@types/node": "^14.18.24",
     "@types/node-fetch": "^3.0.3",
-    "@types/sinon": "^7.0.13",
+    "@types/sinon": "^9.0.11",
     "@typescript-eslint/eslint-plugin": "^5.33.1",
     "@typescript-eslint/parser": "^5.33.1",
     "api-extractor-model-me": "^0.1.1",
@@ -313,7 +313,7 @@
     "prettier": "^2.7.1",
     "protobufjs-cli": "^1.1.1",
     "semver": "^7.3.5",
-    "sinon": "^7.3.2",
+    "sinon": "^9.2.4",
     "ts-node": "^10.4.0",
     "typescript": "^4.3.5",
     "yargs": "^15.3.1"

--- a/spec/common/providers/https.spec.ts
+++ b/spec/common/providers/https.spec.ts
@@ -811,14 +811,13 @@ describe("onCallHandler", () => {
         { accept: "text/event-stream" }
       ) as any;
 
-
       const fn = https.onCallHandler(
         {
           cors: { origin: true, methods: "POST" },
         },
-        async (req, resp) => {
+        (req, resp) => {
           resp.write("initial message");
-          mockReq.emit('close');
+          mockReq.emit("close");
           resp.write("should not be sent");
           return "done";
         },
@@ -852,18 +851,18 @@ describe("onCallHandler", () => {
         const fn = https.onCallHandler(
           {
             cors: { origin: true, methods: "POST" },
-            heartbeatSeconds: 5
+            heartbeatSeconds: 5,
           },
           async () => {
             // Simulate long-running operation
-            await new Promise(resolve => setTimeout(resolve, 11_000));
+            await new Promise((resolve) => setTimeout(resolve, 11_000));
             return "done";
           },
           "gcfv2"
         );
 
         const handlerPromise = runHandler(fn, mockReq as any);
-        await clock.tickAsync(11_000)
+        await clock.tickAsync(11_000);
         const resp = await handlerPromise;
         expect(resp.body).to.include(': ping\n: ping\ndata: {"result":"done"}');
       });
@@ -879,10 +878,10 @@ describe("onCallHandler", () => {
         const fn = https.onCallHandler(
           {
             cors: { origin: true, methods: "POST" },
-            heartbeatSeconds: null
+            heartbeatSeconds: null,
           },
           async () => {
-            await new Promise(resolve => setTimeout(resolve, 31_000));
+            await new Promise((resolve) => setTimeout(resolve, 31_000));
             return "done";
           },
           "gcfv2"

--- a/spec/fixtures/mockrequest.ts
+++ b/spec/fixtures/mockrequest.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'node:stream';
+
 import * as jwt from 'jsonwebtoken';
 import * as jwkToPem from 'jwk-to-pem';
 import * as nock from 'nock';
@@ -5,14 +7,14 @@ import * as mockJWK from '../fixtures/credential/jwk.json';
 import * as mockKey from '../fixtures/credential/key.json';
 
 // MockRequest mocks an https.Request.
-export class MockRequest {
+export class MockRequest extends EventEmitter {
   public method: 'POST' | 'GET' | 'OPTIONS' = 'POST';
 
   constructor(
     readonly body: any,
     readonly headers: { [name: string]: string }
   ) {
-    // This block intentionally left blank.
+    super()
   }
 
   public header(name: string): string {

--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -53,7 +53,7 @@ export function runHandler(
       private callback: () => void;
 
       constructor() {
-        request.on("close", () => this.end())
+        request.on("close", () => this.end());
       }
 
       public status(code: number) {

--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -86,6 +86,7 @@ export function runHandler(
 
       public write(writeBody: any) {
         this.sentBody += typeof writeBody === "object" ? JSON.stringify(writeBody) : writeBody;
+        return true;
       }
 
       public end() {

--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -52,6 +52,10 @@ export function runHandler(
       private headers: { [name: string]: string } = {};
       private callback: () => void;
 
+      constructor() {
+        request.on("close", () => this.end())
+      }
+
       public status(code: number) {
         this.statusCode = code;
         return this;

--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -94,8 +94,8 @@ export function runHandler(
       }
 
       public on(event: string, callback: () => void) {
-        if (event !== "finish") {
-          throw new Error("MockResponse only implements the finish event");
+        if (event !== "finish" && event !== "close") {
+          throw new Error("MockResponse only implements close and finish event");
         }
         this.callback = callback;
       }

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -748,9 +748,7 @@ function wrapOnCallHandler<Req = any, Res = any>(
     let heartbeatInterval: NodeJS.Timeout | null = null;
 
     const heartbeatSeconds =
-      options.heartbeatSeconds === undefined
-        ? DEFAULT_HEARTBEAT_SECONDS
-        : options.heartbeatSeconds;
+      options.heartbeatSeconds === undefined ? DEFAULT_HEARTBEAT_SECONDS : options.heartbeatSeconds;
 
     const clearScheduledHeartbeat = () => {
       if (heartbeatInterval) {

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -856,15 +856,12 @@ function wrapOnCallHandler<Req = any, Res = any>(
             if (!acceptsStreaming) {
               return false;
             }
-
             // if connection is already closed, response.write() is no-op.
             if (abortController.signal.aborted) {
               return false;
             }
-
             const formattedData = encodeSSE({ message: chunk });
             const wrote = res.write(formattedData);
-
             // Reset heartbeat timer after successful write
             if (wrote && heartbeatInterval !== null && heartbeatSeconds > 0) {
               scheduleHeartbeat();
@@ -887,14 +884,11 @@ function wrapOnCallHandler<Req = any, Res = any>(
         result = await (handler as any)(arg, responseProxy);
         clearScheduledHeartbeat();
       }
-
       if (!abortController.signal.aborted) {
         // Encode the result as JSON to preserve types like Dates.
         result = encode(result);
-
         // If there was some result, encode it in the body.
         const responseBody: HttpResponseBody = { result };
-
         if (acceptsStreaming) {
           res.write(encodeSSE(responseBody));
           res.end();

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -713,7 +713,7 @@ export interface CallableOptions {
    *
    * Defaults to 30 seconds.
    */
-  heartbeatSeconds?: number | null
+  heartbeatSeconds?: number | null;
 }
 
 /** @internal */
@@ -752,9 +752,9 @@ function wrapOnCallHandler<Req = any, Res = any>(
         clearInterval(heartbeatInterval);
         heartbeatInterval = null;
       }
-    }
+    };
 
-    req.on('close', () => {
+    req.on("close", () => {
       clearHeartbeatInterval();
       abortController.abort();
     });
@@ -832,27 +832,24 @@ function wrapOnCallHandler<Req = any, Res = any>(
           write(chunk): boolean {
             // if client doesn't accept sse-protocol, response.write() is no-op.
             if (!acceptsStreaming) {
-              return false
+              return false;
             }
             // if connection is already closed, response.write() is no-op.
             if (abortController.signal.aborted) {
-              return false
+              return false;
             }
             const formattedData = encodeSSE({ message: chunk });
             return res.write(formattedData);
           },
           acceptsStreaming,
-          signal: abortController.signal
+          signal: abortController.signal,
         };
         if (acceptsStreaming) {
           // SSE always responds with 200
           res.status(200);
           const heartbeatSeconds = options.heartbeatSeconds ?? DEFAULT_HEARTBEAT_SECONDS;
           if (heartbeatSeconds !== null && heartbeatSeconds > 0) {
-            heartbeatInterval = setInterval(
-              () => res.write(": ping\n"),
-              heartbeatSeconds * 1000
-            );
+            heartbeatInterval = setInterval(() => res.write(": ping\n"), heartbeatSeconds * 1000);
           }
         }
         // For some reason the type system isn't picking up that the handler

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -205,7 +205,7 @@ export interface CallableOptions extends HttpsOptions {
    *
    * Defaults to 30 seconds.
    */
-  heartbeatSeconds?: number | null
+  heartbeatSeconds?: number | null;
 }
 
 /**

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -198,6 +198,14 @@ export interface CallableOptions extends HttpsOptions {
    * further decisions, such as requiring additional security checks or rejecting the request.
    */
   consumeAppCheckToken?: boolean;
+
+  /**
+   * Time in seconds between sending heartbeat messages to keep the connection
+   * alive. Set to `null` to disable heartbeats.
+   *
+   * Defaults to 30 seconds.
+   */
+  heartbeatSeconds?: number | null
 }
 
 /**

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -395,6 +395,7 @@ export function onCall<T = any, Return = any | Promise<any>>(
       cors: { origin, methods: "POST" },
       enforceAppCheck: opts.enforceAppCheck ?? options.getGlobalOptions().enforceAppCheck,
       consumeAppCheckToken: opts.consumeAppCheckToken,
+      heartbeatSeconds: opts.heartbeatSeconds,
     },
     fixedLen,
     "gcfv2"


### PR DESCRIPTION
In https://github.com/firebase/firebase-functions/pull/1634, we introduced new API to return response chunks for callable functions. This means that callable function response my be long-running.

To ensure that long-running requests are handled well, we are adding 2 new features:

1. heartbeat: Some network proxies may close request connection when no response data is sent for some time interval. By default, callable function will send a heartbeat ping every 30 seconds. Our client SDKs will ignore these pings. Users can disable heartbeat for streaming response by setting `heartbeatSeconds` configuration to `null`. 

2. AbortSignal: `response` object of the callable handler will now include `signal` property which the developer can use to check and see if a client connection has been dropped. They can forward this signal property to `fetch`-like APIs so that underlying calls would be terminated properly.

e.g. 

```js
exports.generateText = onCall(
  { 
    heartbeatSeconds: 10 // (Default: 30. Set to 'null' to disable heartbeat. )
  },
  async (request, response) => {
    const prompt = request.data.text;
    const result = await model.generateContentStream(
      prompt,
      { signal: response.signal }
    );

    for await (const chunk of result.stream) {
      if (response.acceptsStreaming) {
        // if the client did not request a streaming response,
        // response.write() is a no-op.
        response.write(chunk.text())
      }
    }
    return (await result.data()).text()
  }
```
 