### PR TITLE
Update SSE respones to have 2 newlines per SSE spec

### DIFF
--- a/spec/common/providers/https.spec.ts
+++ b/spec/common/providers/https.spec.ts
@@ -778,7 +778,7 @@ describe("onCallHandler", () => {
 
       const resp = await runHandler(fn, mockReq as any);
       const data = [`data: {"message":"hello"}`, `data: {"result":"world"}`];
-      expect(resp.body).to.equal([...data, ""].join("\n"));
+      expect(resp.body).to.equal([...data, ""].join("\n\n"));
     });
 
     it("returns error in SSE format", async () => {
@@ -800,7 +800,7 @@ describe("onCallHandler", () => {
 
       const resp = await runHandler(fn, mockReq as any);
       const data = [`data: {"error":{"message":"INTERNAL","status":"INTERNAL"}}`];
-      expect(resp.body).to.equal([...data, ""].join("\n"));
+      expect(resp.body).to.equal([...data, ""].join("\n\n"));
     });
 
     it("always returns error for v1 callables", async () => {
@@ -851,7 +851,7 @@ describe("onCallHandler", () => {
 
       const resp = await runHandler(fn, mockReq);
 
-      expect(resp.body).to.equal(`data: {"message":"initial message"}\n`);
+      expect(resp.body).to.equal(`data: {"message":"initial message"}\n\n`);
     });
 
     describe("Heartbeats", () => {
@@ -890,7 +890,7 @@ describe("onCallHandler", () => {
         await clock.tickAsync(11_000);
         const resp = await handlerPromise;
         const data = [": ping", ": ping", `data: {"result":"done"}`];
-        expect(resp.body).to.equal([...data, ""].join("\n"));
+        expect(resp.body).to.equal([...data, ""].join("\n\n"));
       });
 
       it("doesn't send heartbeat messages if user writes data", async () => {
@@ -919,7 +919,7 @@ describe("onCallHandler", () => {
         await clock.tickAsync(10_000);
         const resp = await handlerPromise;
         const data = [`data: {"message":"hello"}`, `data: {"result":"done"}`];
-        expect(resp.body).to.equal([...data, ""].join("\n"));
+        expect(resp.body).to.equal([...data, ""].join("\n\n"));
       });
 
       it("respects null heartbeatSeconds option", async () => {
@@ -945,7 +945,7 @@ describe("onCallHandler", () => {
         const handlerPromise = runHandler(fn, mockReq as any);
         await clock.tickAsync(31_000);
         const resp = await handlerPromise;
-        expect(resp.body).to.equal('data: {"result":"done"}\n');
+        expect(resp.body).to.equal('data: {"result":"done"}\n\n');
       });
     });
   });

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -738,7 +738,7 @@ export function onCallHandler<Req = any, Res = any, Stream = unknown>(
 }
 
 function encodeSSE(data: unknown): string {
-  return `data: ${JSON.stringify(data)}\n`;
+  return `data: ${JSON.stringify(data)}\n\n`;
 }
 
 /** @internal */
@@ -766,7 +766,7 @@ function wrapOnCallHandler<Req = any, Res = any, Stream = unknown>(
       if (!abortController.signal.aborted) {
         heartbeatInterval = setTimeout(() => {
           if (!abortController.signal.aborted) {
-            res.write(": ping\n");
+            res.write(": ping\n\n");
             scheduleHeartbeat();
           }
         }, heartbeatSeconds * 1000);


### PR DESCRIPTION
This should be backward-compatible since SSE clients will ignore newlines in the responses.