### PR TITLE
chore: suppress new auth triggers and internal pubsub types from docgen

### DIFF
--- a/src/v2/index.doc.ts
+++ b/src/v2/index.doc.ts
@@ -1,10 +1,11 @@
+// Documentation-only entry point. This file is not part of the public API
+// and is used only by api-extractor to generate reference documentation.
+// It includes exports that are not part of the main `index.ts` entry point
+// to avoid forcing optional peer dependencies on all users.
+//
+// DO NOT use for runtime imports.
+
 /**
- * Documentation-only entry point. This file is not part of the public API
- * and is used only by api-extractor to generate reference documentation.
- * It includes exports that are not part of the main `index.ts` entry point
- * to avoid forcing optional peer dependencies on all users.
- *
- * DO NOT use for runtime imports.
  * The 2nd gen API for Cloud Functions for Firebase.
  * This SDK supports deep imports. For example, the namespace
  * `pubsub` is available at `firebase-functions/v2` or is directly importable

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -378,12 +378,14 @@ export function getOpts(blockingOptions: BlockingOptions): InternalOptions {
 /**
  * The user data payload for an Auth Event. this is the standard "UserRecord"
  * from the firebase Admin SDK.
+ * @internal
  */
 export type User = AdminUserRecord;
 
 /**
  * The event object passed to the handler funcation for Firebase Authentication
  * events.
+ * @internal
  */
 export interface AuthEvent<T> extends CloudEvent<T> {
   /** The project identifier */
@@ -393,7 +395,10 @@ export interface AuthEvent<T> extends CloudEvent<T> {
   tenantId?: string;
 }
 
-/** Options for configuring a Firebase Authentication Trigger */
+/**
+ * Options for configuring a Firebase Authentication Trigger
+ * @internal
+ */
 export interface AuthOptions extends options.EventHandlerOptions {
   /**
    * The Id of the Identity Platform tenant to scope the function to.
@@ -404,7 +409,10 @@ export interface AuthOptions extends options.EventHandlerOptions {
   tenantId?: string | Expression<string> | typeof RESET_VALUE;
 }
 
-// constant to represent the absence of tenant ID.
+/**
+ * constant to represent the absence of tenant ID.
+ * @internal
+ */
 export const IS_NOT_TENANT = RESET_VALUE;
 
 // Helper to handle overloaded function signature
@@ -546,6 +554,7 @@ const USER_CREATED_EVENT = "google.firebase.auth.user.v2.created";
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
  *
  * @beta
+ * @internal
  *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
@@ -557,6 +566,7 @@ export function onUserCreated(
  * Handles user creation events in Firebase Authentication.
  *
  * @beta
+ * @internal
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -581,6 +591,7 @@ const USER_DELETED_EVENT = "google.firebase.auth.user.v2.deleted";
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
  *
  * @beta
+ * @internal
  *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
@@ -592,6 +603,7 @@ export function onUserDeleted(
  * Handles user deletion events in Firebase Authentication.
  *
  * @beta
+ * @internal
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.

--- a/src/v2/providers/pubsub.ts
+++ b/src/v2/providers/pubsub.ts
@@ -153,6 +153,7 @@ export interface MessagePublishedData<T = any> {
 /**
  * A v1-compatible Pub/Sub Message.
  * Note: This is a plain object mimicking the v1 Message structure, not an instance of the v1 Message class.
+ * @hidden
  * @typeParam T - Type of `json` payload.
  */
 export interface V1PubSubMessage<T = any> {


### PR DESCRIPTION
This PR cleans up the 2nd-gen reference documentation (docgen:v2) so that only public, generally available APIs are published in the Table of Contents and reference markdown. Specifically, we suppress the newly added Auth triggers and related options (onUserCreated, onUserDeleted, AuthEvent, AuthOptions) since they are currently allowlist-only and not ready for public DevSite documentation yet.

We also suppress V1PubSubMessage from showing up as a standalone page in the 2nd-gen docs, as it is strictly a backward-compatibility type for legacy pub/sub payloads and is confusing when displayed alongside 2nd-gen reference pages. Finally, we clean up the 2nd-gen SDK home page (firebase-functions.md) by moving an internal developer comment out of the @packageDocumentation block in index.doc.ts so it no longer outputs onto the public overview page.

Testing
Ran npm run docgen:v2 and verified that the non-public Auth triggers and V1PubSubMessage are completely removed from _toc.yaml and reference markdown, and that the overview home page is clean. Ran npm test (973 passing) to verify no runtime or type breaks.

