### PR TITLE
BREAKING: remove functions.config() implementation

### DIFF
--- a/spec/v1/config.spec.ts
+++ b/spec/v1/config.spec.ts
@@ -28,12 +28,9 @@ describe("config()", () => {
   it("throws an error with migration guidance", () => {
     expect(config).to.throw(
       Error,
-      /functions\.config\(\) has been removed in firebase-functions v7/
-    );
-    expect(config).to.throw(Error, /migrate to environment parameters using the params module/);
-    expect(config).to.throw(
-      Error,
-      /https:\/\/firebase\.google\.com\/docs\/functions\/config-env#migrate-config/
+      "functions.config() has been removed in firebase-functions v7. " +
+        "Migrate to environment parameters using the params module. " +
+        "Migration guide: https://firebase.google.com/docs/functions/config-env#migrate-config"
     );
   });
 });

--- a/src/v1/config.ts
+++ b/src/v1/config.ts
@@ -23,14 +23,14 @@
 export { firebaseConfig } from "../common/config";
 
 /**
- * @deprecated functions.config() has been removed in firebase-functions v7.
- * Please migrate to environment parameters using the params module.
+ * @deprecated `functions.config()` has been removed in firebase-functions v7.
+ * Migrate to environment parameters using the `params` module immediately.
  * Migration guide: https://firebase.google.com/docs/functions/config-env#migrate-config
  */
 export function config(): Record<string, any> {
   throw new Error(
     "functions.config() has been removed in firebase-functions v7. " +
-      "Please migrate to environment parameters using the params module. " +
+      "Migrate to environment parameters using the params module. " +
       "Migration guide: https://firebase.google.com/docs/functions/config-env#migrate-config"
   );
 }


### PR DESCRIPTION
Replace functions.config() implementation with an error that provides clear migration guidance to the params module. This removes the deprecated API as planned for the next major release while helping developers migrate.

The error message directs users to: https://firebase.google.com/docs/functions/config-env#migrate-config

BREAKING CHANGE: functions.config() now throws an error instead of returning configuration values. Migrate to environment parameters using the params module.