### PR TITLE
chore: fix logger export to make it mockable.

### DIFF
--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -178,3 +178,17 @@ function entryFromArgs(severity: LogSeverity, args: any[]): LogEntry {
   }
   return out;
 }
+
+/**
+ * Logger object containing all logging methods.
+ *
+ * Mockable for testing purposes.
+ */
+export const logger = {
+  write,
+  debug,
+  log,
+  info,
+  warn,
+  error,
+};

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -28,7 +28,6 @@
  * @packageDocumentation
  */
 
-import * as logger from "../logger";
 import * as alerts from "./providers/alerts";
 import * as database from "./providers/database";
 import * as eventarc from "./providers/eventarc";
@@ -50,7 +49,6 @@ export {
   https,
   identity,
   pubsub,
-  logger,
   tasks,
   eventarc,
   scheduler,
@@ -60,6 +58,7 @@ export {
   dataconnect,
 };
 
+export { logger } from "../logger";
 export { setGlobalOptions } from "./options";
 export type {
   GlobalOptions,


### PR DESCRIPTION
Due to quirks of how `tsdown` generates JS code vs how `tsc` generates JS code, we tweak how logger module is exported to allow it to be mockable.