### PR TITLE
fix(v2): validate timeoutSeconds per trigger type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,1 @@
 - Validate `timeoutSeconds` per v2 trigger type (540s for events, 3600s for HTTPS/callable, 1800s for task queues) so misconfigured values fail at function-definition or manifest-extraction time instead of at deploy time. (#1874)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+- Validate `timeoutSeconds` per v2 trigger type (540s for events, 3600s for HTTPS/callable, 1800s for task queues) so misconfigured values fail at function-definition or manifest-extraction time instead of at deploy time.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,2 @@
-- Validate `timeoutSeconds` per v2 trigger type (540s for events, 3600s for HTTPS/callable, 1800s for task queues) so misconfigured values fail at function-definition or manifest-extraction time instead of at deploy time.
+- Validate `timeoutSeconds` per v2 trigger type (540s for events, 3600s for HTTPS/callable, 1800s for task queues) so misconfigured values fail at function-definition or manifest-extraction time instead of at deploy time. (#1874)
 

--- a/spec/v2/options.spec.ts
+++ b/spec/v2/options.spec.ts
@@ -21,8 +21,15 @@
 // SOFTWARE.
 
 import { expect } from "chai";
-import { defineJsonSecret, defineSecret } from "../../src/params";
-import { GlobalOptions, optionsToEndpoint, RESET_VALUE } from "../../src/v2/options";
+import { defineInt, defineJsonSecret, defineSecret } from "../../src/params";
+import {
+  assertTimeoutSecondsValid,
+  GlobalOptions,
+  optionsToEndpoint,
+  optionsToTriggerAnnotations,
+  RESET_VALUE,
+  setGlobalOptions,
+} from "../../src/v2/options";
 
 describe("GlobalOptions", () => {
   it("should accept all valid secret types in secrets array (type test)", () => {
@@ -90,5 +97,136 @@ describe("optionsToEndpoint", () => {
   it("should reset vpc when networkInterface is RESET_VALUE", () => {
     const endpoint = optionsToEndpoint({ networkInterface: RESET_VALUE });
     expect(endpoint.vpc).to.equal(RESET_VALUE);
+  });
+});
+
+describe("assertTimeoutSecondsValid", () => {
+  afterEach(() => {
+    setGlobalOptions({});
+  });
+
+  it("is a no-op when timeoutSeconds is undefined", () => {
+    expect(() => assertTimeoutSecondsValid({}, "event")).to.not.throw();
+    expect(() => assertTimeoutSecondsValid({}, "https")).to.not.throw();
+    expect(() => assertTimeoutSecondsValid({}, "task")).to.not.throw();
+  });
+
+  it("accepts values within each kind's limit", () => {
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 540 }, "event")).to.not.throw();
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 3600 }, "https")).to.not.throw();
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1800 }, "task")).to.not.throw();
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 0 }, "event")).to.not.throw();
+  });
+
+  it("throws when timeoutSeconds exceeds the event-handler limit", () => {
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 3600 }, "event")).to.throw(
+      /between 0 and 540 for event-handling functions/
+    );
+  });
+
+  it("throws when timeoutSeconds exceeds the HTTPS limit", () => {
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 3601 }, "https")).to.throw(
+      /between 0 and 3600 for HTTPS and callable functions/
+    );
+  });
+
+  it("throws when timeoutSeconds exceeds the task-queue limit", () => {
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1801 }, "task")).to.throw(
+      /between 0 and 1800 for task queue functions/
+    );
+  });
+
+  it("throws when timeoutSeconds is negative", () => {
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: -1 }, "event")).to.throw(
+      /between 0 and 540/
+    );
+  });
+
+  it("skips validation for Expression timeouts", () => {
+    const expr = { timeoutSeconds: defineInt("TIMEOUT") };
+    expect(() => assertTimeoutSecondsValid(expr, "event")).to.not.throw();
+  });
+
+  it("skips validation for RESET_VALUE timeouts", () => {
+    const opts = { timeoutSeconds: RESET_VALUE as unknown as number };
+    expect(() => assertTimeoutSecondsValid(opts, "event")).to.not.throw();
+  });
+
+  it("falls back to the global timeoutSeconds when the function-level option is absent", () => {
+    setGlobalOptions({ timeoutSeconds: 3600 });
+    expect(() => assertTimeoutSecondsValid({}, "event")).to.throw(
+      /between 0 and 540 for event-handling functions/
+    );
+    expect(() => assertTimeoutSecondsValid({}, "https")).to.not.throw();
+  });
+
+  it("prefers the function-level timeoutSeconds over the global one", () => {
+    setGlobalOptions({ timeoutSeconds: 60 });
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1000 }, "event")).to.throw(
+      /between 0 and 540/
+    );
+  });
+
+  it("treats a function-level RESET_VALUE as a clear of an out-of-range global", () => {
+    setGlobalOptions({ timeoutSeconds: 3600 });
+    expect(() =>
+      assertTimeoutSecondsValid({ timeoutSeconds: RESET_VALUE as unknown as number }, "event")
+    ).to.not.throw();
+  });
+});
+
+describe("optionsToEndpoint timeout validation", () => {
+  afterEach(() => {
+    setGlobalOptions({});
+  });
+
+  it("does not validate when kind is omitted (backwards compatibility)", () => {
+    expect(() => optionsToEndpoint({ timeoutSeconds: 9999 })).to.not.throw();
+  });
+
+  it("throws when kind is provided and timeoutSeconds exceeds the limit", () => {
+    expect(() => optionsToEndpoint({ timeoutSeconds: 3600 }, "event")).to.throw(
+      /between 0 and 540/
+    );
+    expect(() => optionsToEndpoint({ timeoutSeconds: 3601 }, "https")).to.throw(
+      /between 0 and 3600/
+    );
+    expect(() => optionsToEndpoint({ timeoutSeconds: 1801 }, "task")).to.throw(
+      /between 0 and 1800/
+    );
+  });
+
+  it("is a no-op for in-range timeouts when kind is provided", () => {
+    expect(() => optionsToEndpoint({ timeoutSeconds: 540 }, "event")).to.not.throw();
+    expect(() => optionsToEndpoint({ timeoutSeconds: 3600 }, "https")).to.not.throw();
+    expect(() => optionsToEndpoint({ timeoutSeconds: 1800 }, "task")).to.not.throw();
+  });
+});
+
+describe("optionsToTriggerAnnotations timeout validation", () => {
+  afterEach(() => {
+    setGlobalOptions({});
+  });
+
+  it("does not validate when kind is omitted (backwards compatibility)", () => {
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 9999 })).to.not.throw();
+  });
+
+  it("throws when kind is provided and timeoutSeconds exceeds the limit", () => {
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 3600 }, "event")).to.throw(
+      /between 0 and 540/
+    );
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 3601 }, "https")).to.throw(
+      /between 0 and 3600/
+    );
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 1801 }, "task")).to.throw(
+      /between 0 and 1800/
+    );
+  });
+
+  it("is a no-op for in-range timeouts when kind is provided", () => {
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 540 }, "event")).to.not.throw();
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 3600 }, "https")).to.not.throw();
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 1800 }, "task")).to.not.throw();
   });
 });

--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -336,6 +336,14 @@ describe("onRequest", () => {
     await runHandler(func, req);
     expect(hello).to.equal("world");
   });
+
+  it("rejects timeoutSeconds above the 3600s HTTPS limit", () => {
+    expect(() =>
+      https.onRequest({ timeoutSeconds: 3601 }, (_req, res) => {
+        res.end();
+      })
+    ).to.throw(/between 0 and 3600 for HTTPS and callable functions/);
+  });
 });
 
 describe("onCall", () => {
@@ -603,6 +611,12 @@ describe("onCall", () => {
     expect(hello).to.be.undefined;
     await runHandler(func, req);
     expect(hello).to.equal("world");
+  });
+
+  it("rejects timeoutSeconds above the 3600s HTTPS limit", () => {
+    expect(() => https.onCall({ timeoutSeconds: 3601 }, () => 42)).to.throw(
+      /between 0 and 3600 for HTTPS and callable functions/
+    );
   });
 
   describe("authPolicy", () => {

--- a/spec/v2/providers/pubsub.spec.ts
+++ b/spec/v2/providers/pubsub.spec.ts
@@ -134,6 +134,19 @@ describe("onMessagePublished", () => {
     expect(res).to.equal("input");
   });
 
+  it("rejects timeoutSeconds above the 540s event-handler limit", () => {
+    expect(() =>
+      pubsub.onMessagePublished({ topic: "topic", timeoutSeconds: 3600 }, () => 42)
+    ).to.throw(/between 0 and 540 for event-handling functions/);
+  });
+
+  it("rejects a global timeoutSeconds above the 540s event-handler limit", () => {
+    options.setGlobalOptions({ timeoutSeconds: 3600 });
+    expect(() => pubsub.onMessagePublished("topic", () => 42)).to.throw(
+      /between 0 and 540 for event-handling functions/
+    );
+  });
+
   it("should parse pubsub messages", async () => {
     let json: unknown;
     const messageJSON = {

--- a/spec/v2/providers/storage.spec.ts
+++ b/spec/v2/providers/storage.spec.ts
@@ -503,6 +503,14 @@ describe("v2/storage", () => {
       await storage.onObjectFinalized("bucket", () => null)(event);
       expect(hello).to.equal("world");
     });
+
+    it("rejects timeoutSeconds above the 540s event-handler limit on __endpoint access", () => {
+      const func = storage.onObjectFinalized(
+        { bucket: "my-bucket", timeoutSeconds: 3600 },
+        () => 42
+      );
+      expect(() => func.__endpoint).to.throw(/between 0 and 540 for event-handling functions/);
+    });
   });
 
   describe("onObjectDeleted", () => {

--- a/spec/v2/providers/tasks.spec.ts
+++ b/spec/v2/providers/tasks.spec.ts
@@ -324,6 +324,12 @@ describe("onTaskDispatched", () => {
     expect(hello).to.equal("world");
   });
 
+  it("rejects timeoutSeconds above the 1800s task-queue limit", () => {
+    expect(() => onTaskDispatched({ timeoutSeconds: 1801 }, () => null)).to.throw(
+      /between 0 and 1800 for task queue functions/
+    );
+  });
+
   describe("v1-compatible getters", () => {
     it("should provide v1-compatible context on the request object", async () => {
       let capturedRequest: any;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -42,6 +42,31 @@ import * as logger from "../logger";
 export { RESET_VALUE } from "../common/options";
 
 /**
+ * Maximum timeout in seconds for event-handling functions (e.g. Firestore,
+ * Realtime Database, Pub/Sub, Storage, Eventarc, alerts, scheduler).
+ * @internal
+ */
+export const MAX_EVENT_TIMEOUT_SECONDS = 540;
+
+/**
+ * Maximum timeout in seconds for HTTPS and callable functions.
+ * @internal
+ */
+export const MAX_HTTPS_TIMEOUT_SECONDS = 3600;
+
+/**
+ * Maximum timeout in seconds for Task Queue functions.
+ * @internal
+ */
+export const MAX_TASK_TIMEOUT_SECONDS = 1800;
+
+/**
+ * Function category used to pick a `timeoutSeconds` upper bound.
+ * @internal
+ */
+export type TimeoutKind = "event" | "https" | "task";
+
+/**
  * List of all regions supported by Cloud Functions (2nd gen).
  */
 export type SupportedRegion =
@@ -335,12 +360,56 @@ export interface EventHandlerOptions extends Omit<GlobalOptions, "enforceAppChec
 }
 
 /**
+ * Validate that `timeoutSeconds` (resolved with global option fallback) does
+ * not exceed the maximum allowed value for the given function kind. Throws a
+ * plain `Error` matching the v1 `assertRuntimeOptionsValid` shape so the
+ * problem surfaces at function-definition time instead of at deploy time.
+ * `Expression`, `RESET_VALUE`, and `undefined` are skipped — only literal
+ * numbers are checked.
+ * @internal
+ */
+export function assertTimeoutSecondsValid(
+  opts: GlobalOptions | EventHandlerOptions | HttpsOptions | undefined,
+  kind: TimeoutKind
+): void {
+  const timeoutSeconds = opts?.timeoutSeconds ?? getGlobalOptions().timeoutSeconds;
+  if (typeof timeoutSeconds !== "number") {
+    return;
+  }
+  let max: number;
+  let label: string;
+  switch (kind) {
+    case "https":
+      max = MAX_HTTPS_TIMEOUT_SECONDS;
+      label = "HTTPS and callable";
+      break;
+    case "task":
+      max = MAX_TASK_TIMEOUT_SECONDS;
+      label = "task queue";
+      break;
+    default:
+      max = MAX_EVENT_TIMEOUT_SECONDS;
+      label = "event-handling";
+      break;
+  }
+  if (timeoutSeconds < 0 || timeoutSeconds > max) {
+    throw new Error(
+      `timeoutSeconds must be between 0 and ${max} for ${label} functions. Got ${timeoutSeconds}.`
+    );
+  }
+}
+
+/**
  * Apply GlobalOptions to trigger definitions.
  * @internal
  */
 export function optionsToTriggerAnnotations(
-  opts: GlobalOptions | EventHandlerOptions | HttpsOptions
+  opts: GlobalOptions | EventHandlerOptions | HttpsOptions,
+  kind?: TimeoutKind
 ): TriggerAnnotation {
+  if (kind !== undefined) {
+    assertTimeoutSecondsValid(opts, kind);
+  }
   const annotation: TriggerAnnotation = {};
   copyIfPresent(
     annotation,
@@ -398,8 +467,12 @@ export function optionsToTriggerAnnotations(
  * @internal
  */
 export function optionsToEndpoint(
-  opts: GlobalOptions | EventHandlerOptions | HttpsOptions
+  opts: GlobalOptions | EventHandlerOptions | HttpsOptions,
+  kind?: TimeoutKind
 ): ManifestEndpoint {
+  if (kind !== undefined) {
+    assertTimeoutSecondsValid(opts, kind);
+  }
   const endpoint: ManifestEndpoint = {};
   copyIfPresent(
     endpoint,

--- a/src/v2/providers/ai/index.ts
+++ b/src/v2/providers/ai/index.ts
@@ -237,7 +237,7 @@ export function beforeGenerateContent(
   func = wrapTraceContext(withInit(func));
 
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "https");
   func.__endpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),
     platform: "gcfv2",
@@ -344,7 +344,7 @@ export function afterGenerateContent(
   func = wrapTraceContext(withInit(func));
 
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "https");
   func.__endpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),
     platform: "gcfv2",

--- a/src/v2/providers/alerts/alerts.ts
+++ b/src/v2/providers/alerts/alerts.ts
@@ -235,7 +235,7 @@ export function getEndpointAnnotation(
   appId?: string
 ): ManifestEndpoint {
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "event");
   const endpoint: ManifestEndpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),
     platform: "gcfv2",

--- a/src/v2/providers/database.ts
+++ b/src/v2/providers/database.ts
@@ -601,7 +601,7 @@ export function makeEndpoint(
   instance: PathPattern
 ): ManifestEndpoint {
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "event");
 
   const eventFilters: Record<string, string> = {};
   const eventFilterPathPatterns: Record<string, string> = {

--- a/src/v2/providers/dataconnect/graphql.ts
+++ b/src/v2/providers/dataconnect/graphql.ts
@@ -94,7 +94,7 @@ export function onGraphRequest(opts: GraphqlServerOptions): HttpsFunction {
   const baseOpts = options.optionsToEndpoint(globalOpts);
   // global options calls region a scalar and https allows it to be an array,
   // but optionsToTriggerAnnotations handles both cases.
-  const specificOpts = options.optionsToEndpoint(opts as options.GlobalOptions);
+  const specificOpts = options.optionsToEndpoint(opts as options.GlobalOptions, "https");
   const endpoint: Partial<ManifestEndpoint> = {
     ...initV2Endpoint(globalOpts, opts),
     platform: "gcfv2",

--- a/src/v2/providers/dataconnect/index.ts
+++ b/src/v2/providers/dataconnect/index.ts
@@ -253,7 +253,7 @@ function makeEndpoint(
   operation: PathPattern | undefined
 ): ManifestEndpoint {
   const baseOpts = optionsToEndpoint(getGlobalOptions());
-  const specificOpts = optionsToEndpoint(opts);
+  const specificOpts = optionsToEndpoint(opts, "event");
 
   const eventFilters: Record<string, string> = {};
   const eventFilterPathPatterns: Record<string, string> = {};

--- a/src/v2/providers/eventarc.ts
+++ b/src/v2/providers/eventarc.ts
@@ -203,7 +203,7 @@ export function onCustomEventPublished<T = any>(
   const channel = opts.channel ?? "locations/us-central1/channels/firebase";
 
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "event");
 
   const endpoint: ManifestEndpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -899,7 +899,7 @@ export function makeEndpoint(
   namespace: string | Expression<string>
 ): ManifestEndpoint {
   const baseOpts = optionsToEndpoint(getGlobalOptions());
-  const specificOpts = optionsToEndpoint(opts);
+  const specificOpts = optionsToEndpoint(opts, "event");
 
   const eventFilters: Record<string, string | Expression<string>> = {
     database,

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -355,7 +355,10 @@ export function onRequest(
       const baseOpts = options.optionsToTriggerAnnotations(options.getGlobalOptions());
       // global options calls region a scalar and https allows it to be an array,
       // but optionsToTriggerAnnotations handles both cases.
-      const specificOpts = options.optionsToTriggerAnnotations(opts as options.GlobalOptions);
+      const specificOpts = options.optionsToTriggerAnnotations(
+        opts as options.GlobalOptions,
+        "https"
+      );
       const trigger: any = {
         platform: "gcfv2",
         ...baseOpts,
@@ -384,7 +387,7 @@ export function onRequest(
   const baseOpts = options.optionsToEndpoint(globalOpts);
   // global options calls region a scalar and https allows it to be an array,
   // but optionsToTriggerAnnotations handles both cases.
-  const specificOpts = options.optionsToEndpoint(opts as options.GlobalOptions);
+  const specificOpts = options.optionsToEndpoint(opts as options.GlobalOptions, "https");
   const endpoint: Partial<ManifestEndpoint> = {
     ...initV2Endpoint(globalOpts, opts),
     platform: "gcfv2",
@@ -485,7 +488,7 @@ export function onCall<T = any, Return = any | Promise<any>, Stream = unknown>(
       const baseOpts = options.optionsToTriggerAnnotations(options.getGlobalOptions());
       // global options calls region a scalar and https allows it to be an array,
       // but optionsToTriggerAnnotations handles both cases.
-      const specificOpts = options.optionsToTriggerAnnotations(opts);
+      const specificOpts = options.optionsToTriggerAnnotations(opts, "https");
       return {
         platform: "gcfv2",
         ...baseOpts,
@@ -505,7 +508,7 @@ export function onCall<T = any, Return = any | Promise<any>, Stream = unknown>(
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
   // global options calls region a scalar and https allows it to be an array,
   // but optionsToEndpoint handles both cases.
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "https");
   func.__endpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),
     platform: "gcfv2",

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -325,7 +325,7 @@ export function beforeOperation(
 
   /** Endpoint */
   const baseOptsEndpoint = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOptsEndpoint = options.optionsToEndpoint(opts);
+  const specificOptsEndpoint = options.optionsToEndpoint(opts, "https");
   func.__endpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),
     platform: "gcfv2",

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -395,7 +395,7 @@ export function onMessagePublished<T = any>(
   Object.defineProperty(func, "__trigger", {
     get: () => {
       const baseOpts = options.optionsToTriggerAnnotations(options.getGlobalOptions());
-      const specificOpts = options.optionsToTriggerAnnotations(opts);
+      const specificOpts = options.optionsToTriggerAnnotations(opts, "event");
 
       return {
         platform: "gcfv2",
@@ -414,7 +414,7 @@ export function onMessagePublished<T = any>(
   });
 
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-  const specificOpts = options.optionsToEndpoint(opts);
+  const specificOpts = options.optionsToEndpoint(opts, "event");
 
   const endpoint: ManifestEndpoint = {
     ...initV2Endpoint(options.getGlobalOptions(), opts),

--- a/src/v2/providers/remoteConfig.ts
+++ b/src/v2/providers/remoteConfig.ts
@@ -153,7 +153,7 @@ export function onConfigUpdated(
   }
 
   const baseOpts = optionsToEndpoint(getGlobalOptions());
-  const specificOpts = optionsToEndpoint(optsOrHandler);
+  const specificOpts = optionsToEndpoint(optsOrHandler, "event");
 
   const func: any = wrapTraceContext(
     withInit((raw: CloudEvent<unknown>) => {

--- a/src/v2/providers/scheduler.ts
+++ b/src/v2/providers/scheduler.ts
@@ -225,7 +225,7 @@ export function onSchedule(
 
   const globalOpts = options.getGlobalOptions();
   const baseOptsEndpoint = options.optionsToEndpoint(globalOpts);
-  const specificOptsEndpoint = options.optionsToEndpoint(separatedOpts.opts);
+  const specificOptsEndpoint = options.optionsToEndpoint(separatedOpts.opts, "event");
 
   const ep: ManifestEndpoint = {
     ...initV2Endpoint(globalOpts, separatedOpts.opts),

--- a/src/v2/providers/storage.ts
+++ b/src/v2/providers/storage.ts
@@ -779,7 +779,7 @@ export function onOperation(
   Object.defineProperty(func, "__trigger", {
     get: () => {
       const baseOpts = options.optionsToTriggerAnnotations(options.getGlobalOptions());
-      const specificOpts = options.optionsToTriggerAnnotations(opts);
+      const specificOpts = options.optionsToTriggerAnnotations(opts, "event");
 
       return {
         platform: "gcfv2",
@@ -807,7 +807,7 @@ export function onOperation(
   Object.defineProperty(func, "__endpoint", {
     get: () => {
       const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
-      const specificOpts = options.optionsToEndpoint(opts);
+      const specificOpts = options.optionsToEndpoint(opts, "event");
 
       const endpoint: ManifestEndpoint = {
         platform: "gcfv2",

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -241,7 +241,10 @@ export function onTaskDispatched<Args = any>(
       const baseOpts = options.optionsToTriggerAnnotations(options.getGlobalOptions());
       // global options calls region a scalar and https allows it to be an array,
       // but optionsToTriggerAnnotations handles both cases.
-      const specificOpts = options.optionsToTriggerAnnotations(opts as options.GlobalOptions);
+      const specificOpts = options.optionsToTriggerAnnotations(
+        opts as options.GlobalOptions,
+        "task"
+      );
       const taskQueueTrigger: Record<string, unknown> = {};
       copyIfPresent(taskQueueTrigger, opts, "retryConfig", "rateLimits");
       convertIfPresent(
@@ -268,7 +271,7 @@ export function onTaskDispatched<Args = any>(
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
   // global options calls region a scalar and https allows it to be an array,
   // but optionsToManifestEndpoint handles both cases.
-  const specificOpts = options.optionsToEndpoint(opts as options.GlobalOptions);
+  const specificOpts = options.optionsToEndpoint(opts as options.GlobalOptions, "task");
 
   func.__endpoint = {
     platform: "gcfv2",

--- a/src/v2/providers/testLab.ts
+++ b/src/v2/providers/testLab.ts
@@ -188,7 +188,7 @@ export function onTestMatrixCompleted(
   }
 
   const baseOpts = optionsToEndpoint(getGlobalOptions());
-  const specificOpts = optionsToEndpoint(optsOrHandler);
+  const specificOpts = optionsToEndpoint(optsOrHandler, "event");
 
   const func: any = (raw: CloudEvent<unknown>) => {
     return wrapTraceContext(withInit(handler))(raw as CloudEvent<TestMatrixCompletedData>);


### PR DESCRIPTION
Fixes #1737

### Description

The v2 SDK currently accepts any `timeoutSeconds` value and only the Cloud Functions control plane rejects invalid ones at deploy time with errors like `cannot exceed 540 seconds`. v1 has had `assertRuntimeOptionsValid` for a long time but v2 was missing the equivalent, so users only find out they configured the wrong limit after a multi-minute deploy round-trip.

This PR adds per-trigger-type validation that throws at function-definition time (or at manifest-extraction time for providers whose `__endpoint` is a lazy getter, such as `storage`).

Limits enforced:

- **event-handling** — 540s (firestore, database, pubsub, storage, scheduler, eventarc, testLab, remoteConfig, alerts, dataconnect)
- **HTTPS and callable** — 3600s (`onRequest`, `onCall`, `onCallGenkit`, identity, dataconnect/graphql, ai)
- **task queue** — 1800s (`onTaskDispatched`)

Implementation:

- New internal helper `assertTimeoutSecondsValid(opts, kind)` and `MAX_{EVENT,HTTPS,TASK}_TIMEOUT_SECONDS` constants in `src/v2/options.ts`.
- `optionsToEndpoint` and `optionsToTriggerAnnotations` gained an optional `kind: TimeoutKind` argument. When omitted they behave exactly as before — validation is opt-in at the call site, so existing consumers of these helpers are unaffected.
- Each v2 provider passes its own `kind` when converting the function-specific options. Global-option calls stay unannotated so they keep working exactly as before (no regression for a project that sets `timeoutSeconds` globally on a function type that can tolerate it).
- `Expression<number>`, `RESET_VALUE`, and `undefined` are deliberately skipped. The SDK cannot know the concrete value for parametrized expressions, and `RESET_VALUE` is the user explicitly asking us to clear the global.
- `onCallGenkit` delegates to `onCall(opts, …)` and is therefore covered transitively.

Error messages follow the v1 shape but include the per-kind label:

```
timeoutSeconds must be between 0 and 540 for event-handling functions. Got 3600.
timeoutSeconds must be between 0 and 3600 for HTTPS and callable functions. Got 3601.
timeoutSeconds must be between 0 and 1800 for task queue functions. Got 1801.
```

### Tests

- `spec/v2/options.spec.ts` — 13 unit tests for `assertTimeoutSecondsValid` covering each kind's limit, negative values, `Expression`, `RESET_VALUE`, global fallback, function-level override, and function-level `RESET_VALUE` clearing an out-of-range global. Plus 6 integration tests for `optionsToEndpoint` / `optionsToTriggerAnnotations` (omitted kind = no-op for backwards compatibility, provided kind = enforced).
- Per-provider regressions:
  - `spec/v2/providers/https.spec.ts` — `onRequest` and `onCall` both reject 3601s.
  - `spec/v2/providers/pubsub.spec.ts` — function-level 3600s and a global 3600s (via `setGlobalOptions`) are both rejected.
  - `spec/v2/providers/tasks.spec.ts` — 1801s rejected.
  - `spec/v2/providers/storage.spec.ts` — validation fires when `__endpoint` is accessed (lazy-getter path).

Full suite: **900 / 900 passing**, `npm run build` clean, `npm run lint` 0 errors on the touched files, `prettier --check` clean.

### Backwards compatibility

- The new `kind` argument is optional. Calls to `optionsToEndpoint` / `optionsToTriggerAnnotations` that don't pass it keep their current behavior, so downstream code that reaches into these helpers is unaffected.
- In-range timeouts (0–540 for events, 0–3600 for HTTPS, 0–1800 for tasks) continue to work identically.
- `0` is still accepted, matching v1's `assertRuntimeOptionsValid`. Enforcing the documented 1s minimum can be a separate follow-up if desired.
- Users who were silently shipping invalid timeouts will now see the error while running locally instead of at deploy time — this is the intended fix.

### Code sample

Before: this deploys, hits `gcloud beta functions deploy`, and fails after ~30 seconds:

```ts
import { onDocumentWritten } from "firebase-functions/v2/firestore";

export const fn = onDocumentWritten(
  { document: "users/{id}", timeoutSeconds: 3600 },
  (event) => { /* ... */ },
);
```

After: fails immediately when the function module is loaded with:

```
Error: timeoutSeconds must be between 0 and 540 for event-handling functions. Got 3600.
```