### PR TITLE
Implement V1 compat API for PubSub

### DIFF
--- a/src/v2/core.ts
+++ b/src/v2/core.ts
@@ -25,7 +25,6 @@
  * @packageDocumentation
  */
 
-import type { EventContext } from "../v1/cloud-functions";
 import { Change } from "../common/change";
 import { ManifestEndpoint } from "../runtime/manifest";
 
@@ -92,13 +91,6 @@ export interface CloudEvent<T> {
 
   /** Information about this specific event. */
   data: T;
-
-  /** V1- compatible context of this event.
-   * 
-   * This getter is added at runtime for V1 compatibility.
-   * May be undefined if not set by a provider
-   */
-  readonly context?: EventContext;
 }
 
 /**


### PR DESCRIPTION
This PR adds the v1-compatible argument getters (context and message) directly to the v2 Pub/Sub CloudEvent<MessagePublishedData> class.
This allows developers to access v1-style arguments via property access, e.g., const { message, context } = event;, for a smoother migration of existing business logic to the v2 function signature.Implementation Details

The v1-compatible context getter is implemented as a lazily-computed property on the CloudEvent object. To correctly construct the v1 EventContext from the v2 event's properties, the following two internal helper functions are introduced:

1. `attachPubSubContext<T>(event: CloudEvent<MessagePublishedData<T>>, topic: string):`
Adds the v1-style context property to the v2 event object using Object.defineProperty.
The getter computes the EventContext by mapping v2 properties (event.id, event.time) and by calling getResourceName.
This ensures the context is only computed once upon first access.

2. `getResourceName(event: CloudEvent<MessagePublishedData<any>>, topic: string):`
Extracts the full resource name for the v1 EventContext resource object.
It attempts to parse the project ID and topic name from event.source or falls back to environment variables and the function's topic name parameter if necessary.

This is the first of a series of PRs aimed at simplifying the migration from v1 to v2. By introducing this new 
onMessagePublished function, we are providing a more robust and flexible way to handle Pub/Sub events in Cloud Functions for Firebase v2.

