### PR TITLE
Fix bug where sse response hangs if handler threw an error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+- Add onCallGenkit (#1655)

--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -80,7 +80,7 @@ export function runHandler(
         const body =
           typeof this.sentBody === "undefined"
             ? toSend
-            : this.sentBody + ((toSend as string) || "");
+            : this.sentBody + String(toSend || "");
         this.end(body);
       }
 

--- a/spec/helper.ts
+++ b/spec/helper.ts
@@ -73,18 +73,21 @@ export function runHandler(
 
       public send(sendBody: any) {
         if (this.writeCalled) {
-          throw Error("Cannot set headers after they are sent to the client")
+          throw Error("Cannot set headers after they are sent to the client");
         }
 
         const toSend = typeof sendBody === "object" ? JSON.stringify(sendBody) : sendBody;
-        const body = typeof this.sentBody === 'undefined' ? toSend : this.sentBody + ((toSend as string) || "");
+        const body =
+          typeof this.sentBody === "undefined"
+            ? toSend
+            : this.sentBody + ((toSend as string) || "");
         this.end(body);
       }
 
       public write(writeBody: any, cb?: () => void) {
         this.writeCalled = true;
 
-        if (typeof this.sentBody === 'undefined') {
+        if (typeof this.sentBody === "undefined") {
           this.sentBody = writeBody;
         } else {
           this.sentBody += typeof writeBody === "object" ? JSON.stringify(writeBody) : writeBody;

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -933,7 +933,8 @@ function wrapOnCallHandler<Req = any, Res = any, Stream = unknown>(
         const { status } = httpErr.httpErrorCode;
         const body = { error: httpErr.toJSON() };
         if (version === "gcfv2" && req.header("accept") === "text/event-stream") {
-          res.send(encodeSSE(body));
+          res.write(encodeSSE(body));
+          res.end();
         } else {
           res.status(status).send(body);
         }


### PR DESCRIPTION
When callable function handler throws an error, the existing implementation doesn't capture the error. Instead the error is throw, killing the process:

```
>  {"severity":"ERROR","message":"Unhandled error ReferenceError: datat is not defined\n    at /Users/[REDACTED_USER_NAME]/google/cf3-streaming-demo/functions/lib/index.js:90:9\n    at async /Users/[REDACTED_USER_NAME]/google/cf3-streaming-demo/functions/nod
e_modules/firebase-functions/lib/common/providers/https.js:544:26\n    at async runFunction (/Users/[REDACTED_USER_NAME]/google/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:506:9)\n    at async runHTTPS (/Users/[REDACTED_USER_NAME]/google/firebase
-tools/lib/emulator/functionsEmulatorRuntime.js:531:5)\n    at async /Users/[REDACTED_USER_NAME]/google/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:694:21"}
⚠  functions: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:405:5)
    at ServerResponse.setHeader (node:_http_outgoing:648:11)
    at ServerResponse.header (/node_modules/express/lib/response.js:795:10)
    at ServerResponse.contentType (/node_modules/express/lib/response.js:625:15)
    at ServerResponse.send (/Users/[REDACTED_USER_NAME]/google/firebase-tools/node_modules/express/lib/response.js:150:14)
    at /Users/[REDACTED_USER_NAME]/google/cf3-streaming-demo/functions/node_modules/firebase-functions/lib/common/providers/https.js:575:25
    at async runFunction (/Users/[REDACTED_USER_NAME]/google/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:506:9)
    at async runHTTPS (/Users/[REDACTED_USER_NAME]/google/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:531:5)
    at async /Users/[REDACTED_USER_NAME]/google/firebase-tools/lib/emulator/functionsEmulatorRuntime.js:694:21
⚠  Your function was killed because it raised an unhandled error.
i  functions: Finished "us-central1-genStreamError" in 5044.977417ms
```

I needed to make some changes to the `MockResponse` class since it incorrectly implemented how `Response` object actually works for node.js.