### PR TITLE
fix(https): defer CORS param resolution until runtime

### DIFF
--- a/spec/v2/providers/https.spec.ts
+++ b/spec/v2/providers/https.spec.ts
@@ -68,6 +68,7 @@ describe("onRequest", () => {
   afterEach(() => {
     options.setGlobalOptions({});
     delete process.env.GCLOUD_PROJECT;
+    delete process.env.FUNCTIONS_CONTROL_API;
   });
 
   it("should return a minimal trigger/endpoint with appropriate values", () => {
@@ -232,7 +233,7 @@ describe("onRequest", () => {
     const origins = defineList("ORIGINS");
 
     try {
-      process.env.ORIGINS = '["example.com","example2.com"]';
+      process.env.FUNCTIONS_CONTROL_API = "true";
       const func = https.onRequest(
         {
           cors: origins,
@@ -241,6 +242,8 @@ describe("onRequest", () => {
           res.send("42");
         }
       );
+      delete process.env.FUNCTIONS_CONTROL_API;
+      process.env.ORIGINS = '["example.com","example2.com"]';
       const req = request({
         headers: {
           referrer: "example.com",
@@ -261,6 +264,7 @@ describe("onRequest", () => {
       });
     } finally {
       delete process.env.ORIGINS;
+      delete process.env.FUNCTIONS_CONTROL_API;
       clearParams();
     }
   });
@@ -351,6 +355,7 @@ describe("onCall", () => {
   afterEach(() => {
     delete process.env.GCLOUD_PROJECT;
     delete process.env.ORIGINS;
+    delete process.env.FUNCTIONS_CONTROL_API;
     clearParams();
   });
 
@@ -486,7 +491,11 @@ describe("onCall", () => {
   });
 
   it("should allow cors params", async () => {
+    delete process.env.ORIGINS;
+    process.env.FUNCTIONS_CONTROL_API = "true";
     const func = https.onCall({ cors: origins }, () => 42);
+    delete process.env.FUNCTIONS_CONTROL_API;
+    process.env.ORIGINS = '["example.com","example2.com"]';
     const req = request({
       headers: {
         referrer: "example.com",

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -255,6 +255,40 @@ export const hasClaim =
     return !value || auth.token[claim] === value;
   };
 
+type ResolvedCorsOrigin = boolean | string | RegExp | Array<boolean | string | RegExp>;
+
+function normalizeCorsOrigin(origin: ResolvedCorsOrigin | undefined): ResolvedCorsOrigin | undefined {
+  // Arrays cause the access-control-allow-origin header to be dynamic based
+  // on the origin header of the request. If there is only one element in the
+  // array, this is unnecessary.
+  if (Array.isArray(origin) && origin.length === 1) {
+    return origin[0];
+  }
+
+  return origin;
+}
+
+function resolveCorsOrigin(
+  corsOption: HttpsOptions["cors"],
+  isCorsDebugEnabled: boolean
+): cors.CorsOptions["origin"] {
+  if (isCorsDebugEnabled) {
+    // Respect `cors: false` to turn off cors even if debug feature is enabled.
+    return corsOption === false ? false : true;
+  }
+
+  if (corsOption instanceof Expression) {
+    return (
+      _requestOrigin: string | undefined,
+      callback: (err: Error | null, origin?: ResolvedCorsOrigin) => void
+    ): void => {
+      callback(null, normalizeCorsOrigin(corsOption.value()));
+    };
+  }
+
+  return normalizeCorsOrigin(corsOption);
+}
+
 /**
  * Handles HTTPS requests.
  */
@@ -323,18 +357,9 @@ export function onRequest(
 
   handler = withErrorHandler(handler);
 
-  if (isDebugFeatureEnabled("enableCors") || "cors" in opts) {
-    let origin = opts.cors instanceof Expression ? opts.cors.value() : opts.cors;
-    if (isDebugFeatureEnabled("enableCors")) {
-      // Respect `cors: false` to turn off cors even if debug feature is enabled.
-      origin = opts.cors === false ? false : true;
-    }
-    // Arrays cause the access-control-allow-origin header to be dynamic based
-    // on the origin header of the request. If there is only one element in the
-    // array, this is unnecessary.
-    if (Array.isArray(origin) && origin.length === 1) {
-      origin = origin[0];
-    }
+  const isCorsDebugEnabled = isDebugFeatureEnabled("enableCors");
+  if (isCorsDebugEnabled || "cors" in opts) {
+    const origin = resolveCorsOrigin(opts.cors, isCorsDebugEnabled);
     const middleware = cors({ origin });
 
     const userProvidedHandler = handler;
@@ -434,24 +459,14 @@ export function onCall<T = any, Return = any | Promise<any>, Stream = unknown>(
     opts = optsOrHandler as CallableOptions;
   }
 
-  let cors: string | boolean | RegExp | Array<string | RegExp> | undefined;
+  let cors: HttpsOptions["cors"];
   if ("cors" in opts) {
-    if (opts.cors instanceof Expression) {
-      cors = opts.cors.value();
-    } else {
-      cors = opts.cors;
-    }
+    cors = opts.cors;
   } else {
     cors = true;
   }
 
-  let origin = isDebugFeatureEnabled("enableCors") ? true : cors;
-  // Arrays cause the access-control-allow-origin header to be dynamic based
-  // on the origin header of the request. If there is only one element in the
-  // array, this is unnecessary.
-  if (Array.isArray(origin) && origin.length === 1) {
-    origin = origin[0];
-  }
+  const origin = resolveCorsOrigin(cors, isDebugFeatureEnabled("enableCors"));
 
   // fix the length of handler to make the call to handler consistent
   const fixedLen = (req: CallableRequest<T>, resp?: CallableResponse<Stream>) => handler(req, resp);

--- a/src/v2/providers/https.ts
+++ b/src/v2/providers/https.ts
@@ -257,7 +257,9 @@ export const hasClaim =
 
 type ResolvedCorsOrigin = boolean | string | RegExp | Array<boolean | string | RegExp>;
 
-function normalizeCorsOrigin(origin: ResolvedCorsOrigin | undefined): ResolvedCorsOrigin | undefined {
+function normalizeCorsOrigin(
+  origin: ResolvedCorsOrigin | undefined
+): ResolvedCorsOrigin | undefined {
   // Arrays cause the access-control-allow-origin header to be dynamic based
   // on the origin header of the request. If there is only one element in the
   // array, this is unnecessary.


### PR DESCRIPTION
## What This PR Solves

Fixes https://github.com/firebase/firebase-functions/issues/1773.

CORS options can be backed by params such as `defineList`, but v2 HTTPS handlers were resolving those params while the Functions control API was analyzing source code. At that point runtime env values may not exist yet, which can trigger deploy-time warnings or failures like parsing `undefined`.

This PR keeps the param-backed CORS option unresolved during function definition and resolves it from the CORS middleware at request time instead. It preserves debug CORS behavior and the existing single-origin normalization.

## Testing Details

- Updated v2 HTTPS unit coverage for `onRequest({ cors: defineList(...) })` so function analysis can run with `FUNCTIONS_CONTROL_API=true` before the param value exists, then runtime request handling resolves `ORIGINS`.
- Updated v2 HTTPS unit coverage for `onCall({ cors: defineList(...) })` with the same deploy-time/runtime split.
- Manually tested with a local `test-project/functions` app exporting both `corsParamOnRequest` and `corsParamOnCall`, each using `cors: defineList("ALLOWED_ORIGINS")`.
- Manual test loaded the functions while `FUNCTIONS_CONTROL_API=true` and `ALLOWED_ORIGINS` was unset, confirming module analysis no longer resolves/parses the param during deploy-time loading.
- Manual test then set `ALLOWED_ORIGINS=["https://app.example.com","https://admin.example.com"]` and verified CORS preflight behavior: allowed origins returned the matching `Access-Control-Allow-Origin` header, and `https://evil.example.com` did not.