### PR TITLE
wire format for a nonEmpty field in string/[]string param inputs

### DIFF
--- a/spec/fixtures/sources/commonjs-params/index.js
+++ b/spec/fixtures/sources/commonjs-params/index.js
@@ -21,7 +21,10 @@ params.defineInt("ANOTHER_INT", {
   },
 });
 
-params.defineList("LIST_PARAM", {input: { multiSelect: { options: [{ value: "c" }, { value: "d" }, { value: "e" }]}}})
+params.defineList("LIST_PARAM", {input: { multiSelect: { options: [{ value: "c" }, { value: "d" }, { value: "e" }]}}});
+
+params.defineString("NON_EMPTY_STRING", {input: { text: { nonEmpty: true } } } );
+params.defineList("NON_EMPTY_MULTISTRING", {input: {  multiSelect: { nonEmpty: true, options: [{ value: "a" }, { value: "b" }]}}});
 
 params.defineSecret("SUPER_SECRET_FLAG");
 

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -435,6 +435,25 @@ describe("loadStack", () => {
                 multiSelect: { options: [{ value: "c" }, { value: "d" }, { value: "e" }] },
               },
             },
+            {
+              name: "NON_EMPTY_STRING",
+              type: "string",
+              input: {
+                text: {
+                  nonEmpty: true,
+                },
+              },
+            },
+            {
+              name: "NON_EMPTY_MULTISTRING",
+              type: "list",
+              input: {
+                multiSelect: {
+                  nonEmpty: true,
+                  options: [{ value: "a" }, { value: "b" }],
+                },
+              },
+            },
             { name: "SUPER_SECRET_FLAG", type: "secret" },
           ],
         },

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -327,7 +327,6 @@ type ParamInput<T> =
  * to type it in interactively at deploy time. Input that does not match the
  * provided validationRegex, if present, will be retried.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export interface TextInput<T = unknown> {
   text: {
     example?: string;
@@ -342,7 +341,12 @@ export interface TextInput<T = unknown> {
      * failing to conform to the validationRegex,
      */
     validationErrorMessage?: string;
-  };
+    /**
+     * If set on an input for a string or string list param, nonEmpty prevents
+     * the prompt from accepting the empty string or empty list as valid input.
+     * Syntactic sugar over setting validationRegex to /.+/
+     */
+  } & (T extends string | string[] ? { nonEmpty?: boolean } : {});
 }
 
 /**
@@ -383,6 +387,13 @@ export interface SelectInput<T = unknown> {
 export interface MultiSelectInput {
   multiSelect: {
     options: Array<SelectOptions<string>>;
+
+    /**
+     * If set on an input for a string or string list param, nonEmpty prevents
+     * the prompt from accepting the empty string or empty list as valid input.
+     * Syntactic sugar over setting validationRegex to /.+/
+     */
+    nonEmpty?: boolean;
   };
 }
 
@@ -415,10 +426,8 @@ export type ParamSpec<T extends string | number | boolean | string[]> = {
 
 /**
  * Representation of parameters for the stack over the wire.
- *
  * @remarks
  * N.B: a WireParamSpec is just a ParamSpec with default expressions converted into a CEL literal
- *
  * @alpha
  */
 export type WireParamSpec<T extends string | number | boolean | string[]> = {


### PR DESCRIPTION
As #1912 but with the option moved to param inputs.