### PR TITLE
feat: add built-in functionRegion parameter for region

### DIFF
--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -140,11 +140,13 @@ describe("Params value extraction", () => {
   });
 
   it("extracts the special case FUNCTION_REGION / functionRegion / region from process.env", () => {
-    process.env.FUNCTION_REGION = "us-east1";
-    expect(params.functionRegion.value()).to.equal("us-east1");
-    expect(params.region.value()).to.equal("us-east1");
-
-    delete process.env.FUNCTION_REGION;
+    try {
+      process.env.FUNCTION_REGION = "us-east1";
+      expect(params.functionRegion.value()).to.equal("us-east1");
+      expect(params.region.value()).to.equal("us-east1");
+    } finally {
+      delete process.env.FUNCTION_REGION;
+    }
     expect(params.functionRegion.value()).to.equal("");
     expect(params.region.value()).to.equal("");
   });

--- a/spec/params/params.spec.ts
+++ b/spec/params/params.spec.ts
@@ -139,6 +139,16 @@ describe("Params value extraction", () => {
     delete process.env.FIREBASE_CONFIG;
   });
 
+  it("extracts the special case FUNCTION_REGION / functionRegion / region from process.env", () => {
+    process.env.FUNCTION_REGION = "us-east1";
+    expect(params.functionRegion.value()).to.equal("us-east1");
+    expect(params.region.value()).to.equal("us-east1");
+
+    delete process.env.FUNCTION_REGION;
+    expect(params.functionRegion.value()).to.equal("");
+    expect(params.region.value()).to.equal("");
+  });
+
   it("falls back on the javascript zero values in case of type mismatch", () => {
     const stringToInt = params.defineInt("A_STRING");
     expect(stringToInt.value()).to.equal(0);
@@ -378,6 +388,14 @@ describe("Params as CEL", () => {
     expect(params.storageBucket.equals(str).toCEL()).to.equal(
       `{{ params.STORAGE_BUCKET == params.A_STRING }}`
     );
+    expect(params.functionRegion.toCEL()).to.equal(`{{ params.FUNCTION_REGION }}`);
+    expect(params.functionRegion.equals("foo").toCEL()).to.equal(
+      `{{ params.FUNCTION_REGION == "foo" }}`
+    );
+    expect(params.functionRegion.equals(str).toCEL()).to.equal(
+      `{{ params.FUNCTION_REGION == params.A_STRING }}`
+    );
+    expect(params.region.toCEL()).to.equal(`{{ params.FUNCTION_REGION }}`);
   });
 
   it("identity expressions", () => {

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -138,6 +138,19 @@ export const storageBucket: Param<string> = new InternalExpression(
   "STORAGE_BUCKET",
   (env: NodeJS.ProcessEnv) => JSON.parse(env.FIREBASE_CONFIG || "{}")?.storageBucket || ""
 );
+/**
+ * A built-in parameter that resolves to the Cloud region, without prompting
+ * the deployer.
+ */
+export const functionRegion: Param<string> = new InternalExpression(
+  "FUNCTION_REGION",
+  (env: NodeJS.ProcessEnv) => env.FUNCTION_REGION || ""
+);
+/**
+ * A built-in parameter that resolves to the Cloud region, without prompting
+ * the deployer. Alias for {@link functionRegion}.
+ */
+export const region: Param<string> = functionRegion;
 
 /**
  * Declares a secret param, that will persist values only in Cloud Secret Manager.


### PR DESCRIPTION
### Description
GCF v2 does not include the FUNCTION_REGION environment variable by default, which can break some workflows. In particular, Firebase Extensions may depend on this variable to target callable or task queue functions in the same region. This change adds the `functionRegion` built-in parameter (and `region` alias) to the SDK.

### Scenarios Tested
- Unit tests for value extraction and CEL representation.

relnote: Add `functionRegion` built-in parameter for region