### PR TITLE
fix/v2-auth-event-data-unpacking

### DIFF
--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -527,6 +527,43 @@ describe("identity", () => {
       expect(func.__endpoint.eventTrigger?.eventFilters?.tenantid).to.equal(param);
       clearParams();
     });
+
+    it("should unpack user from protobuf v2 value envelope with normalized fields", () => {
+      let called = false;
+      const func = identity.onUserCreated((event) => {
+        called = true;
+        expect(event.data.uid).to.equal("1qEveruhwnbiG1B9taHIBMmOVE83");
+        expect(event.data.email).to.equal("testuser@example.com");
+        expect(event.data.emailVerified).to.be.true;
+        expect(event.data.displayName).to.equal("Test User");
+        expect(event.data.photoURL).to.equal("http://example.com/photo.jpg");
+        expect(event.data.metadata.creationTime).to.equal("Sun, 01 Jan 2023 00:00:00 GMT");
+        return null;
+      });
+
+      const mockEvent = {
+        specversion: "1.0" as const,
+        source: "//identitytoolkit.googleapis.com/projects/my-project",
+        id: "event-id",
+        type: "google.firebase.auth.user.v2.created",
+        time: new Date().toISOString(),
+        data: {
+          value: {
+            uid: "1qEveruhwnbiG1B9taHIBMmOVE83",
+            email: "testuser@example.com",
+            emailVerified: true,
+            displayName: "Test User",
+            photoURL: "http://example.com/photo.jpg",
+            metadata: {
+              createTime: "2023-01-01T00:00:00Z",
+            },
+          },
+        } as any,
+      };
+
+      func(mockEvent);
+      expect(called).to.be.true;
+    });
   });
 
   describe("onUserDeleted", () => {
@@ -579,6 +616,37 @@ describe("identity", () => {
           },
         } as any,
         tenantid: "my-tenant",
+      };
+
+      func(mockEvent);
+      expect(called).to.be.true;
+    });
+
+    it("should unpack user from protobuf v2 oldValue envelope on execution", () => {
+      let called = false;
+      const func = identity.onUserDeleted((event) => {
+        called = true;
+        expect(event.data.uid).to.equal("my-deleted-uid");
+        expect(event.data.email).to.equal("deleted@example.com");
+        expect(event.data.metadata.creationTime).to.equal("Sun, 01 Jan 2023 00:00:00 GMT");
+        return null;
+      });
+
+      const mockEvent = {
+        specversion: "1.0" as const,
+        source: "//identitytoolkit.googleapis.com/projects/my-project",
+        id: "event-id",
+        type: "google.firebase.auth.user.v2.deleted",
+        time: new Date().toISOString(),
+        data: {
+          oldValue: {
+            uid: "my-deleted-uid",
+            email: "deleted@example.com",
+            metadata: {
+              createTime: "2023-01-01T00:00:00Z",
+            },
+          },
+        } as any,
       };
 
       func(mockEvent);

--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -564,6 +564,53 @@ describe("identity", () => {
       func(mockEvent);
       expect(called).to.be.true;
     });
+
+    it("should normalize photoUrl (proto3 JSON) to photoURL", () => {
+      let called = false;
+      const func = identity.onUserCreated((event) => {
+        called = true;
+        expect(event.data.photoURL).to.equal("http://example.com/proto-photo.jpg");
+        return null;
+      });
+
+      const mockEvent = {
+        specversion: "1.0" as const,
+        source: "//identitytoolkit.googleapis.com/projects/my-project",
+        id: "event-id",
+        type: "google.firebase.auth.user.v2.created",
+        time: new Date().toISOString(),
+        data: {
+          value: {
+            uid: "photo-uid",
+            photoUrl: "http://example.com/proto-photo.jpg",
+          },
+        } as any,
+      };
+
+      func(mockEvent);
+      expect(called).to.be.true;
+    });
+
+    it("should gracefully handle null/malformed raw.data without throwing", () => {
+      let called = false;
+      const func = identity.onUserCreated((event) => {
+        called = true;
+        expect(event.data).to.be.undefined;
+        return null;
+      });
+
+      const mockEvent = {
+        specversion: "1.0" as const,
+        source: "//identitytoolkit.googleapis.com/projects/my-project",
+        id: "event-id",
+        type: "google.firebase.auth.user.v2.created",
+        time: new Date().toISOString(),
+        data: null as any,
+      };
+
+      func(mockEvent);
+      expect(called).to.be.true;
+    });
   });
 
   describe("onUserDeleted", () => {
@@ -645,6 +692,33 @@ describe("identity", () => {
             metadata: {
               createTime: "2023-01-01T00:00:00Z",
             },
+          },
+        } as any,
+      };
+
+      func(mockEvent);
+      expect(called).to.be.true;
+    });
+
+    it("should unpack user from old_value (snake_case) envelope on execution", () => {
+      let called = false;
+      const func = identity.onUserDeleted((event) => {
+        called = true;
+        expect(event.data.uid).to.equal("snake-deleted-uid");
+        expect(event.data.email).to.equal("snake-deleted@example.com");
+        return null;
+      });
+
+      const mockEvent = {
+        specversion: "1.0" as const,
+        source: "//identitytoolkit.googleapis.com/projects/my-project",
+        id: "event-id",
+        type: "google.firebase.auth.user.v2.deleted",
+        time: new Date().toISOString(),
+        data: {
+          old_value: {
+            uid: "snake-deleted-uid",
+            email: "snake-deleted@example.com",
           },
         } as any,
       };

--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -611,6 +611,27 @@ describe("identity", () => {
       func(mockEvent);
       expect(called).to.be.true;
     });
+
+    it("should gracefully handle explicit { value: null } inside raw.data without throwing", () => {
+      let called = false;
+      const func = identity.onUserCreated((event) => {
+        called = true;
+        expect(event.data).to.be.undefined;
+        return null;
+      });
+
+      const mockEvent = {
+        specversion: "1.0" as const,
+        source: "//identitytoolkit.googleapis.com/projects/my-project",
+        id: "event-id",
+        type: "google.firebase.auth.user.v2.created",
+        time: new Date().toISOString(),
+        data: { value: null } as any,
+      };
+
+      func(mockEvent);
+      expect(called).to.be.true;
+    });
   });
 
   describe("onUserDeleted", () => {

--- a/src/common/providers/identity.ts
+++ b/src/common/providers/identity.ts
@@ -96,7 +96,8 @@ export class UserRecordMetadata implements auth.UserMetadata {
 }
 
 /**
- * Helper function that creates a `UserRecord` class from data sent over the wire.
+ * Helper function that creates a `UserRecord` class from the wire protocol of the v1 `LegacyEvent`
+ * (or normalized wire data).
  * @param wireData data sent over the wire
  * @returns an instance of `UserRecord` with correct toJSON functions
  */

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -427,7 +427,16 @@ function unpackAndNormalizeUserRecord(rawData: unknown): User | undefined {
     return undefined;
   }
   const dataObj = rawData as Record<string, unknown>;
-  const rawUser = dataObj.value ?? dataObj.oldValue ?? dataObj.old_value ?? dataObj;
+  let rawUser: unknown;
+  if ("value" in dataObj) {
+    rawUser = dataObj.value;
+  } else if ("oldValue" in dataObj) {
+    rawUser = dataObj.oldValue;
+  } else if ("old_value" in dataObj) {
+    rawUser = dataObj.old_value;
+  } else {
+    rawUser = dataObj;
+  }
   if (!rawUser || typeof rawUser !== "object") {
     return undefined;
   }

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -421,8 +421,12 @@ function getOptsAndHandler(
 // Matches both absolute paths (/projects/...) and relative paths (projects/...)
 const PROJECT_ID_REGEX = /(?:^|\/)projects\/([^\/]+)/;
 
-/** @hidden */
-function unpackAndNormalizeUserRecord(rawData: unknown): User | undefined {
+/**
+ * Converts the v2 Eventarc (`AuthEventData`) protobuf wire protocol (`value`/`oldValue`, `createTime`, `photoUrl`)
+ * into the v1 `LegacyEvent` wire protocol expected by `userRecordConstructor`.
+ * @hidden
+ */
+function convertV2EventToV1Event(rawData: unknown): User | undefined {
   if (!rawData || typeof rawData !== "object") {
     return undefined;
   }
@@ -465,7 +469,7 @@ function unpackAndNormalizeUserRecord(rawData: unknown): User | undefined {
 function getAuthEvent(raw: CloudEvent<unknown>): AuthEvent<User> {
   const event: AuthEvent<User> = { ...raw } as any;
   if (raw.data !== undefined && raw.data !== null) {
-    event.data = unpackAndNormalizeUserRecord(raw.data);
+    event.data = convertV2EventToV1Event(raw.data);
   }
   const rawAny = raw as any;
   // Support both lowercase (CloudEvents standard) and camelCase (local testing)

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -422,23 +422,41 @@ function getOptsAndHandler(
 const PROJECT_ID_REGEX = /(?:^|\/)projects\/([^\/]+)/;
 
 /** @hidden */
+function unpackAndNormalizeUserRecord(rawData: unknown): User | undefined {
+  if (!rawData || typeof rawData !== "object") {
+    return undefined;
+  }
+  const dataObj = rawData as Record<string, unknown>;
+  const rawUser = dataObj.value ?? dataObj.oldValue ?? dataObj.old_value ?? dataObj;
+  if (!rawUser || typeof rawUser !== "object") {
+    return undefined;
+  }
+  const userData = { ...(rawUser as Record<string, unknown>) };
+  if (userData.photoUrl && !userData.photoURL) {
+    userData.photoURL = userData.photoUrl;
+  }
+  if (userData.metadata && typeof userData.metadata === "object") {
+    const meta = { ...(userData.metadata as Record<string, unknown>) };
+    if (meta.createTime && !meta.createdAt && !meta.creationTime) {
+      meta.creationTime = meta.createTime;
+    }
+    userData.metadata = meta;
+  }
+  return userRecordConstructor(userData);
+}
+
+/**
+ * Normalizes raw CloudEvents from Eventarc into AuthEvent<User>.
+ * Eventarc wraps v2 Authentication user payloads inside an `AuthEventData`
+ * protobuf envelope (`value` for creation events, `oldValue` for deletion events).
+ * We unbox the envelope (falling back to `raw.data` for unit tests) and normalize
+ * protobuf-specific field names (`createTime` -> `creationTime`, `photoUrl` -> `photoURL`).
+ * @hidden
+ */
 function getAuthEvent(raw: CloudEvent<unknown>): AuthEvent<User> {
   const event: AuthEvent<User> = { ...raw } as any;
-  if (raw.data) {
-    const dataObj = raw.data as Record<string, unknown>;
-    const rawUser = (dataObj.value || dataObj.oldValue || dataObj.old_value || dataObj) as Record<
-      string,
-      unknown
-    >;
-    const userData = { ...rawUser };
-    if (userData.metadata && typeof userData.metadata === "object") {
-      const meta = { ...(userData.metadata as Record<string, unknown>) };
-      if (meta.createTime && !meta.createdAt && !meta.creationTime) {
-        meta.creationTime = meta.createTime;
-      }
-      userData.metadata = meta;
-    }
-    event.data = userRecordConstructor(userData);
+  if (raw.data !== undefined && raw.data !== null) {
+    event.data = unpackAndNormalizeUserRecord(raw.data);
   }
   const rawAny = raw as any;
   // Support both lowercase (CloudEvents standard) and camelCase (local testing)

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -425,7 +425,20 @@ const PROJECT_ID_REGEX = /(?:^|\/)projects\/([^\/]+)/;
 function getAuthEvent(raw: CloudEvent<unknown>): AuthEvent<User> {
   const event: AuthEvent<User> = { ...raw } as any;
   if (raw.data) {
-    event.data = userRecordConstructor(raw.data as Record<string, unknown>);
+    const dataObj = raw.data as Record<string, unknown>;
+    const rawUser = (dataObj.value || dataObj.oldValue || dataObj.old_value || dataObj) as Record<
+      string,
+      unknown
+    >;
+    const userData = { ...rawUser };
+    if (userData.metadata && typeof userData.metadata === "object") {
+      const meta = { ...(userData.metadata as Record<string, unknown>) };
+      if (meta.createTime && !meta.createdAt && !meta.creationTime) {
+        meta.creationTime = meta.createTime;
+      }
+      userData.metadata = meta;
+    }
+    event.data = userRecordConstructor(userData);
   }
   const rawAny = raw as any;
   // Support both lowercase (CloudEvents standard) and camelCase (local testing)


### PR DESCRIPTION
While testing and migrating extensions to v2 Cloud Functions, we noticed that properties inside event.data for onUserCreated and onUserDeleted triggers were missing vital information like email, displayName, and metadata.creationTime. This disparity from v1 happens because Eventarc delivers v2 Authentication payloads wrapped inside a google.events.firebase.auth.v2.AuthEventData envelope. Specifically, the target User object is nested under .value for creation events and .oldValue (or .old_value) for deletion events. Because getAuthEvent passed the outer envelope directly to userRecordConstructor, the constructor couldn't find the user attributes at the root level and fell back to null values. Additionally, protobuf JSON outputs createTime and photoUrl, whereas our constructor expects createdAt/creationTime and photoURL.

To fix this specifically for v2 without touching common or v1 code paths, we extracted an unpackAndNormalizeUserRecord helper in src/v2/providers/identity.ts. This helper unboxes value, oldValue, or old_value (falling back to raw.data for direct unit test payloads) and normalizes protobuf field names (createTime -> creationTime, photoUrl -> photoURL) with explicit runtime object guards before constructing the user record. This ensures v2 events receive full attribute parity while leaving v1 triggers completely untouched.

To verify this, we expanded the unit test suite in identity.spec.ts with new cases covering .value and .oldValue/.old_value envelope unpacking, photoUrl normalization, and null payload resilience. Ran Manual tests by deploying the functions and checking Cloud logs to ensure that all the attributes were cleanly unpacked.