### PR TITLE
chore: remove functions.config() API from v2 namespace

### DIFF
--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -75,10 +75,6 @@ export { traceContext } from "../common/trace";
 import * as params from "../params";
 export { params };
 
-// NOTE: Required to support the Functions Emulator which monkey patches `functions.config()`
-// TODO(danielylee): Remove in next major release.
-export { config } from "../v1/config";
-
 // Required for v1 Emulator support.
 import { setApp as setEmulatedAdminApp } from "../common/app";
 export const app = { setEmulatedAdminApp };


### PR DESCRIPTION
This change would break code like this:

```ts
const functions = require("firebase-functions")

functions.config() // Error: undefined is not callable
```

User must use v1 namespace which throws a more explicit error:

```ts
const functions = require("firebase-functions/v1")

functions.config() // Error: functions.config() has been removed in firebase-functions v7.
```