### PR TITLE
Add "v2/lifecycle" import path

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,11 @@
       "import": "./lib/esm/v2/index.mjs",
       "require": "./lib/v2/index.js"
     },
+    "./v2/lifecycle": {
+      "types": "./lib/lifecycle/index.d.ts",
+      "import": "./lib/esm/lifecycle/index.mjs",
+      "require": "./lib/lifecycle/index.js"
+    },
     "./v2/core": {
       "types": "./lib/v2/core.d.ts",
       "import": "./lib/esm/v2/core.mjs",
@@ -497,6 +502,9 @@
       ],
       "v2/identity": [
         "lib/v2/providers/identity"
+      ],
+      "v2/lifecycle": [
+        "lib/lifecycle/index"
       ],
       "v2/options": [
         "lib/v2/options"

--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -83,8 +83,6 @@ export { traceContext } from "../common/trace";
 import * as params from "../params";
 export { params };
 
-export { afterFirstDeploy, afterRedeploy } from "../lifecycle";
-
 // NOTE: Required to support the Functions Emulator which monkey patches `functions.config()`
 // TODO(danielylee): Remove in next major release.
 export { config } from "../v1/config";


### PR DESCRIPTION
Lifecycle features can now be accessed through "firebase-functions/v2/lifecycle" as well, copying the convention of other v2-specific features.

This also removes the discoverability via "firebase-functions/v2".