### PR TITLE
fix(tasks): removes the 'retry' option from tasks

### DIFF
--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -282,7 +282,6 @@ export function onTaskDispatched<Args = any>(
     convertInvoker
   );
   convertIfPresent(func.__endpoint.taskQueueTrigger, opts, "invoker", "invoker", convertInvoker);
-  copyIfPresent(func.__endpoint.taskQueueTrigger, opts, "retry", "retry");
 
   func.__requiredAPIs = [
     {


### PR DESCRIPTION
Resolves https://github.com/firebase/firebase-functions/issues/1623

**Note:** this issue is part of a larger issue where `TaskQueueOptions` extends from `EventHandlerOptions`, which provides properties that seemingly have no purpose and aren’t supported in the [API specification](https://github.com/firebase/firebase-tools/blob/master/src/deploy/functions/runtimes/discovery/v1alpha1.ts#L240) for tasks.