### PR TITLE
Adds auth.rawToken to context to allow access to the underlying token.

### DIFF
--- a/spec/v1/providers/https.spec.ts
+++ b/spec/v1/providers/https.spec.ts
@@ -199,6 +199,7 @@ describe("#onCall", () => {
 
     let gotData: Record<string, any>;
     let gotContext: Record<string, any>;
+    const rawToken = generateUnsignedIdToken("123456");
     const reqData = { hello: "world" };
     const authContext = {
       uid: "SomeUID",
@@ -207,8 +208,9 @@ describe("#onCall", () => {
         sub: "SomeUID",
         uid: "SomeUID",
       },
+      rawToken,
     };
-    const originalAuth = "Bearer " + generateUnsignedIdToken("123456");
+    const originalAuth = "Bearer " + rawToken;
     const func = https.onCall((data, context) => {
       gotData = data;
       gotContext = context;

--- a/spec/v1/providers/tasks.spec.ts
+++ b/spec/v1/providers/tasks.spec.ts
@@ -160,6 +160,7 @@ describe("#onDispatch", () => {
       auth: {
         uid: "abc",
         token: "token" as any,
+        rawToken: "abc123",
       },
       queueName: "fn",
       id: "task0",

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -78,8 +78,12 @@ export interface AppCheckData {
  * The interface for Auth tokens verified in Callable functions
  */
 export interface AuthData {
+  /** The user's uid from the request's ID token. */
   uid: string;
+  /** The decoded claims of the ID token after verification. */
   token: DecodedIdToken;
+  /** The raw ID token as parsed from the header. */
+  rawToken: string;
 }
 
 // This type is the direct v1 callable interface and is also an interface
@@ -646,6 +650,7 @@ export async function checkAuthToken(
     ctx.auth = {
       uid: authToken.uid,
       token: authToken,
+      rawToken: idToken,
     };
     return "VALID";
   } catch (err) {

--- a/src/common/providers/tasks.ts
+++ b/src/common/providers/tasks.ts
@@ -80,6 +80,7 @@ export interface RateLimits {
 export interface AuthData {
   uid: string;
   token: DecodedIdToken;
+  rawToken: string;
 }
 
 /** Metadata about a call to a Task Queue function. */
@@ -205,6 +206,7 @@ export function onDispatchHandler<Req = any>(
         context.auth = {
           uid: authToken.uid,
           token: authToken,
+          rawToken: token,
         };
       }
 

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -106,6 +106,8 @@ export interface EventContext<Params = Record<string, string>> {
   auth?: {
     token: object;
     uid: string;
+    /** If available, the unparsed ID token. */
+    rawToken?: string;
   };
 
   /**


### PR DESCRIPTION
I've seen this request come through specifically for Genkit, but I think it applies generally -- there are some cases where a user might want to proxy calls to another Firebase service or use e.g. ServerApp to access data as the user. To do this, the original Auth ID token needs to be available to them.

This adds rawToken to AuthData throughout the codebase. If this seems like a good idea I'll go through proper channels to propose the API change.