### PR TITLE
Refactor: Make `defineString` generic for better type-safety

### DIFF
--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -130,7 +130,7 @@ export function defineSecret(name: string): SecretParam {
  * @param options Configuration options for the parameter.
  * @returns A parameter with a `string` return type for `.value`.
  */
-export function defineString(name: string, options: ParamOptions<string> = {}): StringParam {
+export function defineString<T extends string>(name: string, options: ParamOptions<T> = {}): StringParam<T> {
   const param = new StringParam(name, options);
   registerParam(param);
   return param;

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -293,12 +293,18 @@ export interface SelectOptions<T = unknown> {
   value: T;
 }
 
+/**
+ * This can be removed once typescript is upgraded to v5.4+
+ * @internal
+ */
+type NoInfer<T> = [T][T extends any ? 0 : never];
+
 /** The wire representation of a parameter when it's sent to the CLI. A superset of `ParamOptions`. */
 export type ParamSpec<T extends string | number | boolean | string[]> = {
   /** The name of the parameter which will be stored in .env files. Use UPPERCASE. */
   name: string;
   /** An optional default value to be used while prompting for input. Can be a literal or another parametrized expression. */
-  default?: T | Expression<T>;
+  default?: NoInfer<T> | Expression<NoInfer<T>>;
   /** An optional human-readable string to be used as a replacement for the parameter's name when prompting. */
   label?: string;
   /** An optional long-form description of the parameter to be displayed while prompting. */
@@ -468,10 +474,10 @@ export class SecretParam {
  *  A parametrized value of String type that will be read from .env files
  *  if present, or prompted for by the CLI if missing.
  */
-export class StringParam extends Param<string> {
+export class StringParam<T extends string = string> extends Param<T> {
   /** @internal */
-  runtimeValue(): string {
-    return process.env[this.name] || "";
+  runtimeValue(): T {
+    return process.env[this.name] as T;
   }
 }
 


### PR DESCRIPTION
### Description

The `defineString` function does not narrow the type when adding `input.select.options`. This means we have to typecast in certain situations, even though we know what the types should be.

### Code sample

```ts
const environmentParam = params.defineString("ENVIRONMENT", {
      default: "production", // This will now error out if it does not match one of the options
      input: {
        select: {
          options: [
            { label: "Production", value: "production" },
            { label: "Staging", value: "staging" },
            { label: "Development", value: "development" },
          ],
        },
      },
});

const environment = environmentParam.value();
// ^? "production" | "staging" | "development"
```
