### PR TITLE
fix: resolve BASH_REMATCH overwriting in changelog.sh and handle duplicate prerelease publishes in publish.sh

### DIFF
--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -58,7 +58,7 @@ process_note() {
     return
   fi
   
-  if echo "$note" | grep -qE '\(#[0-9]+\)$'; then
+  if echo "$note" | grep -qE '\((#[0-9]+(,[[:space:]]*#[0-9]+)*)\)$'; then
     CHANGELOG_NOTES+="- $note"$'\n'
   elif [ -n "$PR_SUFFIX" ]; then
     CHANGELOG_NOTES+="- $note $PR_SUFFIX"$'\n'

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -49,6 +49,24 @@ while read -r sha; do
 done < <(git rev-list "${PREVIOUS_TAG}..HEAD")
 
 CHANGELOG_NOTES=""
+
+process_note() {
+  local note="$1"
+  note=$(echo "$note" | sed -E 's/[[:space:]]*$//')
+  
+  if [[ -z "$note" || "$note" =~ ^[[:space:]]*$ || "$note" =~ ^[Nn]one$ ]]; then
+    return
+  fi
+  
+  if echo "$note" | grep -qE '\(#[0-9]+\)$'; then
+    CHANGELOG_NOTES+="- $note"$'\n'
+  elif [ -n "$PR_SUFFIX" ]; then
+    CHANGELOG_NOTES+="- $note $PR_SUFFIX"$'\n'
+  else
+    CHANGELOG_NOTES+="- $note"$'\n'
+  fi
+}
+
 while read -r sha; do
   # Check if this SHA was reverted
   FULL_SHA=$(git rev-parse "$sha")
@@ -71,21 +89,29 @@ while read -r sha; do
     fi
   fi
 
+  current_note=""
   while read -r line; do
-    if [ -n "$line" ]; then
-      if echo "$line" | grep -qE '\(#[0-9]+\)$'; then
-        CHANGELOG_NOTES+="- $line"$'\n'
-      elif [ -n "$PR_SUFFIX" ]; then
-        CHANGELOG_NOTES+="- $line $PR_SUFFIX"$'\n'
+    line=$(echo "$line" | sed -E 's/\r$//')
+    
+    if [[ "$line" =~ ^[Rr]elnotes?:[[:space:]]*(.*) ]]; then
+      next_note="${BASH_REMATCH[1]}"
+      if [ -n "$current_note" ]; then
+        process_note "$current_note"
+      fi
+      current_note="$next_note"
+    elif [ -n "$current_note" ]; then
+      if [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^# ]]; then
+        process_note "$current_note"
+        current_note=""
       else
-        CHANGELOG_NOTES+="- $line"$'\n'
+        current_note="$current_note $line"
       fi
     fi
-  done < <(git log -1 --format="%b" "$sha" | \
-           grep -iE '^relnotes?:' | \
-           grep -vi 'relnotes?:[[:space:]]*none' | \
-           sed -E 's/^[Rr]elnotes?:[[:space:]]*//g' | \
-           sed -E 's/[[:space:]]*$//')
+  done < <(git log -1 --format="%b" "$sha")
+  
+  if [ -n "$current_note" ]; then
+    process_note "$current_note"
+  fi
 done < <(git rev-list "${PREVIOUS_TAG}..HEAD")
 
 echo -e "$CHANGELOG_NOTES"

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -52,13 +52,17 @@ CHANGELOG_NOTES=""
 
 process_note() {
   local note="$1"
-  note=$(echo "$note" | sed -E 's/[[:space:]]*$//')
+  # Trim trailing whitespace using pure bash parameter expansion
+  note="${note%"${note##*[![:space:]]}"}"
   
-  if [[ -z "$note" || "$note" =~ ^[[:space:]]*$ || "$note" =~ ^[Nn]one$ ]]; then
+  # Case-insensitive check for 'none'
+  if [[ -z "$note" || "$note" =~ ^[[:space:]]*$ || "$note" =~ ^[Nn][Oo][Nn][Ee]$ ]]; then
     return
   fi
   
-  if echo "$note" | grep -qE '\((#[0-9]+(,[[:space:]]*#[0-9]+)*)\)$'; then
+  # Check for PR suffix using native bash regex to avoid spawning grep
+  local pr_regex='\((#[0-9]+(,[[:space:]]*#[0-9]+)*)\)$'
+  if [[ "$note" =~ $pr_regex ]]; then
     CHANGELOG_NOTES+="- $note"$'\n'
   elif [ -n "$PR_SUFFIX" ]; then
     CHANGELOG_NOTES+="- $note $PR_SUFFIX"$'\n'
@@ -91,7 +95,7 @@ while read -r sha; do
 
   current_note=""
   while read -r line; do
-    line=$(echo "$line" | sed -E 's/\r$//')
+    line="${line%$'\r'}"
     
     if [[ "$line" =~ ^[Rr]elnotes?:[[:space:]]*(.*) ]]; then
       next_note="${BASH_REMATCH[1]}"


### PR DESCRIPTION
# Description
1. Fixes a bug in `scripts/changelog.sh` where nested regex matches in `process_note` would overwrite the global `BASH_REMATCH` array before the outer loop could extract the captured group. This caused the script to lose the original PR numbers on wrapped lines, falling back to appending the squash merge's PR suffix to all of them. Also includes support for multiple comma-separated PR numbers in a single note.
2. Fixes an issue in `scripts/publish.sh` where prerelease publishing (e.g. running with `--prerelease`) would fail if `rc.0` was already published on npm for that target version series, since it always bumped from the stable version. It now dynamically checks npm for any existing prerelease versions of the target version series, and performs a `prerelease` increment (e.g., to `rc.1`) if one exists.

# Release Notes
relnote: none
