### PR TITLE
fix: rename task timeout kind and also apply it to scheduler

### DIFF
--- a/spec/v2/options.spec.ts
+++ b/spec/v2/options.spec.ts
@@ -108,14 +108,16 @@ describe("assertTimeoutSecondsValid", () => {
   it("is a no-op when timeoutSeconds is undefined", () => {
     expect(() => assertTimeoutSecondsValid({}, "event")).to.not.throw();
     expect(() => assertTimeoutSecondsValid({}, "https")).to.not.throw();
-    expect(() => assertTimeoutSecondsValid({}, "task")).to.not.throw();
+    expect(() => assertTimeoutSecondsValid({}, "scheduledOrTask")).to.not.throw();
     expect(() => assertTimeoutSecondsValid({}, "identity")).to.not.throw();
   });
 
   it("accepts values within each kind's limit", () => {
     expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 540 }, "event")).to.not.throw();
     expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 3600 }, "https")).to.not.throw();
-    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1800 }, "task")).to.not.throw();
+    expect(() =>
+      assertTimeoutSecondsValid({ timeoutSeconds: 1800 }, "scheduledOrTask")
+    ).to.not.throw();
     expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 0 }, "event")).to.not.throw();
     expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1 }, "event")).to.not.throw();
     expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 7 }, "identity")).to.not.throw();
@@ -133,9 +135,9 @@ describe("assertTimeoutSecondsValid", () => {
     );
   });
 
-  it("throws when timeoutSeconds exceeds the task-queue limit", () => {
-    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1801 }, "task")).to.throw(
-      /between 0 and 1800 for task queue functions/
+  it("throws when timeoutSeconds exceeds the scheduled/task-queue limit", () => {
+    expect(() => assertTimeoutSecondsValid({ timeoutSeconds: 1801 }, "scheduledOrTask")).to.throw(
+      /between 0 and 1800 for scheduled or task queue functions/
     );
   });
 
@@ -188,7 +190,7 @@ describe("assertTimeoutSecondsValid", () => {
       /between 0 and 540 for event-handling functions/
     );
     expect(() => assertTimeoutSecondsValid({}, "https")).to.not.throw();
-    expect(() => assertTimeoutSecondsValid({}, "task")).to.throw();
+    expect(() => assertTimeoutSecondsValid({}, "scheduledOrTask")).to.throw();
     expect(() => assertTimeoutSecondsValid({}, "identity")).to.throw();
   });
 
@@ -223,7 +225,7 @@ describe("optionsToEndpoint timeout validation", () => {
     expect(() => optionsToEndpoint({ timeoutSeconds: 3601 }, "https")).to.throw(
       /between 0 and 3600/
     );
-    expect(() => optionsToEndpoint({ timeoutSeconds: 1801 }, "task")).to.throw(
+    expect(() => optionsToEndpoint({ timeoutSeconds: 1801 }, "scheduledOrTask")).to.throw(
       /between 0 and 1800/
     );
     expect(() => optionsToEndpoint({ timeoutSeconds: 8 }, "identity")).to.throw(/between 0 and 7/);
@@ -232,7 +234,7 @@ describe("optionsToEndpoint timeout validation", () => {
   it("is a no-op for in-range timeouts when kind is provided", () => {
     expect(() => optionsToEndpoint({ timeoutSeconds: 540 }, "event")).to.not.throw();
     expect(() => optionsToEndpoint({ timeoutSeconds: 3600 }, "https")).to.not.throw();
-    expect(() => optionsToEndpoint({ timeoutSeconds: 1800 }, "task")).to.not.throw();
+    expect(() => optionsToEndpoint({ timeoutSeconds: 1800 }, "scheduledOrTask")).to.not.throw();
     expect(() => optionsToEndpoint({ timeoutSeconds: 7 }, "identity")).to.not.throw();
   });
 });
@@ -253,7 +255,7 @@ describe("optionsToTriggerAnnotations timeout validation", () => {
     expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 3601 }, "https")).to.throw(
       /between 0 and 3600/
     );
-    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 1801 }, "task")).to.throw(
+    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 1801 }, "scheduledOrTask")).to.throw(
       /between 0 and 1800/
     );
     expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 8 }, "identity")).to.throw(
@@ -264,7 +266,9 @@ describe("optionsToTriggerAnnotations timeout validation", () => {
   it("is a no-op for in-range timeouts when kind is provided", () => {
     expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 540 }, "event")).to.not.throw();
     expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 3600 }, "https")).to.not.throw();
-    expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 1800 }, "task")).to.not.throw();
+    expect(() =>
+      optionsToTriggerAnnotations({ timeoutSeconds: 1800 }, "scheduledOrTask")
+    ).to.not.throw();
     expect(() => optionsToTriggerAnnotations({ timeoutSeconds: 7 }, "identity")).to.not.throw();
   });
 });

--- a/spec/v2/providers/scheduler.spec.ts
+++ b/spec/v2/providers/scheduler.spec.ts
@@ -146,6 +146,21 @@ describe("schedule", () => {
       ]);
     });
 
+    it("should accept timeoutSeconds up to the 1800s scheduled-function limit", () => {
+      const schfn = schedule.onSchedule(
+        { schedule: "* * * * *", timeoutSeconds: 1800 },
+        () => undefined
+      );
+
+      expect(schfn.__endpoint.timeoutSeconds).to.eq(1800);
+    });
+
+    it("should reject timeoutSeconds above the 1800s scheduled-function limit", () => {
+      expect(() =>
+        schedule.onSchedule({ schedule: "* * * * *", timeoutSeconds: 1801 }, () => undefined)
+      ).to.throw(/between 0 and 1800 for scheduled or task queue functions/);
+    });
+
     it("should create a schedule function with preserveExternalChanges", () => {
       const schfn = schedule.onSchedule(
         {

--- a/spec/v2/providers/tasks.spec.ts
+++ b/spec/v2/providers/tasks.spec.ts
@@ -326,7 +326,7 @@ describe("onTaskDispatched", () => {
 
   it("rejects timeoutSeconds above the 1800s task-queue limit", () => {
     expect(() => onTaskDispatched({ timeoutSeconds: 1801 }, () => null)).to.throw(
-      /between 0 and 1800 for task queue functions/
+      /between 0 and 1800 for scheduled or task queue functions/
     );
   });
 

--- a/spec/v2/providers/timeout.spec.ts
+++ b/spec/v2/providers/timeout.spec.ts
@@ -67,7 +67,7 @@ describe("v2 provider timeout validation", () => {
     {
       name: "tasks.onTaskDispatched rejects task timeouts above 1800s",
       build: () => tasks.onTaskDispatched({ timeoutSeconds: 1801 }, () => null),
-      expectedError: /between 0 and 1800 for task queue functions/,
+      expectedError: /between 0 and 1800 for scheduled or task queue functions/,
     },
     {
       name: "pubsub.onMessagePublished rejects event timeouts above 540s",
@@ -112,10 +112,10 @@ describe("v2 provider timeout validation", () => {
       expectedError: /between 0 and 540 for event-handling functions/,
     },
     {
-      name: "scheduler.onSchedule rejects event timeouts above 540s",
+      name: "scheduler.onSchedule rejects schedule timeouts above 1800s",
       build: () =>
-        scheduler.onSchedule({ schedule: "* * * * *", timeoutSeconds: 3600 }, () => null),
-      expectedError: /between 0 and 540 for event-handling functions/,
+        scheduler.onSchedule({ schedule: "* * * * *", timeoutSeconds: 1801 }, () => null),
+      expectedError: /between 0 and 1800 for scheduled or task queue functions/,
     },
     {
       name: "testLab.onTestMatrixCompleted rejects event timeouts above 540s",

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -44,7 +44,7 @@ export { RESET_VALUE } from "../common/options";
 
 /**
  * Maximum timeout in seconds for event-handling functions (e.g. Firestore,
- * Realtime Database, Pub/Sub, Storage, Eventarc, alerts, scheduler).
+ * Realtime Database, Pub/Sub, Storage, Eventarc, alerts).
  * See https://firebase.google.com/docs/functions/manage-functions
  * @internal
  */
@@ -57,10 +57,10 @@ export const MAX_EVENT_TIMEOUT_SECONDS = 540;
 export const MAX_HTTPS_TIMEOUT_SECONDS = 3600;
 
 /**
- * Maximum timeout in seconds for Task Queue functions.
+ * Maximum timeout in seconds for scheduled and Task Queue functions.
  * @internal
  */
-export const MAX_TASK_TIMEOUT_SECONDS = 1800;
+export const MAX_SCHEDULE_OR_TASK_TIMEOUT_SECONDS = 1800;
 
 /**
  * Maximum timeout in seconds for Identity blocking functions.
@@ -72,7 +72,7 @@ export const MAX_IDENTITY_TIMEOUT_SECONDS = 7;
  * Function category used to pick a `timeoutSeconds` upper bound.
  * @internal
  */
-export type TimeoutKind = "event" | "https" | "task" | "identity";
+export type TimeoutKind = "event" | "https" | "scheduledOrTask" | "identity";
 
 /**
  * List of all regions supported by Cloud Functions (2nd gen).
@@ -412,9 +412,9 @@ export function assertTimeoutSecondsValid(
       max = MAX_HTTPS_TIMEOUT_SECONDS;
       label = "HTTPS and callable";
       break;
-    case "task":
-      max = MAX_TASK_TIMEOUT_SECONDS;
-      label = "task queue";
+    case "scheduledOrTask":
+      max = MAX_SCHEDULE_OR_TASK_TIMEOUT_SECONDS;
+      label = "scheduled or task queue";
       break;
     case "identity":
       max = MAX_IDENTITY_TIMEOUT_SECONDS;

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -60,7 +60,7 @@ export const MAX_HTTPS_TIMEOUT_SECONDS = 3600;
  * Maximum timeout in seconds for scheduled and Task Queue functions.
  * @internal
  */
-export const MAX_SCHEDULE_OR_TASK_TIMEOUT_SECONDS = 1800;
+export const MAX_SCHEDULED_OR_TASK_TIMEOUT_SECONDS = 1800;
 
 /**
  * Maximum timeout in seconds for Identity blocking functions.
@@ -199,7 +199,7 @@ export interface GlobalOptions {
    * The maximum timeout for a function depends on the type of function:
    * Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
-   * maximum timeout of 3,600s (1 hour). Task queue functions have a maximum
+   * maximum timeout of 3,600s (1 hour). Task queue and scheduled functions have a maximum
    * timeout of 1,800s (30 minutes).
    */
   timeoutSeconds?: number | Expression<number> | ResetValue;
@@ -413,7 +413,7 @@ export function assertTimeoutSecondsValid(
       label = "HTTPS and callable";
       break;
     case "scheduledOrTask":
-      max = MAX_SCHEDULE_OR_TASK_TIMEOUT_SECONDS;
+      max = MAX_SCHEDULED_OR_TASK_TIMEOUT_SECONDS;
       label = "scheduled or task queue";
       break;
     case "identity":

--- a/src/v2/providers/scheduler.ts
+++ b/src/v2/providers/scheduler.ts
@@ -225,7 +225,7 @@ export function onSchedule(
 
   const globalOpts = options.getGlobalOptions();
   const baseOptsEndpoint = options.optionsToEndpoint(globalOpts);
-  const specificOptsEndpoint = options.optionsToEndpoint(separatedOpts.opts, "event");
+  const specificOptsEndpoint = options.optionsToEndpoint(separatedOpts.opts, "scheduledOrTask");
 
   const ep: ManifestEndpoint = {
     ...initV2Endpoint(globalOpts, separatedOpts.opts),

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -241,7 +241,7 @@ export function onTaskDispatched<Args = any>(
       const baseOpts = options.optionsToTriggerAnnotations(options.getGlobalOptions());
       // global options calls region a scalar and https allows it to be an array,
       // but optionsToTriggerAnnotations handles both cases.
-      const specificOpts = options.optionsToTriggerAnnotations(opts, "task");
+      const specificOpts = options.optionsToTriggerAnnotations(opts, "scheduledOrTask");
       const taskQueueTrigger: Record<string, unknown> = {};
       copyIfPresent(taskQueueTrigger, opts, "retryConfig", "rateLimits");
       convertIfPresent(
@@ -268,7 +268,7 @@ export function onTaskDispatched<Args = any>(
   const baseOpts = options.optionsToEndpoint(options.getGlobalOptions());
   // global options calls region a scalar and https allows it to be an array,
   // but optionsToManifestEndpoint handles both cases.
-  const specificOpts = options.optionsToEndpoint(opts, "task");
+  const specificOpts = options.optionsToEndpoint(opts, "scheduledOrTask");
 
   func.__endpoint = {
     platform: "gcfv2",

--- a/src/v2/providers/tasks.ts
+++ b/src/v2/providers/tasks.ts
@@ -85,7 +85,7 @@ export interface TaskQueueOptions extends options.EventHandlerOptions {
    * The minimum timeout for a gen 2 function is 1s. The maximum timeout for a
    * function depends on the type of function: Event handling functions have a
    * maximum timeout of 540s (9 minutes). HTTPS and callable functions have a
-   * maximum timeout of 3,600s (1 hour). Task queue functions have a maximum
+   * maximum timeout of 3,600s (1 hour). Task queue and scheduled functions have a maximum
    * timeout of 1,800s (30 minutes)
    */
   timeoutSeconds?: number | Expression<number> | ResetValue;


### PR DESCRIPTION
Fixes #1933 

This PR renames the "task" timeout kind to "scheduledOrTask" and ensures that both task and scheduler functions use this. The documentation states that task and scheduler functions should have the same timeout settings, but scheduler functions were falling back to a generic "event" timeout kind.

## Testing
- Verified that the changes fix the example as described in the issue.
- Automated tests pass

relnote: none