### PR TITLE
Adding lifecycle events in docgen

### DIFF
--- a/src/v2/index.doc.ts
+++ b/src/v2/index.doc.ts
@@ -18,3 +18,6 @@ export * from "./index";
 // Explicitly export the hidden dataconnect module wrapper for documentation generation
 // This shadows the `dataconnect` export from `./index`.
 export * as dataconnect from "./dataconnect.doc";
+
+// Explicitly export the lifecycle module for documentation generation
+export * as lifecycle from "../lifecycle";


### PR DESCRIPTION
In PR #1926, afterFirstDeploy and afterRedeploy were moved from top-level v2/index.ts exports to deep import paths (firebase-functions/v2/lifecycle), causing api-extractor to stop discovering them during documentation extraction. This PR explicitly exports lifecycle in the documentation-only entrypoint (src/v2/index.doc.ts) so afterFirstDeploy(), afterRedeploy(), and their action types (LifecycleAction, TaskAction, CallAction, HttpAction) show up cleanly on the DevSite 2nd Gen API reference.

relnote: Bringing in lifecycle triggers into docgen.