### PR TITLE
fix(firestore): fallback to valid resource path in createSnapshotFromJson

### DIFF
--- a/spec/v2/providers/firestore.spec.ts
+++ b/spec/v2/providers/firestore.spec.ts
@@ -872,6 +872,17 @@ describe("firestore", () => {
 
       expect(snapshot.data()).to.deep.eq({ hello: "a new world" });
     });
+
+    it("should create snapshot with correct path even if value is missing and source is database URL", () => {
+      const rawEvent: firestore.RawFirestoreEvent = makeEvent(deletedData);
+      rawEvent.datacontenttype = "application/json";
+      rawEvent.source = "//firestore.googleapis.com/projects/my-project/databases/my-db";
+
+      const snapshot = firestore.createSnapshot(rawEvent);
+
+      expect(snapshot.exists).to.be.false;
+      expect(snapshot.ref.path).to.eq("foo/fGRodw71mHutZ4wGDuT8");
+    });
   });
 
   describe("createBeforeSnapshot", () => {
@@ -933,6 +944,17 @@ describe("firestore", () => {
       const snapshot = firestore.createBeforeSnapshot(rawEvent);
 
       expect(snapshot.data()).to.deep.eq({});
+    });
+
+    it("should create before snapshot with correct path even if oldValue is missing and source is database URL", () => {
+      const rawEvent: firestore.RawFirestoreEvent = makeEvent(createdData);
+      rawEvent.datacontenttype = "application/json";
+      rawEvent.source = "//firestore.googleapis.com/projects/my-project/databases/my-db";
+
+      const snapshot = firestore.createBeforeSnapshot(rawEvent);
+
+      expect(snapshot.exists).to.be.false;
+      expect(snapshot.ref.path).to.eq("foo/fGRodw71mHutZ4wGDuT8");
     });
   });
 

--- a/src/common/providers/firestore.ts
+++ b/src/common/providers/firestore.ts
@@ -29,7 +29,10 @@ import { dateToTimestampProto } from "../../common/utilities/encoder";
 /** static-complied protobufs */
 const DocumentEventData = google.events.cloud.firestore.v1.DocumentEventData;
 
-let firestoreInstance: any;
+/** @internal */
+interface Firestore extends firestore.Firestore {
+  snapshot_(value: unknown, readTime: unknown, encoding: string): any;
+}
 
 /**
  * Helper to construct a value protobuf or return the document resource path.
@@ -63,9 +66,7 @@ function _getValueProto(data: any, resource: string, valueFieldName: string) {
 
 /** @internal */
 export function createSnapshotFromProtobuf(data: Uint8Array, path: string, databaseId: string) {
-  if (!firestoreInstance) {
-    firestoreInstance = firestore.getFirestore(getApp(), databaseId);
-  }
+  const firestoreInstance = firestore.getFirestore(getApp(), databaseId) as Firestore;
   try {
     const dataBuffer = Buffer.from(data);
     const firestoreDecoded = DocumentEventData.decode(dataBuffer);
@@ -83,9 +84,7 @@ export function createBeforeSnapshotFromProtobuf(
   path: string,
   databaseId: string
 ) {
-  if (!firestoreInstance) {
-    firestoreInstance = firestore.getFirestore(getApp(), databaseId);
-  }
+  const firestoreInstance = firestore.getFirestore(getApp(), databaseId) as Firestore;
   try {
     const dataBuffer = Buffer.from(data);
     const firestoreDecoded = DocumentEventData.decode(dataBuffer);
@@ -105,11 +104,9 @@ export function createSnapshotFromJson(
   updateTime: string | undefined,
   databaseId?: string
 ) {
-  if (!firestoreInstance) {
-    firestoreInstance = databaseId
-      ? firestore.getFirestore(getApp(), databaseId)
-      : firestore.getFirestore(getApp());
-  }
+  const firestoreInstance = (
+    databaseId ? firestore.getFirestore(getApp(), databaseId) : firestore.getFirestore(getApp())
+  ) as Firestore;
   const valueProto = _getValueProto(data, path, "value");
   let timeString = createTime || updateTime;
 
@@ -130,11 +127,9 @@ export function createBeforeSnapshotFromJson(
   updateTime: string | undefined,
   databaseId?: string
 ) {
-  if (!firestoreInstance) {
-    firestoreInstance = databaseId
-      ? firestore.getFirestore(getApp(), databaseId)
-      : firestore.getFirestore(getApp());
-  }
+  const firestoreInstance = (
+    databaseId ? firestore.getFirestore(getApp(), databaseId) : firestore.getFirestore(getApp())
+  ) as Firestore;
 
   const oldValueProto = _getValueProto(data, path, "oldValue");
   const oldReadTime = dateToTimestampProto(createTime || updateTime);

--- a/src/common/providers/firestore.ts
+++ b/src/common/providers/firestore.ts
@@ -31,7 +31,17 @@ const DocumentEventData = google.events.cloud.firestore.v1.DocumentEventData;
 
 let firestoreInstance: any;
 
-/** @hidden */
+/**
+ * Helper to construct a value protobuf or return the document resource path.
+ *
+ * @param data - The Firestore event data payload.
+ * @param resource - The slash-separated document resource path (e.g.
+ * `projects/{project}/databases/{database}/documents/{document_path}`). This is used as the fallback
+ * when the document name or data is not present in the payload (e.g., for non-existent/deleted snapshots).
+ * @param valueFieldName - The key in `data` to extract the document fields from ('value' or 'oldValue').
+ * @returns A protobuf-like object representing the document, or the fallback resource path string.
+ * @hidden
+ */
 function _getValueProto(data: any, resource: string, valueFieldName: string) {
   const value = data?.[valueFieldName];
   if (
@@ -90,7 +100,7 @@ export function createBeforeSnapshotFromProtobuf(
 /** @internal */
 export function createSnapshotFromJson(
   data: any,
-  source: string,
+  path: string,
   createTime: string | undefined,
   updateTime: string | undefined,
   databaseId?: string
@@ -100,7 +110,7 @@ export function createSnapshotFromJson(
       ? firestore.getFirestore(getApp(), databaseId)
       : firestore.getFirestore(getApp());
   }
-  const valueProto = _getValueProto(data, source, "value");
+  const valueProto = _getValueProto(data, path, "value");
   let timeString = createTime || updateTime;
 
   if (!timeString) {
@@ -115,7 +125,7 @@ export function createSnapshotFromJson(
 /** @internal */
 export function createBeforeSnapshotFromJson(
   data: any,
-  source: string,
+  path: string,
   createTime: string | undefined,
   updateTime: string | undefined,
   databaseId?: string
@@ -126,7 +136,7 @@ export function createBeforeSnapshotFromJson(
       : firestore.getFirestore(getApp());
   }
 
-  const oldValueProto = _getValueProto(data, source, "oldValue");
+  const oldValueProto = _getValueProto(data, path, "oldValue");
   const oldReadTime = dateToTimestampProto(createTime || updateTime);
   return firestoreInstance.snapshot_(oldValueProto, oldReadTime, "json");
 }

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -778,7 +778,7 @@ export function createSnapshot(event: RawFirestoreEvent): QueryDocumentSnapshot 
   } else if (event.datacontenttype?.includes("application/json")) {
     return createSnapshotFromJson(
       event.data,
-      event.source,
+      getPath(event),
       (event.data as RawFirestoreData).value?.createTime,
       (event.data as RawFirestoreData).value?.updateTime,
       event.database
@@ -802,7 +802,7 @@ export function createBeforeSnapshot(event: RawFirestoreEvent): QueryDocumentSna
   } else if (event.datacontenttype?.includes("application/json")) {
     return createBeforeSnapshotFromJson(
       event.data,
-      event.source,
+      getPath(event),
       (event.data as RawFirestoreData).oldValue?.createTime,
       (event.data as RawFirestoreData).oldValue?.updateTime,
       event.database

--- a/src/v2/providers/firestore.ts
+++ b/src/v2/providers/firestore.ts
@@ -779,8 +779,8 @@ export function createSnapshot(event: RawFirestoreEvent): QueryDocumentSnapshot 
     return createSnapshotFromJson(
       event.data,
       getPath(event),
-      (event.data as RawFirestoreData).value?.createTime,
-      (event.data as RawFirestoreData).value?.updateTime,
+      (event.data as RawFirestoreData)?.value?.createTime,
+      (event.data as RawFirestoreData)?.value?.updateTime,
       event.database
     );
   } else {
@@ -803,8 +803,8 @@ export function createBeforeSnapshot(event: RawFirestoreEvent): QueryDocumentSna
     return createBeforeSnapshotFromJson(
       event.data,
       getPath(event),
-      (event.data as RawFirestoreData).oldValue?.createTime,
-      (event.data as RawFirestoreData).oldValue?.updateTime,
+      (event.data as RawFirestoreData)?.oldValue?.createTime,
+      (event.data as RawFirestoreData)?.oldValue?.updateTime,
       event.database
     );
   } else {


### PR DESCRIPTION
### Description

If the document payload is missing the `name` field (e.g., during an `onDocumentDeleted` trigger where the "after" snapshot payload is intentionally absent), `createSnapshotFromJson` construct a mocked snapshot and defaults the resource path to the `event.source`.

However, the `event.source` for Firestore CloudEvents is typically just the database prefix (e.g. `//cloudevents.googleapis.com/projects/YOUR_PROJECT/databases/(default)`), which is an invalid Firestore document resource path as it lacks the `documents/DOC_ID` suffix. Falling back to this caused `Firestore#snapshot_` to crash with invalid resource path errors in various edge cases (such as PubSub fallbacks).

This commit updates the fallback to use `getPath(event)` instead, synthesizing a valid `projects/{project}/databases/{database}/documents/{document}` resource path to correctly mock the snapshot.

Also removes our cache of the Firestore instance to rely instead on the better (per db) cache inside of Admin SDK.

Partially addresses #1922 

### Scenarios Tested

npm test
firebase deploy --only functions (with a bug repro case)

### Release notes

relnote: fix(firestore): fallback to valid resource path in createSnapshotFromJson (#1922)
