### PR TITLE
Fix release failure by adding Linux rolldown bindings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,6 +67,9 @@
       "engines": {
         "node": ">=18.0.0"
       },
+      "optionalDependencies": {
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.45"
+      },
       "peerDependencies": {
         "firebase-admin": "^11.10.0 || ^12.0.0 || ^13.0.0"
       }
@@ -2592,7 +2595,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -338,6 +338,9 @@
     "express": "^4.21.0",
     "protobufjs": "^7.2.2"
   },
+  "optionalDependencies": {
+    "@rolldown/binding-linux-x64-gnu": "1.0.0-beta.45"
+  },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",
     "@firebase/api-documenter": "^0.2.0",


### PR DESCRIPTION
The release build in Cloud Build (Linux) was failing because `npm ci` could not find the `@rolldown/binding-linux-x64-gnu` native binding. This is a known issue when lockfiles are generated on non-Linux OSes.

Explicitly adding it to `optionalDependencies` ensures it's included in `package-lock.json` and correctly installed by `npm ci` on Linux, while being safely skipped on other platforms.
