### PR TITLE
feat: add attemptDeadlineSeconds support to v2 scheduled functions

### DIFF
--- a/spec/runtime/manifest.spec.ts
+++ b/spec/runtime/manifest.spec.ts
@@ -286,6 +286,7 @@ describe("initScheduleTrigger", () => {
     expect(st).to.deep.eq({
       schedule: "every 30 minutes",
       timeZone: RESET_VALUE,
+      attemptDeadlineSeconds: RESET_VALUE,
       retryConfig: {
         retryCount: RESET_VALUE,
         maxDoublings: RESET_VALUE,

--- a/spec/v2/providers/scheduler.spec.ts
+++ b/spec/v2/providers/scheduler.spec.ts
@@ -32,6 +32,7 @@ import { runHandler } from "../../helper";
 const MINIMAL_SCHEDULE_TRIGGER: ManifestEndpoint["scheduleTrigger"] = {
   schedule: "",
   timeZone: options.RESET_VALUE,
+  attemptDeadlineSeconds: options.RESET_VALUE,
   retryConfig: {
     retryCount: options.RESET_VALUE,
     maxRetrySeconds: options.RESET_VALUE,
@@ -54,6 +55,7 @@ describe("schedule", () => {
       const options: schedule.ScheduleOptions = {
         schedule: "* * * * *",
         timeZone: "utc",
+        attemptDeadlineSeconds: 300,
         retryCount: 3,
         maxRetrySeconds: 1,
         minBackoffSeconds: 2,
@@ -66,6 +68,7 @@ describe("schedule", () => {
       expect(schedule.getOpts(options)).to.deep.eq({
         schedule: "* * * * *",
         timeZone: "utc",
+        attemptDeadlineSeconds: 300,
         retryConfig: {
           retryCount: 3,
           maxRetrySeconds: 1,
@@ -108,6 +111,7 @@ describe("schedule", () => {
         {
           schedule: "* * * * *",
           timeZone: "utc",
+          attemptDeadlineSeconds: 600,
           retryCount: 3,
           maxRetrySeconds: 10,
           minBackoffSeconds: 11,
@@ -127,6 +131,7 @@ describe("schedule", () => {
         scheduleTrigger: {
           schedule: "* * * * *",
           timeZone: "utc",
+          attemptDeadlineSeconds: 600,
           retryConfig: {
             retryCount: 3,
             maxRetrySeconds: 10,
@@ -159,6 +164,7 @@ describe("schedule", () => {
         scheduleTrigger: {
           schedule: "* * * * *",
           timeZone: undefined,
+          attemptDeadlineSeconds: undefined,
           retryConfig: {
             retryCount: undefined,
             maxRetrySeconds: undefined,

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -97,6 +97,7 @@ export interface ManifestEndpoint {
   scheduleTrigger?: {
     schedule: string | Expression<string>;
     timeZone?: string | Expression<string> | ResetValue;
+    attemptDeadlineSeconds?: number | Expression<number> | ResetValue;
     retryConfig?: {
       retryCount?: number | Expression<number> | ResetValue;
       maxRetrySeconds?: string | Expression<string> | ResetValue;
@@ -302,5 +303,10 @@ export function initV2ScheduleTrigger(
   schedule: string | Expression<string>,
   ...opts: ManifestOptions[]
 ): ManifestEndpoint["scheduleTrigger"] {
-  return initScheduleTrigger(RESETTABLE_V2_SCHEDULE_OPTIONS, schedule, ...opts);
+  const trigger = initScheduleTrigger(RESETTABLE_V2_SCHEDULE_OPTIONS, schedule, ...opts);
+  // Set attemptDeadlineSeconds for v2 only
+  if (trigger.timeZone === RESET_VALUE) {
+    trigger.attemptDeadlineSeconds = RESET_VALUE;
+  }
+  return trigger;
 }

--- a/src/v2/providers/scheduler.ts
+++ b/src/v2/providers/scheduler.ts
@@ -42,6 +42,7 @@ import { withInit } from "../../common/onInit";
 interface SeparatedOpts {
   schedule: string | Expression<string>;
   timeZone?: timezone | Expression<string> | ResetValue;
+  attemptDeadlineSeconds?: number | Expression<number> | ResetValue;
   retryConfig?: {
     retryCount?: number | Expression<number> | ResetValue;
     maxRetrySeconds?: number | Expression<number> | ResetValue;
@@ -63,6 +64,7 @@ export function getOpts(args: string | ScheduleOptions): SeparatedOpts {
   return {
     schedule: args.schedule,
     timeZone: args.timeZone,
+    attemptDeadlineSeconds: args.attemptDeadlineSeconds,
     retryConfig: {
       retryCount: args.retryCount,
       maxRetrySeconds: args.maxRetrySeconds,
@@ -110,6 +112,9 @@ export interface ScheduleOptions extends options.GlobalOptions {
 
   /** The timezone that the schedule executes in. */
   timeZone?: timezone | Expression<string> | ResetValue;
+
+  /** The deadline for attempting the job in seconds. */
+  attemptDeadlineSeconds?: number | Expression<number> | ResetValue;
 
   /** The number of retry attempts for a failed run. */
   retryCount?: number | Expression<number> | ResetValue;
@@ -196,7 +201,7 @@ export function onSchedule(
     scheduleTrigger: initV2ScheduleTrigger(separatedOpts.schedule, globalOpts, separatedOpts.opts),
   };
 
-  copyIfPresent(ep.scheduleTrigger, separatedOpts, "timeZone");
+  copyIfPresent(ep.scheduleTrigger, separatedOpts, "timeZone", "attemptDeadlineSeconds");
   copyIfPresent(
     ep.scheduleTrigger.retryConfig,
     separatedOpts.retryConfig,


### PR DESCRIPTION
Adds new configurable option `attemptDeadlineSeconds` to v2 scheduled function configuration.

Per Cloud Scheduler [docs](https://cloud.google.com/scheduler/docs/reference/rest/v1beta1/projects.locations.jobs)

> The deadline for job attempts. If the request handler does not respond by this deadline then the request is cancelled and the attempt is marked as a DEADLINE_EXCEEDED failure. The failed attempt can be viewed in execution logs. Cloud Scheduler will retry the job according to the RetryConfig.
>
> For HTTP targets, the default is 3 minutes. The deadline must be in the interval [15 seconds, 30 minutes].

This option is useful for customer migrating from v1 scheduled function. V1 Scheduled function relied on pubsub for event delivery, which defaults to 10m ack deadline (~= attempt deadline).

```typescript

  export const myScheduledFunction = onSchedule({
    schedule: "every 5 minutes",
    attemptDeadlineSeconds: 300,
    retryCount: 3
  }, (event) => {
    // Your function logic
  });

```