### PR TITLE
fix for DataSnapshot.val() throwing error when source is null

### DIFF
--- a/src/common/providers/database.ts
+++ b/src/common/providers/database.ts
@@ -126,6 +126,9 @@ export class DataSnapshot implements database.DataSnapshot {
   val(): any {
     const parts = pathParts(this._childPath);
     let source = this._data;
+    if (source === null) {
+      return null;
+    }
     if (parts.length) {
       for (const part of parts) {
         if (source[part] === undefined) {


### PR DESCRIPTION
Resolves https://github.com/firebase/firebase-functions/issues/1677