### PR TITLE
fix(logger): do not synthesize error stack on console.error in logger…

### DIFF
--- a/spec/logger.spec.ts
+++ b/spec/logger.spec.ts
@@ -263,14 +263,6 @@ describe("logger", () => {
       });
     });
 
-    it("should patch console.info with INFO severity", () => {
-      console.info("test info log");
-      expectStdout({
-        severity: "INFO",
-        message: "test info log",
-      });
-    });
-
     it("should patch console.debug with DEBUG severity", () => {
       console.debug("test debug log");
       expectStdout({

--- a/spec/logger.spec.ts
+++ b/spec/logger.spec.ts
@@ -218,4 +218,100 @@ describe("logger", () => {
       });
     });
   });
+
+  describe("compat", () => {
+    const originalConsole = {
+      debug: console.debug,
+      info: console.info,
+      log: console.log,
+      warn: console.warn,
+      error: console.error,
+    };
+
+    before(async () => {
+      // Patch global console methods
+      await import("../src/logger/compat");
+    });
+
+    beforeEach(() => {
+      lastOut = "";
+      lastErr = "";
+    });
+
+    after(() => {
+      // Restore original console methods so other tests remain unaffected
+      console.debug = originalConsole.debug;
+      console.info = originalConsole.info;
+      console.log = originalConsole.log;
+      console.warn = originalConsole.warn;
+      console.error = originalConsole.error;
+    });
+
+    it("should patch console.log with INFO severity", () => {
+      console.log("test info log");
+      expectStdout({
+        severity: "INFO",
+        message: "test info log",
+      });
+    });
+
+    it("should patch console.log with no arguments", () => {
+      console.log();
+      expectStdout({
+        severity: "INFO",
+        message: "",
+      });
+    });
+
+    it("should patch console.info with INFO severity", () => {
+      console.info("test info log");
+      expectStdout({
+        severity: "INFO",
+        message: "test info log",
+      });
+    });
+
+    it("should patch console.debug with DEBUG severity", () => {
+      console.debug("test debug log");
+      expectStdout({
+        severity: "DEBUG",
+        message: "test debug log",
+      });
+    });
+
+    it("should patch console.warn with WARNING severity", () => {
+      console.warn("test warning log");
+      expectStderr({
+        severity: "WARNING",
+        message: "test warning log",
+      });
+    });
+
+    it("should patch console.error with ERROR severity without creating synthetic stack trace for string messages", () => {
+      // String error messages should not have synthetic Error stacks added (Issue #1945)
+      console.error("test error message");
+      expectStderr({
+        severity: "ERROR",
+        message: "test error message",
+      });
+    });
+
+    it("should patch console.error for Error objects preserving the original stack", () => {
+      // Error instances should retain their original stack trace without double wrapping
+      const err = new Error("real error");
+      console.error(err);
+      const parsed = JSON.parse(lastErr.trim()) as logger.LogEntry;
+      expect(parsed.severity).to.eq("ERROR");
+      expect(parsed.message).to.contain("Error: real error");
+      expect(parsed.message).to.not.contain("Error: Error: real error");
+    });
+
+    it("should format multiple arguments in console.error", () => {
+      console.error("failed with code %d: %s", 500, "internal error");
+      expectStderr({
+        severity: "ERROR",
+        message: "failed with code 500: internal error",
+      });
+    });
+  });
 });

--- a/src/logger/compat.ts
+++ b/src/logger/compat.ts
@@ -24,12 +24,14 @@ import { format } from "util";
 import { CONSOLE_SEVERITY, UNPATCHED_CONSOLE } from "./common";
 
 /** @hidden */
-function patchedConsole(severity: string): (data: any, ...args: any[]) => void {
-  return function (data: any, ...args: any[]): void {
-    let message = format(data, ...args);
-    if (severity === "ERROR") {
-      message = new Error(message).stack || message;
-    }
+function patchedConsole(severity: string): (...args: unknown[]) => void {
+  return function (...args: unknown[]): void {
+    // Format arguments matching standard Node console.* behavior.
+    // Unlike logger.error, we intentionally do NOT synthesize an Error stack for
+    // console.error so that Node.js runtime warnings (e.g. MaxListenersExceededWarning)
+    // and standard console.error string logs are not misclassified as unhandled exceptions
+    // in Cloud Error Reporting.
+    const message = format(...args);
 
     UNPATCHED_CONSOLE[CONSOLE_SEVERITY[severity]](JSON.stringify({ severity, message }));
   };


### PR DESCRIPTION
### Description

Fixes #1945

#### Background:
When users import `firebase-functions/logger/compat`, it monkeypatches global `console.*` methods to format logs into structured Cloud Logging JSON lines.

Previously, `patchedConsole("ERROR")` unconditionally created a synthetic `Error` stack for all `console.error` calls via `message = new Error(message).stack || message`.

This caused two problems:
1. **Benign Node.js runtime warnings escalated into false application crashes:** Node.js internal warning handlers (such as `MaxListenersExceededWarning` triggered when connection pooling with libraries like `axios`) print warnings via `console.error`. `logger/compat` intercepted these string warnings and attached a fake stack trace pointing to `patchedConsole` inside `compat.js`. Google Cloud Error Reporting then interpreted these harmless warnings as active application crashes in the function runtime.
2. **Error instance stack corruption:** When actual `Error` objects were passed to `console.error(err)`, `util.format(err)` already rendered the callsite stack trace. Wrapping it again in `new Error(message).stack` resulted in a distorted `Error: Error: ...` double-wrapped stack trace.

#### Changes:
1. **`src/logger/compat.ts`**: Removed `new Error(message).stack` wrapper from `patchedConsole`. String logs and Node runtime warnings to `console.error` are now output directly with `ERROR` severity without synthetic stack traces, while actual `Error` objects retain their authentic callsite stack.
2. **`spec/logger.spec.ts`**: Added a `describe("compat", ...)` test block covering `console.log`, `console.info`, `console.debug`, `console.warn`, and `console.error` (handling strings, formatted templates, and `Error` objects).

### Code sample

```typescript
require("firebase-functions/logger/compat");

// Output before:
// {"severity":"ERROR","message":"Error: (node:...) MaxListenersExceededWarning...\n    at patchedConsole (/compat.js:31:17)..."}

// Output after:
// {"severity":"ERROR","message":"(node:...) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 testEvent listeners added to [EventEmitter]..."}
```

### Release notes

relnote: Fixed an issue where `firebase-functions/logger/compat` added synthetic Error stack traces to string `console.error` calls and Node.js runtime warnings.
