### PR TITLE
docs(ai): add missing JSDoc descriptions for AI provider tables and t…

### DIFF
--- a/src/v2/providers/ai/index.ts
+++ b/src/v2/providers/ai/index.ts
@@ -218,7 +218,7 @@ export interface AIBlockingEvent<T = any> extends CloudEvent<T> {
 type MaybeAsync<T> = T | Promise<T>;
 
 /**
- * A blocking function returned by AI event handlers.
+ * A Cloud Function that handles AI blocking events.
  */
 export type BlockingFunction = HttpsFunction;
 

--- a/src/v2/providers/ai/index.ts
+++ b/src/v2/providers/ai/index.ts
@@ -41,7 +41,7 @@ import * as logger from "../../../logger";
 export { HttpsError };
 
 /**
- * Mapping from FunctionsErrorCode strings to numeric RPC status codes.
+ * Mapping from `FunctionsErrorCode` strings to numeric RPC status codes.
  */
 export const rpcCodeMap: Record<FunctionsErrorCode, number> = {
   ok: 0,
@@ -91,7 +91,7 @@ type MultipleLocationsIf<Allowed extends boolean> = Allowed extends true ? strin
 export interface WebhookOptions<Regional extends boolean = false>
   extends Omit<EventHandlerOptions, "location"> {
   /**
-   * Region where functions should be deployed. Deployed to us-central1 by default.
+   * Region where functions should be deployed. Deployed to `us-central1` by default.
    */
   location?: string | Expression<string> | MultipleLocationsIf<Regional> | ResetValue;
   /**
@@ -109,16 +109,16 @@ export interface PromptTemplateInfo {
 }
 
 /**
- * Authentication state for the caller: "app_user", "unauthenticated", or "unknown".
+ * Authentication state for the caller: `"app_user"`, `"unauthenticated"`, or `"unknown"`.
  */
 export type AuthType = "app_user" | "unauthenticated" | "unknown";
 
 /**
- * Event type for beforeGenerate triggers.
+ * Event type for `beforeGenerate` triggers.
  */
 export const beforeGenerateEventType = "google.firebase.ailogic.v1.beforeGenerate";
 /**
- * Event type for afterGenerate triggers.
+ * Event type for `afterGenerate` triggers.
  */
 export const afterGenerateEventType = "google.firebase.ailogic.v1.afterGenerate";
 
@@ -136,11 +136,11 @@ export type AnyValidAIResponse =
   | VertexV1Beta1GenerateContentResponse;
 
 /**
- * Identifier for the Gemini Developer API (geminiV1Beta).
+ * Identifier for the Gemini Developer API (`geminiV1Beta`).
  */
 export const geminiV1Beta = "google.ai.generativelanguage.v1beta";
 /**
- * Identifier for the Agent Platform Gemini API (formerly Vertex AI) (vertexV1Beta1).
+ * Identifier for the Agent Platform Gemini API (formerly Vertex AI) (`vertexV1Beta1`).
  */
 export const vertexV1Beta1 = "google.cloud.aiplatform.v1beta1";
 /**
@@ -171,25 +171,25 @@ export type AIResponse<API> = string extends API
   : never;
 
 /**
- * Data payload for beforeGenerateContent events.
+ * Data payload for `beforeGenerateContent` events.
  */
 export interface BeforeGenerateContentData<API extends string = string> {
-  /** The full model resource path (for example, projects/PROJECT_ID/locations/global/publishers/google/models/gemini-2.0-flash). */
+  /** The full model resource path (for example, `projects/{PROJECT_ID}/locations/global/publishers/google/models/gemini-3.5-flash`). */
   model: string;
   /** Metadata about the server prompt template used, if applicable. */
   template?: PromptTemplateInfo;
-  /** The Gemini API provider: geminiV1Beta (Gemini Developer API) or vertexV1Beta1 (Agent Platform Gemini API (formerly Vertex AI)). */
+  /** The Gemini API provider: `geminiV1Beta` (Gemini Developer API) or `vertexV1Beta1` (Agent Platform Gemini API (formerly Vertex AI)). */
   api: SupportedAPI;
-  /** The outgoing request payload (available for beforeGenerateContent only). */
+  /** The outgoing request payload. */
   request: AIRequest<API>;
 }
 
 /**
- * Data payload for afterGenerateContent events.
+ * Data payload for `afterGenerateContent` events.
  */
 export interface AfterGenerateContentData<API extends string = string>
   extends BeforeGenerateContentData<API> {
-  /** The model's response payload (available for afterGenerateContent only). */
+  /** The model's response payload. */
   response: AIResponse<API>;
 }
 
@@ -197,7 +197,7 @@ export interface AfterGenerateContentData<API extends string = string>
  * Event context and metadata delivered to AI blocking handlers.
  */
 export interface AIBlockingEvent<T = any> extends CloudEvent<T> {
-  /** Authentication state for the caller: "app_user", "unauthenticated", or "unknown". */
+  /** Authentication state for the caller: `"app_user"`, `"unauthenticated"`, or `"unknown"`. */
   authType: AuthType;
   /** The caller's Firebase Authentication UID, if signed in. */
   authId?: string;
@@ -209,16 +209,16 @@ export interface AIBlockingEvent<T = any> extends CloudEvent<T> {
   appId?: string;
   /** The display name of the calling app, if set. */
   displayName?: string;
-  /** Set when the caller is an Android app. */
+  /** The package name of the calling app (applicable only for apps that target Android platforms). */
   androidPackageName?: string;
-  /** Set when the caller is an Apple platforms app. */
+  /** The bundle ID of the calling app (applicable only for apps that target Apple platforms). */
   iosBundleId?: string;
 }
 
 type MaybeAsync<T> = T | Promise<T>;
 
 /**
- * A Cloud Function that handles AI blocking events.
+ * A function that handles AI blocking events.
  */
 export type BlockingFunction = HttpsFunction;
 

--- a/src/v2/providers/ai/index.ts
+++ b/src/v2/providers/ai/index.ts
@@ -40,6 +40,9 @@ import * as logger from "../../../logger";
 
 export { HttpsError };
 
+/**
+ * Mapping from FunctionsErrorCode strings to numeric RPC status codes.
+ */
 export const rpcCodeMap: Record<FunctionsErrorCode, number> = {
   ok: 0,
   cancelled: 1,
@@ -82,32 +85,72 @@ export {
 };
 type MultipleLocationsIf<Allowed extends boolean> = Allowed extends true ? string[] : never;
 
+/**
+ * Options for configuring AI webhook triggers.
+ */
 export interface WebhookOptions<Regional extends boolean = false>
   extends Omit<EventHandlerOptions, "location"> {
+  /**
+   * Region where functions should be deployed.
+   */
   location?: string | Expression<string> | MultipleLocationsIf<Regional> | ResetValue;
+  /**
+   * Whether to handle regional webhooks.
+   */
   regionalWebhook?: Regional;
 }
 
+/**
+ * Information about a prompt template.
+ */
 export interface PromptTemplateInfo {
+  /** The name of the prompt template. */
   templateName?: string;
 }
 
+/**
+ * Authentication type of the caller.
+ */
 export type AuthType = "app_user" | "unauthenticated" | "unknown";
 
+/**
+ * Event type for beforeGenerate triggers.
+ */
 export const beforeGenerateEventType = "google.firebase.ailogic.v1.beforeGenerate";
+/**
+ * Event type for afterGenerate triggers.
+ */
 export const afterGenerateEventType = "google.firebase.ailogic.v1.afterGenerate";
 
+/**
+ * Union of all valid AI request payloads.
+ */
 export type AnyValidAIRequest =
   | GeminiV1BetaGenerateContentRequest
   | VertexV1Beta1GenerateContentRequest;
+/**
+ * Union of all valid AI response payloads.
+ */
 export type AnyValidAIResponse =
   | GeminiV1BetaGenerateContentResponse
   | VertexV1Beta1GenerateContentResponse;
 
+/**
+ * Identifier for the Gemini v1beta API.
+ */
 export const geminiV1Beta = "google.ai.generativelanguage.v1beta";
+/**
+ * Identifier for the Vertex AI v1beta1 API.
+ */
 export const vertexV1Beta1 = "google.cloud.aiplatform.v1beta1";
+/**
+ * Supported AI API types.
+ */
 export type SupportedAPI = typeof geminiV1Beta | typeof vertexV1Beta1;
 
+/**
+ * Generic type resolving to the corresponding AI request type based on the API identifier.
+ */
 export type AIRequest<API> = string extends API
   ? AnyValidAIRequest
   : API extends typeof geminiV1Beta
@@ -116,6 +159,9 @@ export type AIRequest<API> = string extends API
   ? VertexV1Beta1GenerateContentRequest
   : never;
 
+/**
+ * Generic type resolving to the corresponding AI response type based on the API identifier.
+ */
 export type AIResponse<API> = string extends API
   ? AnyValidAIResponse
   : API extends typeof geminiV1Beta
@@ -124,31 +170,56 @@ export type AIResponse<API> = string extends API
   ? VertexV1Beta1GenerateContentResponse
   : never;
 
+/**
+ * Data payload for beforeGenerateContent events.
+ */
 export interface BeforeGenerateContentData<API extends string = string> {
+  /** The AI model name. */
   model: string;
+  /** Template metadata if a prompt template is used. */
   template?: PromptTemplateInfo;
+  /** The AI API identifier. */
   api: SupportedAPI;
+  /** The incoming generate content request. */
   request: AIRequest<API>;
 }
 
+/**
+ * Data payload for afterGenerateContent events.
+ */
 export interface AfterGenerateContentData<API extends string = string>
   extends BeforeGenerateContentData<API> {
+  /** The generated content response. */
   response: AIResponse<API>;
 }
 
+/**
+ * Event context and payload delivered to AI blocking handlers.
+ */
 export interface AIBlockingEvent<T = any> extends CloudEvent<T> {
+  /** The authentication type of the caller. */
   authType: AuthType;
+  /** The user ID if authenticated. */
   authId?: string;
+  /** The auth claims token payload. */
   authClaims?: any;
+  /** The resource name. */
   resourceName?: string;
+  /** The Firebase app ID. */
   appId?: string;
+  /** The display name of the user. */
   displayName?: string;
+  /** The Android package name if request originates from Android. */
   androidPackageName?: string;
+  /** The iOS bundle ID if request originates from iOS. */
   iosBundleId?: string;
 }
 
 type MaybeAsync<T> = T | Promise<T>;
 
+/**
+ * A blocking function returned by AI event handlers.
+ */
 export type BlockingFunction = HttpsFunction;
 
 /**

--- a/src/v2/providers/ai/index.ts
+++ b/src/v2/providers/ai/index.ts
@@ -91,7 +91,7 @@ type MultipleLocationsIf<Allowed extends boolean> = Allowed extends true ? strin
 export interface WebhookOptions<Regional extends boolean = false>
   extends Omit<EventHandlerOptions, "location"> {
   /**
-   * Region where functions should be deployed.
+   * Region where functions should be deployed. Deployed to us-central1 by default.
    */
   location?: string | Expression<string> | MultipleLocationsIf<Regional> | ResetValue;
   /**
@@ -101,15 +101,15 @@ export interface WebhookOptions<Regional extends boolean = false>
 }
 
 /**
- * Information about a prompt template.
+ * Metadata about the server prompt template used, if applicable.
  */
 export interface PromptTemplateInfo {
-  /** The name of the prompt template. */
+  /** The name of the server prompt template. */
   templateName?: string;
 }
 
 /**
- * Authentication type of the caller.
+ * Authentication state for the caller: "app_user", "unauthenticated", or "unknown".
  */
 export type AuthType = "app_user" | "unauthenticated" | "unknown";
 
@@ -123,28 +123,28 @@ export const beforeGenerateEventType = "google.firebase.ailogic.v1.beforeGenerat
 export const afterGenerateEventType = "google.firebase.ailogic.v1.afterGenerate";
 
 /**
- * Union of all valid AI request payloads.
+ * Union of all valid AI request payloads across supported Gemini API providers.
  */
 export type AnyValidAIRequest =
   | GeminiV1BetaGenerateContentRequest
   | VertexV1Beta1GenerateContentRequest;
 /**
- * Union of all valid AI response payloads.
+ * Union of all valid AI response payloads across supported Gemini API providers.
  */
 export type AnyValidAIResponse =
   | GeminiV1BetaGenerateContentResponse
   | VertexV1Beta1GenerateContentResponse;
 
 /**
- * Identifier for the Gemini v1beta API.
+ * Identifier for the Gemini Developer API (geminiV1Beta).
  */
 export const geminiV1Beta = "google.ai.generativelanguage.v1beta";
 /**
- * Identifier for the Vertex AI v1beta1 API.
+ * Identifier for the Agent Platform Gemini API (formerly Vertex AI) (vertexV1Beta1).
  */
 export const vertexV1Beta1 = "google.cloud.aiplatform.v1beta1";
 /**
- * Supported AI API types.
+ * Supported Gemini API providers: Gemini Developer API or Agent Platform Gemini API (formerly Vertex AI).
  */
 export type SupportedAPI = typeof geminiV1Beta | typeof vertexV1Beta1;
 
@@ -174,13 +174,13 @@ export type AIResponse<API> = string extends API
  * Data payload for beforeGenerateContent events.
  */
 export interface BeforeGenerateContentData<API extends string = string> {
-  /** The AI model name. */
+  /** The full model resource path (for example, projects/PROJECT_ID/locations/global/publishers/google/models/gemini-2.0-flash). */
   model: string;
-  /** Template metadata if a prompt template is used. */
+  /** Metadata about the server prompt template used, if applicable. */
   template?: PromptTemplateInfo;
-  /** The AI API identifier. */
+  /** The Gemini API provider: geminiV1Beta (Gemini Developer API) or vertexV1Beta1 (Agent Platform Gemini API (formerly Vertex AI)). */
   api: SupportedAPI;
-  /** The incoming generate content request. */
+  /** The outgoing request payload (available for beforeGenerateContent only). */
   request: AIRequest<API>;
 }
 
@@ -189,29 +189,29 @@ export interface BeforeGenerateContentData<API extends string = string> {
  */
 export interface AfterGenerateContentData<API extends string = string>
   extends BeforeGenerateContentData<API> {
-  /** The generated content response. */
+  /** The model's response payload (available for afterGenerateContent only). */
   response: AIResponse<API>;
 }
 
 /**
- * Event context and payload delivered to AI blocking handlers.
+ * Event context and metadata delivered to AI blocking handlers.
  */
 export interface AIBlockingEvent<T = any> extends CloudEvent<T> {
-  /** The authentication type of the caller. */
+  /** Authentication state for the caller: "app_user", "unauthenticated", or "unknown". */
   authType: AuthType;
-  /** The user ID if authenticated. */
+  /** The caller's Firebase Authentication UID, if signed in. */
   authId?: string;
-  /** The auth claims token payload. */
+  /** The caller's custom auth claims, if any. */
   authClaims?: any;
-  /** The resource name. */
+  /** The resource name of the caller or request. */
   resourceName?: string;
-  /** The Firebase app ID. */
+  /** The Firebase App ID that made the request. */
   appId?: string;
-  /** The display name of the user. */
+  /** The display name of the calling app, if set. */
   displayName?: string;
-  /** The Android package name if request originates from Android. */
+  /** Set when the caller is an Android app. */
   androidPackageName?: string;
-  /** The iOS bundle ID if request originates from iOS. */
+  /** Set when the caller is an Apple platforms app. */
   iosBundleId?: string;
 }
 

--- a/src/v2/providers/ai/types/gemini/v1beta/index.ts
+++ b/src/v2/providers/ai/types/gemini/v1beta/index.ts
@@ -382,9 +382,13 @@ export declare interface GenerateContentCandidate {
  * @public
  */
 export declare interface GenerateContentRequest extends BaseParams {
+  /** Array of content parts that make up the prompt. */
   contents: Content[];
+  /** Optional tools that the model may use to generate content. */
   tools?: Tool[];
+  /** Optional tool configuration. */
   toolConfig?: ToolConfig;
+  /** Optional system instructions for the model. */
   systemInstruction?: string | Part | Content;
   /**
    * This is the name of a `CachedContent` and not the cache object itself.

--- a/src/v2/providers/ai/types/gemini/v1beta/index.ts
+++ b/src/v2/providers/ai/types/gemini/v1beta/index.ts
@@ -382,7 +382,7 @@ export declare interface GenerateContentCandidate {
  * @public
  */
 export declare interface GenerateContentRequest extends BaseParams {
-  /** Array of content parts that make up the prompt. */
+  /** Array of conversation turns (Content) that make up the prompt. */
   contents: Content[];
   /** Optional tools that the model may use to generate content. */
   tools?: Tool[];


### PR DESCRIPTION
### Description
Adds missing JSDoc descriptions for exported interfaces, variables, type aliases, and properties in `firebase-functions/v2/ai` so that all reference overview tables are populated with descriptions.

### Release notes
relnote: none
