### PR TITLE
Functions can now declare dependencies on additional APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
+- feat: Add requiresAPI function to allow declaring Google Cloud API dependencies in code.
 - fix(v1): Call onInit for schedule.onRun functions (#1801)

--- a/spec/common/api.spec.ts
+++ b/spec/common/api.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from "chai";
+import { requiresAPI, getGlobalRequiredAPIs, clearGlobalRequiredAPIs } from "../../src/common/api";
+
+describe("requiresAPI", () => {
+  afterEach(() => {
+    clearGlobalRequiredAPIs();
+  });
+
+  it("stores required API", () => {
+    requiresAPI("test.googleapis.com", "reason");
+    expect(getGlobalRequiredAPIs()).to.deep.equal([
+      { api: "test.googleapis.com", reason: "reason" },
+    ]);
+  });
+
+  it("throws error for invalid API", () => {
+    expect(() => requiresAPI("" as any, "reason")).to.throw(
+      "requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'."
+    );
+    expect(() => requiresAPI(null as any, "reason")).to.throw(
+      "requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'."
+    );
+    expect(() => requiresAPI("invalid-api" as any, "reason")).to.throw(
+      "requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'."
+    );
+  });
+});

--- a/spec/fixtures/sources/requiresapi/index.js
+++ b/spec/fixtures/sources/requiresapi/index.js
@@ -1,0 +1,8 @@
+const { requiresAPI } = require("../../../../src/v2");
+const functions = require("../../../../src/v1");
+
+requiresAPI("some-api.googleapis.com", "Needed for some reason");
+
+exports.v1http = functions.https.onRequest((req, resp) => {
+    resp.status(200).send("PASS");
+});

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -344,6 +344,11 @@ describe("loadStack", () => {
     process.env.GCLOUD_PROJECT = prev;
     clearGlobalRequiredAPIs();
     clearParams();
+    for (const key of Object.keys(require.cache)) {
+      if (key.includes("fixtures/sources")) {
+        delete require.cache[key];
+      }
+    }
   });
 
   describe("commonjs", () => {

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -343,6 +343,7 @@ describe("loadStack", () => {
   afterEach(() => {
     process.env.GCLOUD_PROJECT = prev;
     clearGlobalRequiredAPIs();
+    clearParams();
   });
 
   describe("commonjs", () => {

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -10,6 +10,7 @@ import {
   ManifestStack,
 } from "../../src/runtime/manifest";
 import { clearParams } from "../../src/params";
+import { clearGlobalRequiredAPIs } from "../../src/common/api";
 import { MINIMAL_V1_ENDPOINT, MINIMAL_V2_ENDPOINT } from "../fixtures";
 import { MINIMAL_SCHEDULE_TRIGGER, MINIMIAL_TASK_QUEUE_TRIGGER } from "../v1/providers/fixtures";
 import { BooleanParam, IntParam, StringParam } from "../../src/params/types";
@@ -341,6 +342,7 @@ describe("loadStack", () => {
 
   afterEach(() => {
     process.env.GCLOUD_PROJECT = prev;
+    clearGlobalRequiredAPIs();
   });
 
   describe("commonjs", () => {
@@ -466,6 +468,28 @@ describe("loadStack", () => {
               httpsTrigger: {},
             },
           },
+        },
+      },
+      {
+        name: "requires api",
+        modulePath: "./spec/fixtures/sources/requiresapi",
+        expected: {
+          endpoints: {
+            v1http: {
+              ...MINIMAL_V1_ENDPOINT,
+              platform: "gcfv1",
+              entryPoint: "v1http",
+              httpsTrigger: {},
+            },
+          },
+          requiredAPIs: [
+            {
+              api: "some-api.googleapis.com",
+              reason: "Needed for some reason",
+            },
+          ],
+          extensions: {},
+          specVersion: "v1alpha1",
         },
       },
     ];

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -344,6 +344,8 @@ describe("loadStack", () => {
     process.env.GCLOUD_PROJECT = prev;
     clearGlobalRequiredAPIs();
     clearParams();
+    // Purge the require cache for fixture modules so that when a file is loaded
+    // a second time via absolute path, it re-executes and successfully runs its global side-effects.
     for (const key of Object.keys(require.cache)) {
       if (key.includes("fixtures/sources")) {
         delete require.cache[key];

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -1,0 +1,48 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { ManifestRequiredAPI } from "../runtime/manifest";
+
+let globalRequiredAPIs: ManifestRequiredAPI[] = [];
+
+/**
+ * Declare that this project requires a specific Google Cloud API to be enabled.
+ * @param api The API name, e.g. "secretmanager.googleapis.com"
+ * @param reason Optional reason why the API is needed.
+ */
+export function requiresAPI(api: string, reason = ""): void {
+  globalRequiredAPIs.push({ api, reason });
+}
+
+/**
+ * @internal
+ */
+export function getGlobalRequiredAPIs(): ManifestRequiredAPI[] {
+  return globalRequiredAPIs;
+}
+
+/**
+ * @internal
+ */
+export function clearGlobalRequiredAPIs(): void {
+  globalRequiredAPIs = [];
+}

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -24,12 +24,19 @@ import { ManifestRequiredAPI } from "../runtime/manifest";
 
 let globalRequiredAPIs: ManifestRequiredAPI[] = [];
 
+export type GoogleCloudApi = `${string}.googleapis.com`;
+
 /**
  * Declare that this project requires a specific Google Cloud API to be enabled.
  * @param api The API name, e.g. "secretmanager.googleapis.com"
  * @param reason Optional reason why the API is needed.
  */
-export function requiresAPI(api: string, reason = ""): void {
+export function requiresAPI(api: GoogleCloudApi, reason = ""): void {
+  if (!api || typeof api !== "string" || !api.endsWith(".googleapis.com")) {
+    throw new Error(
+      "requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'."
+    );
+  }
   globalRequiredAPIs.push({ api, reason });
 }
 

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -33,9 +33,7 @@ export type GoogleCloudApi = `${string}.googleapis.com`;
  */
 export function requiresAPI(api: GoogleCloudApi, reason = ""): void {
   if (!api || typeof api !== "string" || !api.endsWith(".googleapis.com")) {
-    throw new Error(
-      "requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'."
-    );
+    throw new Error("requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'.");
   }
   globalRequiredAPIs.push({ api, reason });
 }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -30,6 +30,7 @@ import {
 } from "./manifest";
 
 import * as params from "../params";
+import { getGlobalRequiredAPIs } from "../common/api";
 
 /**
  * Dynamically load import function to prevent TypeScript from
@@ -193,6 +194,7 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
   const mod = await loadModule(functionsDir);
 
   extractStack(mod, endpoints, requiredAPIs, extensions);
+  requiredAPIs.push(...getGlobalRequiredAPIs());
 
   const stack: ManifestStack = {
     endpoints,

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -30,7 +30,7 @@ import {
 } from "./manifest";
 
 import * as params from "../params";
-import { getGlobalRequiredAPIs } from "../common/api";
+import { getGlobalRequiredAPIs, clearGlobalRequiredAPIs } from "../common/api";
 
 /**
  * Dynamically load import function to prevent TypeScript from
@@ -195,6 +195,7 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
 
   extractStack(mod, endpoints, requiredAPIs, extensions);
   requiredAPIs.push(...getGlobalRequiredAPIs());
+  clearGlobalRequiredAPIs();
 
   const stack: ManifestStack = {
     endpoints,

--- a/src/v1/index.ts
+++ b/src/v1/index.ts
@@ -61,3 +61,4 @@ import * as params from "../params";
 export { params };
 
 export { onInit } from "../common/onInit";
+export { requiresAPI } from "../common/api";

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -63,6 +63,7 @@ export {
 
 export { logger } from "../logger";
 export { setGlobalOptions } from "./options";
+export { requiresAPI } from "../common/api";
 export type {
   GlobalOptions,
   SupportedRegion,


### PR DESCRIPTION
### Description
Adds a new user-facing `requiresAPI` function to declare Google Cloud API dependencies in code. These are appended to the wire protocol manifest.

### Scenarios Tested
- Unit tests verify that `requiresAPI` correctly populates the `requiredAPIs` field in the generated manifest.