### PR TITLE
Add Firebase Auth token to resolver context

### DIFF
--- a/src/v2/providers/dataconnect/graphql.ts
+++ b/src/v2/providers/dataconnect/graphql.ts
@@ -43,7 +43,7 @@ export async function initGraphqlServer(opts: GraphqlServerOptions): Promise<exp
         `/${opts.path ?? "graphql"}`,
         express.json(),
         expressMiddleware(server, {
-          context: async ({ req }) =>
+          context: ({ req }) =>
             Promise.resolve({
               auth: {
                 token: req.header(FIREBASE_AUTH_HEADER),
@@ -144,7 +144,7 @@ export interface GraphqlServerOptions extends Omit<HttpsOptions, "cors"> {
  * Per-request context state shared by all resolvers in a particular query.
  */
 export interface FirebaseContext {
-  auth?: {
+  auth: {
     /** The token attached to the `X-Firebase-Auth-Token` in the request, if present. */
     token?: string;
   };


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

<!-- Are you fixing a bug? Implementing a new feature? Make sure we have the context around your change.
	 Link to other relevant issues or pull requests. -->

Populates the `FirebaseContext` object with the result of the `X-Firebase-Auth-Token` request header, making it available inside resolver functions.

Removing the `uid` field for now from `FirebaseContext`.

### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

```
import { FirebaseContext, onGraphRequest } from 'firebase-functions/dataconnect/graphql';
import { log } from 'firebase-functions/logger';

const opts = {
    schemaFilePath: "dataconnect/schema_test_webhook/schema.gql",
    resolvers: {
        query: {
            hello(parent, args: Record<string, unknown>, contextValue: FirebaseContext, info) {
                log(`Saying hello to the user with Firebase Auth token ${contextValue.auth.token}`);
                return `Hello ${args.name}!`;
            },
        },
    },
}
exports.resolver = onGraphRequest(opts);
```