### PR TITLE
fix/v2-docgen-strip-internal

### DIFF
--- a/src/v2/index.doc.ts
+++ b/src/v2/index.doc.ts
@@ -1,5 +1,4 @@
 /**
- * @internal
  * Documentation-only entry point. This file is not part of the public API
  * and is used only by api-extractor to generate reference documentation.
  * It includes exports that are not part of the main `index.ts` entry point


### PR DESCRIPTION
Fixes a regression where v2 reference documentation generation (docgen:v2) output contained only the dataconnect namespace and dropped all other v2 APIs (https, firestore, pubsub, identity, storage, tasks, etc.) as well as any recent updates.

Root Cause: When src/v2/index.doc.ts was introduced in PR #1825 to document dataconnect/graphql without forcing peer dependencies on users, an @internal TSDoc tag was placed directly inside the top-level comment block right above the export * from "./index"; statement. Because our build configuration (tsconfig.release.json) enables the stripInternal flag, TypeScript associated that @internal tag with the very first export (export * from "./index";) and stripped it completely when compiling to declaration files. As a result, lib/v2/index.doc.d.ts only exported dataconnect (export * as dataconnect from "./dataconnect.doc";), leading api-extractor to ignore the entire rest of the v2 SDK during documentation extraction.

Solution: Remove @internal from src/v2/index.doc.ts so TypeScript preserves the root export * from "./index"; statement in the compiled declaration entrypoint.

Verification: Running npm run docgen:v2 locally now generates all 117 markdown files across all v2 namespaces (alerts, database, dataconnect, eventarc, firestore, https, identity, logger, params, pubsub, remoteConfig, scheduler, storage, tasks, testLab) while keeping dataconnect/graphql nested cleanly inside dataconnect.