### PR TITLE
Add support for an authPolicy that returns Permission Denied when failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add an authPolicy callback to CallableOptions for reusable auth middleware as well as helper auth policies (#1650)

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "node": ">=14.10.0"
       },
       "peerDependencies": {
-        "firebase-admin": ">=11.0.0"
+        "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
       }
     },
     "node_modules/@babel/parser": {

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -536,10 +536,13 @@ describe("onCall", () => {
   describe("authPolicy", () => {
     function req(data: any, auth?: Record<string, string>): any {
       const headers = {
-        "content-type": "application/json"
+        "content-type": "application/json",
       };
       if (auth) {
-        headers["authorization"] = `bearer ignored.${Buffer.from(JSON.stringify(auth), "utf-8").toString("base64")}.ignored`;
+        headers["authorization"] = `bearer ignored.${Buffer.from(
+          JSON.stringify(auth),
+          "utf-8"
+        ).toString("base64")}.ignored`;
       }
       const ret = new MockRequest({ data }, headers);
       ret.method = "POST";
@@ -552,7 +555,7 @@ describe("onCall", () => {
 
     after(() => {
       sinon.restore();
-    })
+    });
 
     it("should check isSignedIn", async () => {
       const func = https.onCall(
@@ -561,7 +564,7 @@ describe("onCall", () => {
         },
         () => 42
       );
-  
+
       const authResp = await runHandler(func, req(null, { sub: "inlined" }));
       expect(authResp.status).to.equal(200);
 
@@ -574,24 +577,24 @@ describe("onCall", () => {
         {
           authPolicy: https.hasClaim("meaning"),
         },
-        () => "HHGTTG",
+        () => "HHGTTG"
       );
       const specificValue = https.onCall(
         {
           authPolicy: https.hasClaim("meaning", "42"),
         },
-        () => "HHGTG",
-      )
+        () => "HHGTG"
+      );
 
-      const cases: Array<{fn: Handler, auth: null | Record<string, string>, status: number}> = [
-        {fn: anyValue, auth: { meaning: "42"}, status: 200},
-        {fn: anyValue, auth: { meaning: "43"}, status: 200},
-        {fn: anyValue, auth: { order: "66"}, status: 403},
-        {fn: anyValue, auth: null, status: 403},
-        {fn: specificValue, auth: { meaning: "42"}, status: 200},
-        {fn: specificValue, auth: { meaning: "43"}, status: 403},
-        {fn: specificValue, auth: { order: "66", }, status: 403},
-        {fn: specificValue, auth: null, status: 403},
+      const cases: Array<{ fn: Handler; auth: null | Record<string, string>; status: number }> = [
+        { fn: anyValue, auth: { meaning: "42" }, status: 200 },
+        { fn: anyValue, auth: { meaning: "43" }, status: 200 },
+        { fn: anyValue, auth: { order: "66" }, status: 403 },
+        { fn: anyValue, auth: null, status: 403 },
+        { fn: specificValue, auth: { meaning: "42" }, status: 200 },
+        { fn: specificValue, auth: { meaning: "43" }, status: 403 },
+        { fn: specificValue, auth: { order: "66" }, status: 403 },
+        { fn: specificValue, auth: null, status: 403 },
       ];
       for (const test of cases) {
         const resp = await runHandler(test.fn, req(null, test.auth));

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -843,8 +843,6 @@ function wrapOnCallHandler<Req = any, Res = any>(
 
       const data: Req = decode(req.body.data);
       if (options.authPolicy) {
-        // Don't ask me why, but Google decided not to disambiguate between unauthenticated and unauthorized
-        // in GRPC status codes, despite the pedantry to disambiguate the two in architecture design.
         const authorized = await options.authPolicy(context.auth ?? null, data);
         if (!authorized) {
           throw new HttpsError("permission-denied", "Permission Denied");

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -703,10 +703,11 @@ type v2CallableHandler<Req, Res> = (
 ) => Res;
 
 /** @internal **/
-export interface CallableOptions {
+export interface CallableOptions<T = any> {
   cors: cors.CorsOptions;
   enforceAppCheck?: boolean;
   consumeAppCheckToken?: boolean;
+  authPolicy?: (token: AuthData | null, data: T) => boolean | Promise<boolean>;
   /**
    * Time in seconds between sending heartbeat messages to keep the connection
    * alive. Set to `null` to disable heartbeats.
@@ -718,7 +719,7 @@ export interface CallableOptions {
 
 /** @internal */
 export function onCallHandler<Req = any, Res = any>(
-  options: CallableOptions,
+  options: CallableOptions<Req>,
   handler: v1CallableHandler | v2CallableHandler<Req, Res>,
   version: "gcfv1" | "gcfv2"
 ): (req: Request, res: express.Response) => Promise<void> {
@@ -739,7 +740,7 @@ function encodeSSE(data: unknown): string {
 
 /** @internal */
 function wrapOnCallHandler<Req = any, Res = any>(
-  options: CallableOptions,
+  options: CallableOptions<Req>,
   handler: v1CallableHandler | v2CallableHandler<Req, Res>,
   version: "gcfv1" | "gcfv2"
 ): (req: Request, res: express.Response) => Promise<void> {
@@ -841,6 +842,14 @@ function wrapOnCallHandler<Req = any, Res = any>(
       }
 
       const data: Req = decode(req.body.data);
+      if (options.authPolicy) {
+        // Don't ask me why, but Google decided not to disambiguate between unauthenticated and unauthorized
+        // in GRPC status codes, despite the pedantry to disambiguate the two in architecture design.
+        const authorized = await options.authPolicy(context.auth ?? null, data);
+        if (!authorized) {
+          throw new HttpsError("permission-denied", "Permission Denied");
+        }
+      }
       let result: Res;
       if (version === "gcfv1") {
         result = await (handler as v1CallableHandler)(data, context);

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -421,8 +421,7 @@ export function onCall<T = any, Return = any | Promise<any>>(
   }
 
   // fix the length of handler to make the call to handler consistent
-  const fixedLen = (req: CallableRequest<T>, resp?: CallableProxyResponse) =>
-    handler(req, resp);
+  const fixedLen = (req: CallableRequest<T>, resp?: CallableProxyResponse) => handler(req, resp);
   let func: any = onCallHandler(
     {
       cors: { origin, methods: "POST" },


### PR DESCRIPTION
Per upcoming design (and to support `onCallGenkit` callable functions' options can now support an `authPolicy` callback. Adds support for this callback, as well as two helpers: `isSignedIn` and `hasClaim`.