### PR TITLE
feat(scheduler): add support for attemptDeadline in onSchedule

### DIFF
--- a/spec/runtime/manifest.spec.ts
+++ b/spec/runtime/manifest.spec.ts
@@ -265,6 +265,7 @@ describe("initScheduleTrigger", () => {
         maxRetryDuration: RESET_VALUE,
         minBackoffDuration: RESET_VALUE,
         maxBackoffDuration: RESET_VALUE,
+        attemptDeadline: RESET_VALUE,
       },
     });
   });
@@ -292,6 +293,7 @@ describe("initScheduleTrigger", () => {
         maxRetrySeconds: RESET_VALUE,
         minBackoffSeconds: RESET_VALUE,
         maxBackoffSeconds: RESET_VALUE,
+        attemptDeadline: RESET_VALUE,
       },
     });
   });

--- a/spec/v1/cloud-functions.spec.ts
+++ b/spec/v1/cloud-functions.spec.ts
@@ -212,6 +212,7 @@ describe("makeCloudFunction", () => {
           maxDoublings: RESET_VALUE,
           maxRetryDuration: RESET_VALUE,
           minBackoffDuration: RESET_VALUE,
+          attemptDeadline: RESET_VALUE,
         },
       },
       labels: {},

--- a/spec/v1/providers/fixtures.ts
+++ b/spec/v1/providers/fixtures.ts
@@ -46,5 +46,6 @@ export const MINIMAL_SCHEDULE_TRIGGER: ManifestEndpoint["scheduleTrigger"] = {
     maxBackoffDuration: options.RESET_VALUE,
     minBackoffDuration: options.RESET_VALUE,
     maxDoublings: options.RESET_VALUE,
+    attemptDeadline: options.RESET_VALUE,
   },
 };

--- a/spec/v1/providers/pubsub.spec.ts
+++ b/spec/v1/providers/pubsub.spec.ts
@@ -215,7 +215,10 @@ describe("Pubsub Functions", () => {
         expect(result.__endpoint.scheduleTrigger).to.deep.equal({
           ...MINIMAL_SCHEDULE_TRIGGER,
           schedule: "every 5 minutes",
-          retryConfig,
+          retryConfig: {
+            ...retryConfig,
+            attemptDeadline: RESET_VALUE,
+          },
         });
         expect(result.__endpoint.labels).to.be.empty;
       });
@@ -249,7 +252,10 @@ describe("Pubsub Functions", () => {
           expect(result.__endpoint.scheduleTrigger).to.deep.equal({
             ...MINIMAL_SCHEDULE_TRIGGER,
             schedule: "every 5 minutes",
-            retryConfig,
+            retryConfig: {
+              ...retryConfig,
+              attemptDeadline: RESET_VALUE,
+            },
             timeZone: "America/New_York",
           });
           expect(result.__endpoint.labels).to.be.empty;
@@ -341,7 +347,10 @@ describe("Pubsub Functions", () => {
           ...MINIMAL_SCHEDULE_TRIGGER,
           schedule: "every 5 minutes",
           timeZone: RESET_VALUE,
-          retryConfig,
+          retryConfig: {
+            ...retryConfig,
+            attemptDeadline: RESET_VALUE,
+          },
         });
         expect(result.__endpoint.region).to.deep.equal(["us-east1"]);
         expect(result.__endpoint.availableMemoryMb).to.deep.equal(256);
@@ -382,7 +391,10 @@ describe("Pubsub Functions", () => {
           ...MINIMAL_SCHEDULE_TRIGGER,
           schedule: "every 5 minutes",
           timeZone: "America/New_York",
-          retryConfig,
+          retryConfig: {
+            ...retryConfig,
+            attemptDeadline: RESET_VALUE,
+          },
         });
         expect(result.__endpoint.region).to.deep.equal(["us-east1"]);
         expect(result.__endpoint.availableMemoryMb).to.deep.equal(256);

--- a/spec/v2/providers/scheduler.spec.ts
+++ b/spec/v2/providers/scheduler.spec.ts
@@ -38,6 +38,7 @@ const MINIMAL_SCHEDULE_TRIGGER: ManifestEndpoint["scheduleTrigger"] = {
     minBackoffSeconds: options.RESET_VALUE,
     maxBackoffSeconds: options.RESET_VALUE,
     maxDoublings: options.RESET_VALUE,
+    attemptDeadline: options.RESET_VALUE,
   },
 };
 
@@ -103,6 +104,20 @@ describe("schedule", () => {
       ]);
     });
 
+    it("should create a schedule function with attemptDeadline", () => {
+      const schfn = schedule.onSchedule(
+        {
+          schedule: "* * * * *",
+          attemptDeadline: "320s",
+        },
+        () => undefined
+      );
+
+      expect(schfn.__endpoint.scheduleTrigger?.retryConfig?.attemptDeadline).to.equal(
+        "320s"
+      );
+    });
+
     it("should create a schedule function given options", () => {
       const schfn = schedule.onSchedule(
         {
@@ -133,6 +148,7 @@ describe("schedule", () => {
             minBackoffSeconds: 11,
             maxBackoffSeconds: 12,
             maxDoublings: 2,
+            attemptDeadline: options.RESET_VALUE,
           },
         },
       });

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -107,6 +107,7 @@ export interface ManifestEndpoint {
       maxRetryDuration?: string | Expression<string> | ResetValue;
       minBackoffDuration?: string | Expression<string> | ResetValue;
       maxBackoffDuration?: string | Expression<string> | ResetValue;
+      attemptDeadline?: string | Expression<string> | ResetValue;
     };
   };
 
@@ -254,6 +255,7 @@ const RESETTABLE_V1_SCHEDULE_OPTIONS: Omit<
   maxRetryDuration: null,
   maxBackoffDuration: null,
   minBackoffDuration: null,
+  attemptDeadline: null,
 };
 
 const RESETTABLE_V2_SCHEDULE_OPTIONS: Omit<
@@ -265,6 +267,7 @@ const RESETTABLE_V2_SCHEDULE_OPTIONS: Omit<
   maxRetrySeconds: null,
   minBackoffSeconds: null,
   maxBackoffSeconds: null,
+  attemptDeadline: null,
 };
 
 function initScheduleTrigger(

--- a/src/v1/cloud-functions.ts
+++ b/src/v1/cloud-functions.ts
@@ -485,7 +485,8 @@ export function makeCloudFunction<EventData>({
           "maxDoublings",
           "maxBackoffDuration",
           "maxRetryDuration",
-          "minBackoffDuration"
+          "minBackoffDuration",
+          "attemptDeadline"
         );
       } else {
         endpoint.eventTrigger = {

--- a/src/v1/function-configuration.ts
+++ b/src/v1/function-configuration.ts
@@ -110,6 +110,11 @@ export interface ScheduleRetryConfig {
    * @defaultValue 5
    */
   maxDoublings?: number | Expression<number> | ResetValue;
+
+  /**
+   * The deadline for each job attempt, specified as a duration string (e.g. "600s").
+   */
+  attemptDeadline?: string | Expression<string> | ResetValue;
 }
 
 /**

--- a/src/v2/providers/scheduler.ts
+++ b/src/v2/providers/scheduler.ts
@@ -48,6 +48,7 @@ interface SeparatedOpts {
     minBackoffSeconds?: number | Expression<number> | ResetValue;
     maxBackoffSeconds?: number | Expression<number> | ResetValue;
     maxDoublings?: number | Expression<number> | ResetValue;
+    attemptDeadline?: string | Expression<string> | ResetValue;
   };
   opts: options.GlobalOptions;
 }
@@ -60,16 +61,22 @@ export function getOpts(args: string | ScheduleOptions): SeparatedOpts {
       opts: {} as options.GlobalOptions,
     };
   }
+  const retryConfig: any = {
+    retryCount: args.retryCount,
+    maxRetrySeconds: args.maxRetrySeconds,
+    minBackoffSeconds: args.minBackoffSeconds,
+    maxBackoffSeconds: args.maxBackoffSeconds,
+    maxDoublings: args.maxDoublings,
+  };
+  
+  if (args.attemptDeadline !== undefined) {
+    retryConfig.attemptDeadline = args.attemptDeadline;
+  }
+
   return {
     schedule: args.schedule,
     timeZone: args.timeZone,
-    retryConfig: {
-      retryCount: args.retryCount,
-      maxRetrySeconds: args.maxRetrySeconds,
-      minBackoffSeconds: args.minBackoffSeconds,
-      maxBackoffSeconds: args.maxBackoffSeconds,
-      maxDoublings: args.maxDoublings,
-    },
+    retryConfig,
     opts: args as options.GlobalOptions,
   };
 }
@@ -125,6 +132,12 @@ export interface ScheduleOptions extends options.GlobalOptions {
 
   /** The time between will double max doublings times. */
   maxDoublings?: number | Expression<number> | ResetValue;
+
+  /**
+   * The deadline for each job attempt, specified as a duration string (e.g. "600s").
+   * See: https://cloud.google.com/scheduler/docs/reference/rest/v1/projects.locations.jobs#Job
+   */
+  attemptDeadline?: string | Expression<string> | ResetValue;
 }
 
 /**
@@ -204,7 +217,8 @@ export function onSchedule(
     "maxRetrySeconds",
     "minBackoffSeconds",
     "maxBackoffSeconds",
-    "maxDoublings"
+    "maxDoublings",
+    "attemptDeadline"
   );
   func.__endpoint = ep;
 


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description
Add support for the `attemptDeadline` option in Cloud Scheduler when using Firebase Functions.

Previously, the `attemptDeadline` value had to be configured manually in the Google Cloud Console after deploying a scheduled function. With this change, developers can specify `attemptDeadline` directly in the `onSchedule` options ( or atleast i think so ), ensuring the configuration is applied automatically during deployment. 

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

### Code sample
```
// v2 Functions
export const myScheduledFunction = onSchedule({
  schedule: "0 9 * * *",
  attemptDeadline: "320s"
}, (event) => {
  // Your function code here
});

// v1 Functions  
export const myV1Function = functions.pubsub
  .schedule("every 5 minutes")
  .retryConfig({
    attemptDeadline: "320s"
  })
  .onRun((context) => {
    // Your function code here
  });
```

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->
