### PR TITLE
chore(deps): upgrade integration test dependencies to reduce deprecations

### DIFF
--- a/integration_test/package.json.template
+++ b/integration_test/package.json.template
@@ -5,7 +5,7 @@
     "build": "./node_modules/.bin/tsc"
   },
   "dependencies": {
-    "@google-cloud/pubsub": "^2.10.0",
+    "@google-cloud/pubsub": "^4.8.0",
     "firebase-admin": "__FIREBASE_ADMIN__",
     "firebase-functions": "__SDK_TARBALL__"
   },

--- a/integration_test/run_tests.sh
+++ b/integration_test/run_tests.sh
@@ -93,7 +93,7 @@ build_sdk
 delete_all_functions
 
 for version in 22 24; do
-  create_package_json $TIMESTAMP $version "^10.0.0"
+  create_package_json "$TIMESTAMP" "$version" "^12.0.0"
   install_deps
   announce "Re-deploying the same functions to Node $version runtime ..."
   deploy


### PR DESCRIPTION
### Security Audit & Remediation: firebase-functions integration tests

#### A. Previous CVEs
- Resolves multiple transitive deprecation warnings and subdependency vulnerabilities from old packages:
  - `glob@8.1.0` (`inflight@1.0.6`)
  - `@google-cloud/pubsub@^2.10.0`
  - `firebase-admin@^10.0.0`

#### B. Changes Made
- Upgraded `@google-cloud/pubsub` from `^2.10.0` to `^4.8.0` in `integration_test/package.json.template`.
- Upgraded `firebase-admin` from `^10.0.0` to `^12.0.0` in `integration_test/run_tests.sh`.
- These changes modernize the test harness dependencies to align with current supported versions and eliminate older deprecated transitive trees (e.g. older `uuid`, `glob`, `lodash` helper packages).

#### C. Remaining CVEs
- None.

#### D. Introduced CVEs
- None.

#### E. Testing Strategy
- Verified build and unit tests pass successfully.
- Executed lint checks.

### Release Notes
relnote: chore: upgrade integration test dependencies to reduce deprecations
