### PR TITLE
Fix tsc error for requiring/importing v1, v2, logger, and params namespaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,16 +307,16 @@
   "typesVersions": {
     "*": {
       "logger": [
-        "lib/logger"
+        "lib/logger/index"
       ],
       "logger/compat": [
         "lib/logger/compat"
       ],
       "params": [
-        "lib/params"
+        "lib/params/index"
       ],
       "v1": [
-        "lib/v1"
+        "lib/v1/index"
       ],
       "v1/analytics": [
         "lib/v1/providers/analytics"
@@ -406,7 +406,7 @@
         "lib/v2/providers/dataconnect"
       ],
       "v2": [
-        "lib/v2"
+        "lib/v2/index"
       ],
       "v2/core": [
         "lib/v2/core"


### PR DESCRIPTION
Explicitly point to /index in typesVersions for v1, v2, logger, and params. This is required for moduleResolution: node to correctly resolve types for directory indexes.

Unblocks https://github.com/firebase/functions-samples/pull/1227.