### PR TITLE
Add V1-compatible getters for context and message

### DIFF
--- a/spec/v2/providers/pubsub.spec.ts
+++ b/spec/v2/providers/pubsub.spec.ts
@@ -270,5 +270,39 @@ describe("onMessagePublished", () => {
       expect(capturedEvent.data.message.json).to.deep.equal({ foo: "bar" });
       expect(capturedEvent.data.message.attributes).to.deep.equal({ attr1: "val1" });
     });
+
+    it("should provide an empty object for attributes if missing in the original message", async () => {
+      const messageDataNoAttrs = {
+        messageId: "uuid-456",
+        data: Buffer.from(JSON.stringify({ foo: "baz" })).toString("base64"),
+        // attributes property is missing
+        publishTime: new Date(Date.now()).toISOString(),
+      };
+      const v2MessageInstance = new pubsub.Message(messageDataNoAttrs);
+      const publishData: pubsub.MessagePublishedData<any> = {
+        message: v2MessageInstance,
+        subscription: "projects/aProject/subscriptions/aSubscription",
+      };
+      const event: CloudEvent<pubsub.MessagePublishedData<any>> = {
+        specversion: "1.0",
+        source: "//pubsub.googleapis.com/projects/aProject/topics/topic",
+        id: "event-id-789",
+        type: EVENT_TRIGGER.eventType,
+        time: messageDataNoAttrs.publishTime,
+        data: publishData,
+      };
+
+      let capturedEvent: any;
+      const func = pubsub.onMessagePublished("topic", (e) => {
+        capturedEvent = e;
+        return Promise.resolve();
+      });
+
+      await func(event);
+
+      // Test the message getter for attributes
+      expect(capturedEvent.message.attributes).to.deep.equal({});
+      expect(capturedEvent.data.message.attributes).to.deep.equal({});
+    });
   });
 });

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -389,10 +389,8 @@ export function onMessagePublished<T = any>(
           data: v2Message.data,
           messageId: v2Message.messageId,
           publishTime: v2Message.publishTime,
+          attributes: v2Message.attributes || {},
         };
-        if (Object.keys(v2Message.attributes).length) {
-          baseMessage.attributes = v2Message.attributes;
-        }
         if (v2Message.orderingKey) {
           baseMessage.orderingKey = v2Message.orderingKey;
         }


### PR DESCRIPTION
Please Disregard the previous PR: 1782. Will close that PR.

This PR introduces a compatibility layer to the v2 [onMessagePublished] Pub/Sub trigger to simplify migration for developers coming from the v1 Firebase Functions SDK.

Specifically, it adds two new getters directly to the [CloudEvent] object received by the function:

1.  event.context: Returns an object mimicking the structure of the v1 `EventContext`.
2.  event.message: Returns a plain object mimicking the structure of the v1 [Message] object, including properties like `messageId`, `publishTime`, and `orderingKey`.

Users should be able to use it as below:

import { onMessagePublished } from "firebase-functions/v2/pubsub";

// v1-style business logic
function handleMessage(message, context) {
  console.log(message.json, context.eventId);
}

export const myV2Function = onMessagePublished("my-topic", (event) => {
  const { message, context } = event; // Easily get v1-compatible objects
  handleMessage(message, context);
});