### PR TITLE
Rename lifecycle hooks to match functions vocab

### DIFF
--- a/spec/lifecycle/lifecycle.spec.ts
+++ b/spec/lifecycle/lifecycle.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import {
-  afterInstall,
-  afterUpdate,
+  afterFirstDeploy,
+  afterRedeploy,
   clearDeclaredLifecycleHooks,
   declaredLifecycleHooks,
 } from "../../src/lifecycle";
@@ -11,16 +11,16 @@ describe("lifecycle", () => {
     clearDeclaredLifecycleHooks();
   });
 
-  describe("afterInstall", () => {
-    it("registers an afterInstall lifecycle action", () => {
-      afterInstall({
+  describe("afterFirstDeploy", () => {
+    it("registers an afterFirstDeploy lifecycle action", () => {
+      afterFirstDeploy({
         task: {
           function: "runInitialSetup",
           body: { seedData: true },
         },
       });
 
-      expect(declaredLifecycleHooks.afterInstall).to.deep.equal({
+      expect(declaredLifecycleHooks.afterFirstDeploy).to.deep.equal({
         task: {
           function: "runInitialSetup",
           body: { seedData: true },
@@ -28,24 +28,24 @@ describe("lifecycle", () => {
       });
     });
 
-    it("throws an error if afterInstall is called more than once", () => {
-      afterInstall({ task: { function: "fn1" } });
-      expect(() => afterInstall({ task: { function: "fn2" } })).to.throw(
-        "Only one afterInstall lifecycle hook is allowed per codebase."
+    it("throws an error if afterFirstDeploy is called more than once", () => {
+      afterFirstDeploy({ task: { function: "fn1" } });
+      expect(() => afterFirstDeploy({ task: { function: "fn2" } })).to.throw(
+        "Only one afterFirstDeploy lifecycle hook is allowed per codebase."
       );
     });
   });
 
-  describe("afterUpdate", () => {
-    it("registers an afterUpdate lifecycle action", () => {
-      afterUpdate({
+  describe("afterRedeploy", () => {
+    it("registers an afterRedeploy lifecycle action", () => {
+      afterRedeploy({
         call: {
           function: "migrateSchema",
           params: { version: 2 },
         },
       });
 
-      expect(declaredLifecycleHooks.afterUpdate).to.deep.equal({
+      expect(declaredLifecycleHooks.afterRedeploy).to.deep.equal({
         call: {
           function: "migrateSchema",
           params: { version: 2 },
@@ -53,10 +53,10 @@ describe("lifecycle", () => {
       });
     });
 
-    it("throws an error if afterUpdate is called more than once", () => {
-      afterUpdate({ call: { function: "fn1" } });
-      expect(() => afterUpdate({ call: { function: "fn2" } })).to.throw(
-        "Only one afterUpdate lifecycle hook is allowed per codebase."
+    it("throws an error if afterRedeploy is called more than once", () => {
+      afterRedeploy({ call: { function: "fn1" } });
+      expect(() => afterRedeploy({ call: { function: "fn2" } })).to.throw(
+        "Only one afterRedeploy lifecycle hook is allowed per codebase."
       );
     });
   });

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -11,7 +11,7 @@ import {
 } from "../../src/runtime/manifest";
 import { clearParams } from "../../src/params";
 import { clearGlobalRequiredAPIs } from "../../src/common/api";
-import { afterInstall, afterUpdate, clearDeclaredLifecycleHooks } from "../../src/lifecycle";
+import { afterFirstDeploy, afterRedeploy, clearDeclaredLifecycleHooks } from "../../src/lifecycle";
 import { MINIMAL_V1_ENDPOINT, MINIMAL_V2_ENDPOINT } from "../fixtures";
 import { MINIMAL_SCHEDULE_TRIGGER, MINIMIAL_TASK_QUEUE_TRIGGER } from "../v1/providers/fixtures";
 import { BooleanParam, IntParam, StringParam } from "../../src/params/types";
@@ -531,14 +531,14 @@ describe("loadStack", () => {
   });
 
   describe("loadStack with lifecycleHooks", () => {
-    it("captures top-level afterInstall and afterUpdate calls into ManifestStack.lifecycleHooks", async () => {
-      afterInstall({
+    it("captures top-level afterFirstDeploy and afterRedeploy calls into ManifestStack.lifecycleHooks", async () => {
+      afterFirstDeploy({
         task: {
           function: "runInitialSetup",
           body: { seedData: "default_catalog" },
         },
       });
-      afterUpdate({
+      afterRedeploy({
         call: {
           function: "migrateSchema",
           params: { targetVersion: "v2.4" },
@@ -547,13 +547,13 @@ describe("loadStack", () => {
 
       const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
       expect(stack.lifecycleHooks).to.deep.equal({
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "runInitialSetup",
             body: { seedData: "default_catalog" },
           },
         },
-        afterUpdate: {
+        afterRedeploy: {
           call: {
             function: "migrateSchema",
             params: { targetVersion: "v2.4" },
@@ -563,7 +563,7 @@ describe("loadStack", () => {
     });
 
     it("captures http lifecycle hooks with function and url into ManifestStack.lifecycleHooks", async () => {
-      afterInstall({
+      afterFirstDeploy({
         http: {
           function: "seedDatabase",
           method: "POST",
@@ -571,7 +571,7 @@ describe("loadStack", () => {
           body: { force: true },
         },
       });
-      afterUpdate({
+      afterRedeploy({
         http: {
           url: "https://example.com/webhook",
           method: "POST",
@@ -581,7 +581,7 @@ describe("loadStack", () => {
 
       const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
       expect(stack.lifecycleHooks).to.deep.equal({
-        afterInstall: {
+        afterFirstDeploy: {
           http: {
             function: "seedDatabase",
             method: "POST",
@@ -589,7 +589,7 @@ describe("loadStack", () => {
             body: { force: true },
           },
         },
-        afterUpdate: {
+        afterRedeploy: {
           http: {
             url: "https://example.com/webhook",
             method: "POST",
@@ -600,7 +600,7 @@ describe("loadStack", () => {
     });
 
     it("preserves falsy but valid JSON values (like 0, false, empty string) in hook payloads", async () => {
-      afterInstall({
+      afterFirstDeploy({
         task: {
           function: "runInitialSetup",
           body: { force: false, code: 0, tag: "" },
@@ -609,7 +609,7 @@ describe("loadStack", () => {
 
       const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
       expect(stack.lifecycleHooks).to.deep.equal({
-        afterInstall: {
+        afterFirstDeploy: {
           task: {
             function: "runInitialSetup",
             body: { force: false, code: 0, tag: "" },

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -70,15 +70,15 @@ export const declaredLifecycleHooks: Record<string, LifecycleAction> = globalSym
 
 /**
  * Registers an action to be executed automatically post-deployment when resources in this codebase
- * are installed for the initial time.
+ * are installed for the first time.
  *
  * @param action The lifecycle action to execute.
  */
-export function afterInstall(action: LifecycleAction): void {
-  if (declaredLifecycleHooks.afterInstall) {
-    throw new Error("Only one afterInstall lifecycle hook is allowed per codebase.");
+export function afterFirstDeploy(action: LifecycleAction): void {
+  if (declaredLifecycleHooks.afterFirstDeploy) {
+    throw new Error("Only one afterFirstDeploy lifecycle hook is allowed per codebase.");
   }
-  declaredLifecycleHooks.afterInstall = action;
+  declaredLifecycleHooks.afterFirstDeploy = action;
 }
 
 /**
@@ -87,11 +87,11 @@ export function afterInstall(action: LifecycleAction): void {
  *
  * @param action The lifecycle action to execute.
  */
-export function afterUpdate(action: LifecycleAction): void {
-  if (declaredLifecycleHooks.afterUpdate) {
-    throw new Error("Only one afterUpdate lifecycle hook is allowed per codebase.");
+export function afterRedeploy(action: LifecycleAction): void {
+  if (declaredLifecycleHooks.afterRedeploy) {
+    throw new Error("Only one afterRedeploy lifecycle hook is allowed per codebase.");
   }
-  declaredLifecycleHooks.afterUpdate = action;
+  declaredLifecycleHooks.afterRedeploy = action;
 }
 
 /**

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -70,7 +70,7 @@ export const declaredLifecycleHooks: Record<string, LifecycleAction> = globalSym
 
 /**
  * Registers an action to be executed automatically post-deployment when resources in this codebase
- * are installed for the first time.
+ * are deployed for the first time.
  *
  * @param action The lifecycle action to execute.
  */

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -83,7 +83,7 @@ export { traceContext } from "../common/trace";
 import * as params from "../params";
 export { params };
 
-export { afterInstall, afterUpdate } from "../lifecycle";
+export { afterFirstDeploy, afterRedeploy } from "../lifecycle";
 
 // NOTE: Required to support the Functions Emulator which monkey patches `functions.config()`
 // TODO(danielylee): Remove in next major release.


### PR DESCRIPTION
### Description

This renames `afterInstall` to `afterFirstDeploy` and `afterUpdate` to `afterRedeploy` to better mirror functions vocabulary and move away from Extensions terms.

### Code sample

```
export const runInitialSetup = onTaskDispatched(async (request) => {
  await performDatabaseSeeding(request.data);
});

// The CLI automatically discovers this call and queues the task after first-time deploy
afterFirstDeploy({
  task: {
    function: "runInitialSetup",
    body: { data: "default_catalog" }
  }
});
```