### PR TITLE
export ai provider and fix docgen tags

### DIFF
--- a/src/v2/index.ts
+++ b/src/v2/index.ts
@@ -28,6 +28,7 @@
  * @packageDocumentation
  */
 
+import * as ai from "./providers/ai";
 import * as alerts from "./providers/alerts";
 import * as database from "./providers/database";
 import * as eventarc from "./providers/eventarc";
@@ -46,6 +47,7 @@ import * as dataconnect from "./providers/dataconnect";
 // To avoid forcing developers who import from the top-level firebase-functions namespace to install these dependencies,
 // we require developers who want to use the graphql provider to import directly from firebase-functions/dataconnect/graphql.
 export {
+  ai,
   alerts,
   database,
   storage,

--- a/src/v2/providers/ai/types/gemini/v1beta/index.ts
+++ b/src/v2/providers/ai/types/gemini/v1beta/index.ts
@@ -28,7 +28,7 @@ export declare interface BaseParams {
 /**
  * Fields common to all Schema types.
  *
- * @internal
+ * @public
  */
 export declare interface BaseSchema {
   /** Optional. Description of the value. */


### PR DESCRIPTION
### Description
Exports the `ai` provider in `src/v2/index.ts` and changes `BaseSchema` from `@internal` to `@public` so docgen can successfully generate reference docs for the AI module.
### Release notes
relnote: Exported `ai` provider from `firebase-functions/v2` and fixed reference doc generation.
