### PR TITLE
fix(analytics): validate against incomplete/invalid app_remove events

### DIFF
--- a/spec/v1/providers/analytics.spec.ts
+++ b/spec/v1/providers/analytics.spec.ts
@@ -301,6 +301,92 @@ describe("Analytics Functions", () => {
           analyticsSpecInput.data
         );
       });
+
+      it("should handle null and missing user property values without throwing", () => {
+        const cloudFunction = analytics
+          .event("app_remove")
+          .onLog((data: analytics.AnalyticsEvent) => data);
+
+        const event: Event = {
+          data: {
+            eventDim: [
+              {
+                name: "app_remove",
+                params: {},
+                date: "20240114",
+                timestampMicros: "1705257600000000",
+              },
+            ],
+            userDim: {
+              userProperties: {
+                // Invalid properties that should be filtered out:
+                null_property: null,
+                value_null: {
+                  value: null,
+                },
+                value_undefined: {
+                  value: undefined,
+                },
+                empty_object: {},
+                value_empty_object: {
+                  value: {},
+                },
+                // Valid properties that should be kept:
+                valid_string: {
+                  value: {
+                    stringValue: "test",
+                  },
+                  setTimestampUsec: "1486076786090987",
+                },
+                valid_empty_string: {
+                  value: {
+                    stringValue: "",
+                  },
+                  setTimestampUsec: "1486076786090987",
+                },
+                valid_zero: {
+                  value: {
+                    intValue: "0",
+                  },
+                  setTimestampUsec: "1486076786090987",
+                },
+              },
+            },
+          },
+          context: {
+            eventId: "70172329041928",
+            timestamp: "2018-04-09T07:56:12.975Z",
+            eventType: "providers/google.firebase.analytics/eventTypes/event.log",
+            resource: {
+              service: "app-measurement.com",
+              name: "projects/project1/events/app_remove",
+            },
+          },
+        };
+
+        return expect(cloudFunction(event.data, event.context)).to.eventually.deep.equal({
+          reportingDate: "20240114",
+          name: "app_remove",
+          params: {},
+          logTime: "2024-01-14T18:40:00.000Z",
+          user: {
+            userProperties: {
+              valid_string: {
+                value: "test",
+                setTime: "2017-02-02T23:06:26.090Z",
+              },
+              valid_empty_string: {
+                value: "",
+                setTime: "2017-02-02T23:06:26.090Z",
+              },
+              valid_zero: {
+                value: "0",
+                setTime: "2017-02-02T23:06:26.090Z",
+              },
+            },
+          },
+        });
+      });
     });
   });
 


### PR DESCRIPTION
This draft PR is a proposed solution to resolve https://github.com/firebase/firebase-functions/issues/1712

  ### Problem

  When an analytics event payload contains malformed user properties, the SDK throws a `TypeError` before the user's callback can execute:

  ```javascript
  // Problematic payloads:
  userProperties: {
    "some_property": null,                    // Entirely null
    "another_property": { "value": null },    // Value field is null
    "empty_property": {}                      // Missing value field
  }

  Error:
  TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
    at unwrapValueAsString (analytics.js:206)

  Solution

  1. Made unwrapValueAsString defensive 
  - Added null/undefined/empty object checks before calling Object.keys()
  - Returns empty string for invalid inputs instead of throwing
  - Improved type safety by changing parameter from any to unknown

  2. Filter invalid user properties 
  - Added filter in UserDimensions constructor to skip properties that are:
    - null or undefined
    - Empty objects {}
    - Objects with value field that is null, undefined, or {}
  - Valid properties (including falsy values like "" and 0) are preserved