### PR TITLE
chore: add .editorconfig with standard defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig â€” https://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{js,jsx,ts,tsx,json,yml,yaml,html,css,scss}]
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab
+


### PR DESCRIPTION
Adds a top-level `.editorconfig` so contributors on different editors get consistent indentation, line endings, and trailing-whitespace handling out of the box.

No effect on existing files â€” EditorConfig is only applied by editors that support it (which is most of them these days).