### PR TITLE
fix: avoid CORS declaration interop requirement

### DIFF
--- a/scripts/packaging-test/index.ts
+++ b/scripts/packaging-test/index.ts
@@ -1,0 +1,3 @@
+import { onCall } from "firebase-functions/v2/https";
+
+onCall({ cors: true }, () => null);

--- a/scripts/packaging-test/tsconfig.json
+++ b/scripts/packaging-test/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "noEmit": true,
+    "strict": true,
+    "target": "es2022"
+  },
+  "files": ["index.ts"]
+}

--- a/scripts/test-packaging.sh
+++ b/scripts/test-packaging.sh
@@ -38,10 +38,16 @@ fi
 echo "Setting up test project in $WORK_DIR..."
 pushd "$WORK_DIR" > /dev/null
 npm init -y > /dev/null
-npm install "$TARBALL_PATH"
+TYPESCRIPT_VERSION=$(node -p "require(process.argv[1]).devDependencies.typescript" "$SCRIPT_DIR/../package.json")
+npm install "$TARBALL_PATH" "typescript@$TYPESCRIPT_VERSION"
 
 echo "Running verification script..."
 cp "$SCRIPT_DIR/verify-exports.mjs" .
 node verify-exports.mjs
+
+echo "Verifying TypeScript declarations without esModuleInterop..."
+cp "$SCRIPT_DIR/packaging-test/index.ts" .
+cp "$SCRIPT_DIR/packaging-test/tsconfig.json" .
+./node_modules/.bin/tsc --project tsconfig.json
 
 popd > /dev/null

--- a/src/common/providers/https.ts
+++ b/src/common/providers/https.ts
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import cors from "cors";
+import * as cors from "cors";
 import * as express from "express";
 import { DecodedAppCheckToken } from "firebase-admin/app-check";
 
@@ -796,7 +796,7 @@ export function onCallHandler<Req = any, Res = any, Stream = unknown>(
         ...options.cors,
         origin,
       };
-      cors(corsOptions as cors.CorsOptions)(req, res, () => {
+      cors.default(corsOptions)(req, res, () => {
         resolve(wrapped(req, res));
       });
     });


### PR DESCRIPTION
### Description

`@types/cors` declares the package with `export =`. PR #1903 added exported CORS types that caused TypeScript to preserve the source default import in `lib/common/providers/https.d.ts`.

Default-importing an `export =` module in a published declaration forces consumers to enable `esModuleInterop`. Use a namespace import instead so that compiler-option requirement does not leak into consumer projects. The explicit `.default` invocation preserves the existing runtime behavior with the repository's current TypeScript and tsdown configuration.

This fixes the declaration regression visible in `firebase-functions@7.3.0`.

The packaging test now compiles a real packed consumer without `esModuleInterop` to prevent regressions.
