### PR TITLE
feat: default npm distribution tag to next for prereleases

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,7 +19,7 @@ show_usage() {
   echo "  --branch <name>           The Git branch to check out (defaults to cloned HEAD)"
   echo "  --org <name>              GitHub Organization override (defaults to 'firebase')"
   echo "  --repository <name>       GitHub Repository override (defaults to 'firebase-functions')"
-  echo "  --dist-tag <tag>          The npm distribution tag (defaults to 'latest')"
+  echo "  --dist-tag <tag>          The npm distribution tag (defaults to 'next' if --prerelease, otherwise 'latest')"
   echo "  --project <project>       The GCP project used to run the deploy pipeline"
   exit 1
 }
@@ -44,7 +44,7 @@ FORCE_RELEASE=false
 TARGET_BRANCH=""
 ORG="firebase"
 REPO="firebase-functions"
-DIST_TAG="latest"
+DIST_TAG=""
 TARGET_PROJECT="firebase-functions-publishing"
 
 # Parse optional arguments
@@ -91,6 +91,15 @@ while [ "$#" -gt 0 ]; do
       ;;
   esac
 done
+
+# Default distribution tag based on prerelease mode if not explicitly supplied
+if [ -z "$DIST_TAG" ]; then
+  if [ "$IS_PRERELEASE" = true ]; then
+    DIST_TAG="next"
+  else
+    DIST_TAG="latest"
+  fi
+fi
 
 # ==============================================================================
 # MODE A: LOCAL ORCHESTRATOR MODE (Runs on your machine)
@@ -258,9 +267,16 @@ fi
 # 7. NPM Publish Execution
 if [ "$DRY_RUN" = true ]; then
   echo "🔍 [Dry Run] Skipping npm publish --tag $DIST_TAG"
+  if [ "$IS_PRERELEASE" = false ] && [ "$DIST_TAG" = "latest" ]; then
+    echo "🔍 [Dry Run] Skipping npm dist-tag add ${PACKAGE_NAME}@${NEXT_VERSION} next"
+  fi
   echo "🏁 Dry run completed successfully! No modifications were made to remote systems."
 else
   echo "Publishing package to npm under tag: $DIST_TAG..."
   npm publish --tag "$DIST_TAG"
+  if [ "$IS_PRERELEASE" = false ] && [ "$DIST_TAG" = "latest" ]; then
+    echo "Updating 'next' dist-tag to point to ${PACKAGE_NAME}@${NEXT_VERSION}..."
+    npm dist-tag add "${PACKAGE_NAME}@${NEXT_VERSION}" next
+  fi
   echo "🚀 Release of $PACKAGE_NAME@$NEXT_VERSION successfully completed!"
 fi

--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -54,7 +54,7 @@ steps:
           $([ -n "${_BRANCH}" ] && echo "--branch ${_BRANCH}") \
           --org=${_REPOSITORY_ORG} \
           --repository=${_REPOSITORY_NAME} \
-          ${_DIST_TAG}
+          $([ -n "${_DIST_TAG}" ] && echo "--dist-tag ${_DIST_TAG}")
     secretEnv: ["GITHUB_TOKEN", "NPMRC_CONTENT"]
 
 options:
@@ -67,7 +67,7 @@ substitutions:
   _PRERELEASE: "false"
   _DRY_RUN: "true"
   _FORCE: "false"
-  _DIST_TAG: "latest"
+  _DIST_TAG: ""
   _REPOSITORY_ORG: "firebase"
   _REPOSITORY_NAME: "firebase-functions"
   _BRANCH: ""


### PR DESCRIPTION
### Description
Updates `publish.sh` and `cloudbuild.yaml` so that:
1. The default npm distribution tag is dynamically evaluated as `next` when `--prerelease` is specified, and `latest` otherwise (unless explicitly overridden via `--dist-tag`).
2. When publishing a stable release under `latest`, `npm dist-tag add <pkg>@<version> next` is also run to update the `next` tag to point to the new stable version so that `@next` never lags behind `@latest`.

relnote: Fix an issue with npm labeling in the deployment pipeline.

### Scenarios Tested
- Tested `./scripts/publish.sh patch` -> Defaults to `NPM Tag: latest` and updates `next` dist-tag.
- Tested `./scripts/publish.sh patch --prerelease` -> Defaults to `NPM Tag: next`.
- Tested `./scripts/publish.sh patch --prerelease --dist-tag customTag` -> Keeps `NPM Tag: customTag`.

### Sample Commands
`./scripts/publish.sh patch --prerelease`