### PR TITLE
feature: functions can now declare lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,4 @@
 - chore: drop support for Node 18 and below (minimum supported version is now Node 20)
 - feat: Add requiresAPI function to allow declaring Google Cloud API dependencies in code.
 - fix(v1): Call onInit for schedule.onRun functions (#1801)
+- feat: Add support to declare lifecycle hooks in functions. (#1915)

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,6 +19,7 @@ module.exports = [
             "v1/",
             "v2/",
             "logger/",
+            "lifecycle/",
             "dist/",
             "spec/fixtures/",
             "scripts/**/*.js",

--- a/lifecycle/index.js
+++ b/lifecycle/index.js
@@ -1,0 +1,26 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2026 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+// This file is not part of the firebase-functions SDK. It is used to silence the
+// imports eslint plugin until it can understand import paths defined by node
+// package exports.
+// For more information, see github.com/import-js/eslint-plugin-import/issues/1810

--- a/package-lock.json
+++ b/package-lock.json
@@ -4731,9 +4731,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4751,9 +4748,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4771,9 +4765,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4791,9 +4782,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -33,6 +33,11 @@
     "./lib/esm/logger/compat.mjs"
   ],
   "exports": {
+    "./lifecycle": {
+      "types": "./lib/lifecycle/index.d.ts",
+      "import": "./lib/esm/lifecycle/index.mjs",
+      "require": "./lib/lifecycle/index.js"
+    },
     "./logger/compat": {
       "types": "./lib/logger/compat.d.ts",
       "import": "./lib/esm/logger/compat.mjs",
@@ -346,6 +351,9 @@
   },
   "typesVersions": {
     "*": {
+      "lifecycle": [
+        "lib/lifecycle/index"
+      ],
       "logger": [
         "lib/logger/index"
       ],

--- a/spec/lifecycle/lifecycle.spec.ts
+++ b/spec/lifecycle/lifecycle.spec.ts
@@ -1,0 +1,63 @@
+import { expect } from "chai";
+import {
+  afterInstall,
+  afterUpdate,
+  clearDeclaredLifecycleHooks,
+  declaredLifecycleHooks,
+} from "../../src/lifecycle";
+
+describe("lifecycle", () => {
+  afterEach(() => {
+    clearDeclaredLifecycleHooks();
+  });
+
+  describe("afterInstall", () => {
+    it("registers an afterInstall lifecycle action", () => {
+      afterInstall({
+        task: {
+          function: "runInitialSetup",
+          body: { seedData: true },
+        },
+      });
+
+      expect(declaredLifecycleHooks.afterInstall).to.deep.equal({
+        task: {
+          function: "runInitialSetup",
+          body: { seedData: true },
+        },
+      });
+    });
+
+    it("throws an error if afterInstall is called more than once", () => {
+      afterInstall({ task: { function: "fn1" } });
+      expect(() => afterInstall({ task: { function: "fn2" } })).to.throw(
+        "Only one afterInstall lifecycle hook is allowed per codebase."
+      );
+    });
+  });
+
+  describe("afterUpdate", () => {
+    it("registers an afterUpdate lifecycle action", () => {
+      afterUpdate({
+        call: {
+          function: "migrateSchema",
+          params: { version: 2 },
+        },
+      });
+
+      expect(declaredLifecycleHooks.afterUpdate).to.deep.equal({
+        call: {
+          function: "migrateSchema",
+          params: { version: 2 },
+        },
+      });
+    });
+
+    it("throws an error if afterUpdate is called more than once", () => {
+      afterUpdate({ call: { function: "fn1" } });
+      expect(() => afterUpdate({ call: { function: "fn2" } })).to.throw(
+        "Only one afterUpdate lifecycle hook is allowed per codebase."
+      );
+    });
+  });
+});

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -575,5 +575,24 @@ describe("loadStack", () => {
         },
       });
     });
+
+    it("preserves falsy but valid JSON values (like 0, false, empty string) in hook payloads", async () => {
+      afterInstall({
+        task: {
+          function: "runInitialSetup",
+          body: { force: false, code: 0, tag: "" },
+        },
+      });
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+      expect(stack.lifecycleHooks).to.deep.equal({
+        afterInstall: {
+          task: {
+            function: "runInitialSetup",
+            body: { force: false, code: 0, tag: "" },
+          },
+        },
+      });
+    });
   });
 });

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -548,6 +548,7 @@ describe("loadStack", () => {
         http: {
           function: "seedDatabase",
           method: "POST",
+          headers: { "X-API-Key": "my-key" },
           body: { force: true },
         },
       });
@@ -555,6 +556,7 @@ describe("loadStack", () => {
         http: {
           url: "https://example.com/webhook",
           method: "POST",
+          headers: { "Content-Type": "application/json" },
         },
       });
 
@@ -564,6 +566,7 @@ describe("loadStack", () => {
           http: {
             function: "seedDatabase",
             method: "POST",
+            headers: { "X-API-Key": "my-key" },
             body: { force: true },
           },
         },
@@ -571,6 +574,7 @@ describe("loadStack", () => {
           http: {
             url: "https://example.com/webhook",
             method: "POST",
+            headers: { "Content-Type": "application/json" },
           },
         },
       });

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -11,6 +11,7 @@ import {
 } from "../../src/runtime/manifest";
 import { clearParams } from "../../src/params";
 import { clearGlobalRequiredAPIs } from "../../src/common/api";
+import { afterInstall, afterUpdate, clearDeclaredLifecycleHooks } from "../../src/lifecycle";
 import { MINIMAL_V1_ENDPOINT, MINIMAL_V2_ENDPOINT } from "../fixtures";
 import { MINIMAL_SCHEDULE_TRIGGER, MINIMIAL_TASK_QUEUE_TRIGGER } from "../v1/providers/fixtures";
 import { BooleanParam, IntParam, StringParam } from "../../src/params/types";
@@ -344,6 +345,7 @@ describe("loadStack", () => {
     process.env.GCLOUD_PROJECT = prev;
     clearGlobalRequiredAPIs();
     clearParams();
+    clearDeclaredLifecycleHooks();
     // Purge the require cache for fixture modules so that when a file is loaded
     // a second time via absolute path, it re-executes and successfully runs its global side-effects.
     for (const key of Object.keys(require.cache)) {
@@ -507,5 +509,71 @@ describe("loadStack", () => {
         runTests(tc);
       });
     }
+  });
+
+  describe("loadStack with lifecycleHooks", () => {
+    it("captures top-level afterInstall and afterUpdate calls into ManifestStack.lifecycleHooks", async () => {
+      afterInstall({
+        task: {
+          function: "runInitialSetup",
+          body: { seedData: "default_catalog" },
+        },
+      });
+      afterUpdate({
+        call: {
+          function: "migrateSchema",
+          params: { targetVersion: "v2.4" },
+        },
+      });
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+      expect(stack.lifecycleHooks).to.deep.equal({
+        afterInstall: {
+          task: {
+            function: "runInitialSetup",
+            body: { seedData: "default_catalog" },
+          },
+        },
+        afterUpdate: {
+          call: {
+            function: "migrateSchema",
+            params: { targetVersion: "v2.4" },
+          },
+        },
+      });
+    });
+
+    it("captures http lifecycle hooks with function and url into ManifestStack.lifecycleHooks", async () => {
+      afterInstall({
+        http: {
+          function: "seedDatabase",
+          method: "POST",
+          body: { force: true },
+        },
+      });
+      afterUpdate({
+        http: {
+          url: "https://example.com/webhook",
+          method: "POST",
+        },
+      });
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+      expect(stack.lifecycleHooks).to.deep.equal({
+        afterInstall: {
+          http: {
+            function: "seedDatabase",
+            method: "POST",
+            body: { force: true },
+          },
+        },
+        afterUpdate: {
+          http: {
+            url: "https://example.com/webhook",
+            method: "POST",
+          },
+        },
+      });
+    });
   });
 });

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -34,18 +34,24 @@ export interface CallAction {
   params?: Record<string, unknown>;
 }
 
-export interface HttpAction {
-  function?: TargetFunction;
-  url?: string | Expression<string>;
-  method?: "GET" | "POST" | "PUT" | "DELETE";
-  body?: unknown;
-}
+export type HttpAction =
+  | {
+      function: TargetFunction;
+      url?: never;
+      method?: "GET" | "POST" | "PUT" | "DELETE";
+      body?: unknown;
+    }
+  | {
+      url: string | Expression<string>;
+      function?: never;
+      method?: "GET" | "POST" | "PUT" | "DELETE";
+      body?: unknown;
+    };
 
-export interface LifecycleAction {
-  task?: TaskAction;
-  call?: CallAction;
-  http?: HttpAction;
-}
+export type LifecycleAction =
+  | { task: TaskAction; call?: never; http?: never }
+  | { call: CallAction; task?: never; http?: never }
+  | { http: HttpAction; task?: never; call?: never };
 
 const majorVersion =
   // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -1,0 +1,104 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2026 Firebase
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import { Expression } from "../params";
+
+export type TargetFunction = string | Expression<string>;
+
+export interface TaskAction {
+  function: TargetFunction;
+  body?: Record<string, unknown>;
+}
+
+export interface CallAction {
+  function: TargetFunction;
+  params?: Record<string, unknown>;
+}
+
+export interface HttpAction {
+  function?: TargetFunction;
+  url?: string | Expression<string>;
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  body?: unknown;
+}
+
+export interface LifecycleAction {
+  task?: TaskAction;
+  call?: CallAction;
+  http?: HttpAction;
+}
+
+const majorVersion =
+  // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
+  typeof __FIREBASE_FUNCTIONS_MAJOR_VERSION__ !== "undefined"
+    ? // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
+      __FIREBASE_FUNCTIONS_MAJOR_VERSION__
+    : "0";
+
+const GLOBAL_SYMBOL = Symbol.for(`firebase-functions:lifecycle:declaredHooks:v${majorVersion}`);
+const globalSymbols = globalThis as unknown as Record<symbol, Record<string, LifecycleAction>>;
+
+if (!globalSymbols[GLOBAL_SYMBOL]) {
+  globalSymbols[GLOBAL_SYMBOL] = {};
+}
+
+/**
+ * Singleton dictionary of declared lifecycle hooks.
+ * @internal
+ */
+export const declaredLifecycleHooks: Record<string, LifecycleAction> = globalSymbols[GLOBAL_SYMBOL];
+
+/**
+ * Registers an action to be executed automatically post-deployment when resources in this codebase
+ * are installed for the initial time.
+ *
+ * @param action The lifecycle action to execute.
+ */
+export function afterInstall(action: LifecycleAction): void {
+  if (declaredLifecycleHooks.afterInstall) {
+    throw new Error("Only one afterInstall lifecycle hook is allowed per codebase.");
+  }
+  declaredLifecycleHooks.afterInstall = action;
+}
+
+/**
+ * Registers an action to be executed automatically post-deployment when resources in this codebase
+ * are updated.
+ *
+ * @param action The lifecycle action to execute.
+ */
+export function afterUpdate(action: LifecycleAction): void {
+  if (declaredLifecycleHooks.afterUpdate) {
+    throw new Error("Only one afterUpdate lifecycle hook is allowed per codebase.");
+  }
+  declaredLifecycleHooks.afterUpdate = action;
+}
+
+/**
+ * Helper to clear declared lifecycle hooks (primarily for testing).
+ * @internal
+ */
+export function clearDeclaredLifecycleHooks(): void {
+  for (const key of Object.keys(declaredLifecycleHooks)) {
+    delete declaredLifecycleHooks[key];
+  }
+}

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -20,35 +20,21 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { Expression } from "../params";
-
-export type TargetFunction = string | Expression<string>;
-
 export interface TaskAction {
-  function: TargetFunction;
+  function: string;
   body?: Record<string, unknown>;
 }
 
 export interface CallAction {
-  function: TargetFunction;
+  function: string;
   params?: Record<string, unknown>;
 }
 
-export type HttpAction =
-  | {
-      function: TargetFunction;
-      url?: never;
-      method?: "GET" | "POST" | "PUT" | "DELETE";
-      headers?: Record<string, string | Expression<string>>;
-      body?: unknown;
-    }
-  | {
-      url: string | Expression<string>;
-      function?: never;
-      method?: "GET" | "POST" | "PUT" | "DELETE";
-      headers?: Record<string, string | Expression<string>>;
-      body?: unknown;
-    };
+export type HttpAction = ({ function: string } | { url: string }) & {
+  method?: "GET" | "POST" | "PUT" | "DELETE";
+  headers?: Record<string, string>;
+  body?: unknown;
+};
 
 export type LifecycleAction =
   | { task: TaskAction; call?: never; http?: never }

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -39,12 +39,14 @@ export type HttpAction =
       function: TargetFunction;
       url?: never;
       method?: "GET" | "POST" | "PUT" | "DELETE";
+      headers?: Record<string, string | Expression<string>>;
       body?: unknown;
     }
   | {
       url: string | Expression<string>;
       function?: never;
       method?: "GET" | "POST" | "PUT" | "DELETE";
+      headers?: Record<string, string | Expression<string>>;
       body?: unknown;
     };
 

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -234,6 +234,7 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
           ...(action.http.function && { function: action.http.function }),
           ...(action.http.url && { url: action.http.url }),
           ...(action.http.method && { method: action.http.method }),
+          ...(action.http.headers && { headers: action.http.headers }),
           ...(action.http.body !== undefined && { body: action.http.body }),
         };
       }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -220,29 +220,22 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
       if (action.task) {
         specAction.task = {
           function: action.task.function,
-          ...(action.task.body && { body: action.task.body }),
+          ...(action.task.body !== undefined && { body: action.task.body }),
         };
       }
       if (action.call) {
         specAction.call = {
           function: action.call.function,
-          ...(action.call.params && { params: action.call.params }),
+          ...(action.call.params !== undefined && { params: action.call.params }),
         };
       }
       if (action.http) {
-        if ("function" in action.http && action.http.function) {
-          specAction.http = {
-            function: action.http.function,
-            ...(action.http.method && { method: action.http.method }),
-            ...(action.http.body && { body: action.http.body }),
-          };
-        } else if ("url" in action.http && action.http.url) {
-          specAction.http = {
-            url: action.http.url,
-            ...(action.http.method && { method: action.http.method }),
-            ...(action.http.body && { body: action.http.body }),
-          };
-        }
+        specAction.http = {
+          ...(action.http.function && { function: action.http.function }),
+          ...(action.http.url && { url: action.http.url }),
+          ...(action.http.method && { method: action.http.method }),
+          ...(action.http.body !== undefined && { body: action.http.body }),
+        };
       }
       stack.lifecycleHooks[event] = specAction;
     }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -25,6 +25,7 @@ import * as url from "url";
 import {
   ManifestEndpoint,
   ManifestExtension,
+  ManifestLifecycleAction,
   ManifestRequiredAPI,
   ManifestStack,
 } from "./manifest";
@@ -32,6 +33,7 @@ import {
 import * as params from "../params";
 import { declaredRoles } from "../security/roles";
 import { getGlobalRequiredAPIs, clearGlobalRequiredAPIs } from "../common/api";
+import { declaredLifecycleHooks, clearDeclaredLifecycleHooks } from "../lifecycle";
 
 /**
  * Dynamically load import function to prevent TypeScript from
@@ -209,5 +211,42 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
   if (declaredRoles.size > 0) {
     stack.requiredRoles = Array.from(declaredRoles);
   }
+
+  const hooks = Object.entries(declaredLifecycleHooks);
+  if (hooks.length > 0) {
+    stack.lifecycleHooks = {};
+    for (const [event, action] of hooks) {
+      const specAction: ManifestLifecycleAction = {};
+      if (action.task) {
+        specAction.task = {
+          function: action.task.function,
+          ...(action.task.body && { body: action.task.body }),
+        };
+      }
+      if (action.call) {
+        specAction.call = {
+          function: action.call.function,
+          ...(action.call.params && { params: action.call.params }),
+        };
+      }
+      if (action.http) {
+        if ("function" in action.http && action.http.function) {
+          specAction.http = {
+            function: action.http.function,
+            ...(action.http.method && { method: action.http.method }),
+            ...(action.http.body && { body: action.http.body }),
+          };
+        } else if ("url" in action.http && action.http.url) {
+          specAction.http = {
+            url: action.http.url,
+            ...(action.http.method && { method: action.http.method }),
+            ...(action.http.body && { body: action.http.body }),
+          };
+        }
+      }
+      stack.lifecycleHooks[event] = specAction;
+    }
+  }
+  clearDeclaredLifecycleHooks();
   return stack;
 }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -25,7 +25,6 @@ import * as url from "url";
 import {
   ManifestEndpoint,
   ManifestExtension,
-  ManifestLifecycleAction,
   ManifestRequiredAPI,
   ManifestStack,
 } from "./manifest";
@@ -212,34 +211,8 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
     stack.requiredRoles = Array.from(declaredRoles);
   }
 
-  const hooks = Object.entries(declaredLifecycleHooks);
-  if (hooks.length > 0) {
-    stack.lifecycleHooks = {};
-    for (const [event, action] of hooks) {
-      const specAction: ManifestLifecycleAction = {};
-      if (action.task) {
-        specAction.task = {
-          function: action.task.function,
-          ...(action.task.body !== undefined && { body: action.task.body }),
-        };
-      }
-      if (action.call) {
-        specAction.call = {
-          function: action.call.function,
-          ...(action.call.params !== undefined && { params: action.call.params }),
-        };
-      }
-      if (action.http) {
-        specAction.http = {
-          ...(action.http.function && { function: action.http.function }),
-          ...(action.http.url && { url: action.http.url }),
-          ...(action.http.method && { method: action.http.method }),
-          ...(action.http.headers && { headers: action.http.headers }),
-          ...(action.http.body !== undefined && { body: action.http.body }),
-        };
-      }
-      stack.lifecycleHooks[event] = specAction;
-    }
+  if (Object.keys(declaredLifecycleHooks).length > 0) {
+    stack.lifecycleHooks = { ...declaredLifecycleHooks };
   }
   clearDeclaredLifecycleHooks();
   return stack;

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -143,18 +143,18 @@ export interface ManifestRequiredAPI {
  */
 export interface ManifestLifecycleAction {
   task?: {
-    function: string | Expression<string>;
+    function: string;
     body?: Record<string, unknown>;
   };
   call?: {
-    function: string | Expression<string>;
+    function: string;
     params?: Record<string, unknown>;
   };
   http?: {
-    function?: string | Expression<string>;
+    function?: string;
     url?: string | Expression<string>;
     method?: string;
-    headers?: Record<string, string | Expression<string>>;
+    headers?: Record<string, string>;
     body?: unknown;
   };
 }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -154,6 +154,7 @@ export interface ManifestLifecycleAction {
     function?: string | Expression<string>;
     url?: string | Expression<string>;
     method?: string;
+    headers?: Record<string, string | Expression<string>>;
     body?: unknown;
   };
 }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -137,6 +137,28 @@ export interface ManifestRequiredAPI {
 }
 
 /**
+ * A definition of a lifecycle action as appears in the Manifest.
+ *
+ * @alpha
+ */
+export interface ManifestLifecycleAction {
+  task?: {
+    function: string | Expression<string>;
+    body?: Record<string, unknown>;
+  };
+  call?: {
+    function: string | Expression<string>;
+    params?: Record<string, unknown>;
+  };
+  http?: {
+    function?: string | Expression<string>;
+    url?: string | Expression<string>;
+    method?: string;
+    body?: unknown;
+  };
+}
+
+/**
  * A definition of a function/extension deployment as appears in the Manifest.
  * @alpha
  */
@@ -147,6 +169,7 @@ export interface ManifestStack {
   endpoints: Record<string, ManifestEndpoint>;
   extensions?: Record<string, ManifestExtension>;
   requiredRoles?: string[];
+  lifecycleHooks?: Record<string, ManifestLifecycleAction>;
 }
 
 /**
@@ -170,6 +193,9 @@ export function stackToWire(stack: ManifestStack): Record<string, unknown> {
     }
   };
   traverse(wireStack.endpoints);
+  if (wireStack.lifecycleHooks) {
+    traverse(wireStack.lifecycleHooks);
+  }
   return wireStack;
 }
 

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -83,6 +83,8 @@ export { traceContext } from "../common/trace";
 import * as params from "../params";
 export { params };
 
+export { afterInstall, afterUpdate } from "../lifecycle";
+
 // NOTE: Required to support the Functions Emulator which monkey patches `functions.config()`
 // TODO(danielylee): Remove in next major release.
 export { config } from "../v1/config";


### PR DESCRIPTION
<!--

Thank you for contributing to the Firebase community! Please fill out the pull request form below
and make note of the following:

Run the linter and test suite
==============================
Run `npm test` to make sure your changes compile properly and the tests all pass on your local machine.
We've hooked up this repo with continuous integration to double check those things for you.

Add tests (if applicable)
==============================
Most non-trivial changes should include some extra test coverage. If you aren't sure how to add
tests, feel free to submit regardless and ask us for some advice.

Sign our CLA
==============================
Please sign our Contributor License Agreement (https://cla.developers.google.com/about/google-individual)
before sending PRs. We cannot accept code without this.

-->

### Description

This PR adds support for declaring codebase lifecycle hooks in the Firebase Functions SDK. Developers can now register actions (`afterInstall` and `afterUpdate`) that are automatically executed post-deployment.

## Summary of Changes

### 1. Hook Registrations (`src/lifecycle/index.ts`)
- Added new top-level entrypoints and types under `firebase-functions/lifecycle`:
  - `afterInstall(action: LifecycleAction)`: Registers a hook to run when resources in the codebase are deployed for the first time.
  - `afterUpdate(action: LifecycleAction)`: Registers a hook to run when resources in the codebase are updated.
- Supported action types:
  - `task`: Triggers a task queue function with an optional payload `body`.
  - `call`: Calls a function (callable trigger) with optional `params`.
  - `http`: Triggers a HTTP endpoint via request `url`/`function`, `method`, and `body`.
- Ensures only one instance of `afterInstall` and `afterUpdate` can be registered per codebase at runtime.

### 2. Stack Manifest Parsing (`src/runtime/loader.ts`, `src/runtime/manifest.ts`)
- Added `ManifestLifecycleAction` and updated `ManifestStack` types to include the `lifecycleHooks` field.
- Updated `loadStack` inside `loader.ts` to capture any declared lifecycle hooks from global symbols during function discovery, mapping them into the compiled JSON/wire format returned to `firebase-tools`.
- Updated `stackToWire` serialization helper to recursively resolve CEL expressions and reset values inside `lifecycleHooks` properties.

### 3. Tests
- Created `spec/lifecycle/lifecycle.spec.ts` to test hook registration and duplicate hook prevention.
- Added tests in `spec/runtime/loader.spec.ts` verifying that `afterInstall` and `afterUpdate` declarations are correctly discovered and serialized into the `ManifestStack`.
### Code sample

<!-- Proposing an API change? Provide code samples showing how the API will be used. -->

```
export const runInitialSetup = onTaskDispatched(async (request) => {
  await performDatabaseSeeding(request.data);
});

// The CLI automatically discovers this call and queues the task after first-time deploy
afterInstall({
  task: {
    function: "runInitialSetup",
    body: { data: "default_catalog" }
  }
});
````