### PR TITLE
Auth event v1 compat

### DIFF
--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -741,6 +741,22 @@ describe("identity", () => {
           eventId: "run-event-id",
         });
       });
+
+      it("handles calling .run() with null or undefined gracefully", async () => {
+        let received: any;
+        const func = identity.onUserCreated((event) => {
+          received = event;
+          return "handled";
+        });
+
+        const resultNull = await func.run(null as any);
+        expect(resultNull).to.equal("handled");
+        expect(received).to.be.null;
+
+        const resultUndef = await func.run(undefined as any);
+        expect(resultUndef).to.equal("handled");
+        expect(received).to.be.undefined;
+      });
     });
   });
 

--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -718,6 +718,29 @@ describe("identity", () => {
         const result = await func.run(vanillaV2Event);
         expect(result).to.equal("vanilla-uid");
       });
+
+      it("supports calling .run() on destructured handlers with vanilla POJO mock events", async () => {
+        const func = identity.onUserCreated(({ user, context }) => {
+          return { uid: user.uid, eventId: context.eventId };
+        });
+
+        const vanillaV2Event: identity.AuthEvent<identity.User> = {
+          specversion: "1.0",
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "run-event-id",
+          type: "google.firebase.auth.user.v2.created",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            uid: "run-destructured-uid",
+          } as any,
+        };
+
+        const result = await func.run(vanillaV2Event);
+        expect(result).to.deep.equal({
+          uid: "run-destructured-uid",
+          eventId: "run-event-id",
+        });
+      });
     });
   });
 
@@ -900,6 +923,29 @@ describe("identity", () => {
         expect(destructuredContext.eventType).to.equal(
           "providers/firebase.auth/eventTypes/user.delete"
         );
+      });
+
+      it("supports calling .run() on destructured handlers with vanilla POJO mock events", async () => {
+        const func = identity.onUserDeleted(({ user, context }) => {
+          return { uid: user.uid, eventType: context.eventType };
+        });
+
+        const vanillaV2Event: identity.AuthEvent<identity.User> = {
+          specversion: "1.0",
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "run-del-event-id",
+          type: "google.firebase.auth.user.v2.deleted",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            uid: "run-destructured-del-uid",
+          } as any,
+        };
+
+        const result = await func.run(vanillaV2Event);
+        expect(result).to.deep.equal({
+          uid: "run-destructured-del-uid",
+          eventType: "providers/firebase.auth/eventTypes/user.delete",
+        });
       });
     });
   });

--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -632,6 +632,93 @@ describe("identity", () => {
       func(mockEvent);
       expect(called).to.be.true;
     });
+
+    describe("v1-compatible getters", () => {
+      it("should provide v1-compatible getters on the event object", () => {
+        let capturedEvent: any;
+        const func = identity.onUserCreated((e) => {
+          capturedEvent = e;
+        });
+
+        const mockEvent = {
+          specversion: "1.0" as const,
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "event-id",
+          type: "google.firebase.auth.user.v2.created",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            value: {
+              uid: "user-uid-123",
+              email: "test@example.com",
+            },
+          } as any,
+        };
+
+        func(mockEvent);
+
+        expect(capturedEvent.context).to.deep.equal({
+          eventId: "event-id",
+          timestamp: "2023-01-01T00:00:00Z",
+          eventType: "providers/firebase.auth/eventTypes/user.create",
+          resource: {
+            service: "firebaseauth.googleapis.com",
+            name: "projects/my-project",
+          },
+          params: {},
+        });
+
+        expect(capturedEvent.user.uid).to.equal("user-uid-123");
+        expect(capturedEvent.user.email).to.equal("test@example.com");
+      });
+
+      it("should support v1 destructuring assignment ({ user, context })", () => {
+        let destructuredUser: any;
+        let destructuredContext: any;
+        const func = identity.onUserCreated(({ user, context }) => {
+          destructuredUser = user;
+          destructuredContext = context;
+        });
+
+        const mockEvent = {
+          specversion: "1.0" as const,
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "event-id",
+          type: "google.firebase.auth.user.v2.created",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            value: {
+              uid: "destructured-uid",
+              email: "destructured@example.com",
+            },
+          } as any,
+        };
+
+        func(mockEvent);
+
+        expect(destructuredUser.uid).to.equal("destructured-uid");
+        expect(destructuredContext.eventId).to.equal("event-id");
+      });
+
+      it("preserves backward compatibility for user tests passing POJOs without v1 getters", async () => {
+        const func = identity.onUserCreated((event) => {
+          return event.data.uid;
+        });
+
+        const vanillaV2Event: identity.AuthEvent<identity.User> = {
+          specversion: "1.0",
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "vanilla-id",
+          type: "google.firebase.auth.user.v2.created",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            uid: "vanilla-uid",
+          } as any,
+        };
+
+        const result = await func.run(vanillaV2Event);
+        expect(result).to.equal("vanilla-uid");
+      });
+    });
   });
 
   describe("onUserDeleted", () => {
@@ -746,6 +833,74 @@ describe("identity", () => {
 
       func(mockEvent);
       expect(called).to.be.true;
+    });
+
+    describe("v1-compatible getters", () => {
+      it("should provide v1-compatible getters on the event object", () => {
+        let capturedEvent: any;
+        const func = identity.onUserDeleted((e) => {
+          capturedEvent = e;
+        });
+
+        const mockEvent = {
+          specversion: "1.0" as const,
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "event-id-del",
+          type: "google.firebase.auth.user.v2.deleted",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            oldValue: {
+              uid: "user-uid-del",
+              email: "del@example.com",
+            },
+          } as any,
+        };
+
+        func(mockEvent);
+
+        expect(capturedEvent.context).to.deep.equal({
+          eventId: "event-id-del",
+          timestamp: "2023-01-01T00:00:00Z",
+          eventType: "providers/firebase.auth/eventTypes/user.delete",
+          resource: {
+            service: "firebaseauth.googleapis.com",
+            name: "projects/my-project",
+          },
+          params: {},
+        });
+
+        expect(capturedEvent.user.uid).to.equal("user-uid-del");
+        expect(capturedEvent.user.email).to.equal("del@example.com");
+      });
+
+      it("should support v1 destructuring assignment ({ user, context })", () => {
+        let destructuredUser: any;
+        let destructuredContext: any;
+        const func = identity.onUserDeleted(({ user, context }) => {
+          destructuredUser = user;
+          destructuredContext = context;
+        });
+
+        const mockEvent = {
+          specversion: "1.0" as const,
+          source: "//identitytoolkit.googleapis.com/projects/my-project",
+          id: "event-id-del",
+          type: "google.firebase.auth.user.v2.deleted",
+          time: "2023-01-01T00:00:00Z",
+          data: {
+            oldValue: {
+              uid: "destructured-del-uid",
+            },
+          } as any,
+        };
+
+        func(mockEvent);
+
+        expect(destructuredUser.uid).to.equal("destructured-del-uid");
+        expect(destructuredContext.eventType).to.equal(
+          "providers/firebase.auth/eventTypes/user.delete"
+        );
+      });
     });
   });
 

--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -742,6 +742,23 @@ describe("identity", () => {
         });
       });
 
+      it("supports calling .run() with an object that already has user and context", async () => {
+        const func = identity.onUserCreated(({ user, context }) => {
+          return { uid: user.uid, eventId: context.eventId };
+        });
+
+        const directCompatObject = {
+          user: { uid: "direct-uid" } as any,
+          context: { eventId: "direct-event-id" } as any,
+        };
+
+        const result = await func.run(directCompatObject as any);
+        expect(result).to.deep.equal({
+          uid: "direct-uid",
+          eventId: "direct-event-id",
+        });
+      });
+
       it("handles calling .run() with null or undefined gracefully", async () => {
         let received: any;
         const func = identity.onUserCreated((event) => {

--- a/spec/v2/providers/identity.spec.ts
+++ b/spec/v2/providers/identity.spec.ts
@@ -749,11 +749,11 @@ describe("identity", () => {
           return "handled";
         });
 
-        const resultNull = await func.run(null as any);
+        const resultNull = await func.run(null);
         expect(resultNull).to.equal("handled");
         expect(received).to.be.null;
 
-        const resultUndef = await func.run(undefined as any);
+        const resultUndef = await func.run(undefined);
         expect(resultUndef).to.equal("handled");
         expect(received).to.be.undefined;
       });

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -429,6 +429,10 @@ function getOptsAndHandler(
 
 // Matches both absolute paths (/projects/...) and relative paths (projects/...)
 const PROJECT_ID_REGEX = /(?:^|\/)projects\/([^\/]+)/;
+const IDENTITY_TOOLKIT_SOURCE_PREFIX = "//identitytoolkit.googleapis.com/";
+const FIREBASE_AUTH_SERVICE = "firebaseauth.googleapis.com";
+const USER_CREATED_EVENT = "google.firebase.auth.user.v2.created";
+const USER_DELETED_EVENT = "google.firebase.auth.user.v2.deleted";
 
 /**
  * Converts the v2 Eventarc (`AuthEventData`) protobuf wire protocol (`value`/`oldValue`, `createTime`, `photoUrl`)
@@ -498,11 +502,9 @@ function getAuthEvent(raw: CloudEvent<unknown>): AuthEvent<User> {
 
 /** @internal */
 export function getV1AuthContext(event: AuthEvent<User>) {
-  const service = "firebaseauth.googleapis.com";
-  const sourcePrefix = `//identitytoolkit.googleapis.com/`;
   let resourceName = event.source || "";
-  if (resourceName.startsWith(sourcePrefix)) {
-    resourceName = resourceName.substring(sourcePrefix.length);
+  if (resourceName.startsWith(IDENTITY_TOOLKIT_SOURCE_PREFIX)) {
+    resourceName = resourceName.substring(IDENTITY_TOOLKIT_SOURCE_PREFIX.length);
   } else if (event.project) {
     resourceName = `projects/${event.project}`;
   }
@@ -515,7 +517,7 @@ export function getV1AuthContext(event: AuthEvent<User>) {
         [USER_DELETED_EVENT]: "providers/firebase.auth/eventTypes/user.delete",
       }[event.type as string] || event.type,
     resource: {
-      service,
+      service: FIREBASE_AUTH_SERVICE,
       name: resourceName,
     },
     params: {},
@@ -576,8 +578,6 @@ function makeAuthTrigger(
   func.__endpoint = endpoint;
   return func;
 }
-
-const USER_CREATED_EVENT = "google.firebase.auth.user.v2.created";
 
 /**
  * Handles user creation events in Firebase Authentication.
@@ -641,8 +641,6 @@ export function onUserCreated(
 ): CloudFunction<AuthEvent<User>> {
   return makeAuthTrigger(USER_CREATED_EVENT, optsOrHandler, handler);
 }
-
-const USER_DELETED_EVENT = "google.firebase.auth.user.v2.deleted";
 
 /**
  * Handles user deletion events in Firebase Authentication.

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -547,7 +547,13 @@ function makeAuthTrigger(
     return wrappedHandler(compatEvent);
   }) as CloudFunction<AuthEvent<User>>;
 
-  func.run = handlerFunc;
+  func.run = ((event: AuthEvent<User>) => {
+    const compatEvent = addV1Compat(event, {
+      context: () => getV1AuthContext(event),
+      user: () => event.data,
+    });
+    return handlerFunc(compatEvent);
+  }) as any;
   const baseOptsEndpoint = options.optionsToEndpoint(options.getGlobalOptions());
   const specificOptsEndpoint = options.optionsToEndpoint(opts);
   const endpoint: ManifestEndpoint = {

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -416,10 +416,19 @@ export interface AuthOptions extends options.EventHandlerOptions {
  */
 export const IS_NOT_TENANT = RESET_VALUE;
 
+/**
+ * Event handler type for Authentication triggers that supports both standard `AuthEvent`
+ * and V1 compatibility destructuring (`{ user, context }`).
+ * @internal
+ */
+export type AuthEventHandler = (
+  event: AuthEvent<User> & V1Compat<"user", User>
+) => any | Promise<any>;
+
 // Helper to handle overloaded function signature
 function getOptsAndHandler(
-  optsOrHandler: AuthOptions | ((event: AuthEvent<User>) => any | Promise<any>),
-  handler?: (event: AuthEvent<User>) => any | Promise<any>
+  optsOrHandler: AuthOptions | AuthEventHandler,
+  handler?: AuthEventHandler
 ) {
   if (typeof optsOrHandler === "function") {
     return { opts: {}, handler: optsOrHandler };
@@ -528,8 +537,8 @@ export function getV1AuthContext(event: AuthEvent<User>) {
 /** @hidden */
 function makeAuthTrigger(
   eventType: string,
-  optsOrHandler: AuthOptions | ((event: any) => any | Promise<any>),
-  handler?: (event: any) => any | Promise<any>
+  optsOrHandler: AuthOptions | AuthEventHandler,
+  handler?: AuthEventHandler
 ): CloudFunction<AuthEvent<User>> {
   const { opts, handler: handlerFunc } = getOptsAndHandler(optsOrHandler, handler);
 
@@ -549,12 +558,15 @@ function makeAuthTrigger(
   }) as CloudFunction<AuthEvent<User>>;
 
   func.run = ((event: AuthEvent<User>) => {
-    const compatEvent = event
-      ? addV1Compat(event, {
-          context: () => getV1AuthContext(event),
-          user: () => event.data,
-        })
-      : event;
+    if (!event) {
+      return handlerFunc(event as Parameters<AuthEventHandler>[0]);
+    }
+    const existingUser = (event as any).user;
+    const existingContext = (event as any).context;
+    const compatEvent = addV1Compat(event, {
+      context: () => existingContext ?? getV1AuthContext(event),
+      user: () => event.data ?? existingUser,
+    });
     return handlerFunc(compatEvent);
   }) as any;
   const baseOptsEndpoint = options.optionsToEndpoint(options.getGlobalOptions());
@@ -645,8 +657,8 @@ export function onUserCreated(
   handler: (event: AuthEvent<User>) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>>;
 export function onUserCreated(
-  optsOrHandler: AuthOptions | ((event: any) => any | Promise<any>),
-  handler?: (event: any) => any | Promise<any>
+  optsOrHandler: AuthOptions | AuthEventHandler,
+  handler?: AuthEventHandler
 ): CloudFunction<AuthEvent<User>> {
   return makeAuthTrigger(USER_CREATED_EVENT, optsOrHandler, handler);
 }
@@ -708,8 +720,8 @@ export function onUserDeleted(
   handler: (event: AuthEvent<User>) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>>;
 export function onUserDeleted(
-  optsOrHandler: AuthOptions | ((event: any) => any | Promise<any>),
-  handler?: (event: any) => any | Promise<any>
+  optsOrHandler: AuthOptions | AuthEventHandler,
+  handler?: AuthEventHandler
 ): CloudFunction<AuthEvent<User>> {
   return makeAuthTrigger(USER_DELETED_EVENT, optsOrHandler, handler);
 }

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -46,6 +46,7 @@ import * as options from "../options";
 import { SupportedSecretParam } from "../../params/types";
 import { withInit } from "../../common/onInit";
 import { CloudEvent, CloudFunction } from "../core";
+import { addV1Compat, V1Compat } from "../compat";
 import { UserRecord as AdminUserRecord } from "firebase-admin/auth";
 import { userRecordConstructor } from "../../common/providers/identity";
 
@@ -495,11 +496,37 @@ function getAuthEvent(raw: CloudEvent<unknown>): AuthEvent<User> {
   return event;
 }
 
+/** @internal */
+export function getV1AuthContext(event: AuthEvent<User>) {
+  const service = "firebaseauth.googleapis.com";
+  const sourcePrefix = `//identitytoolkit.googleapis.com/`;
+  let resourceName = event.source || "";
+  if (resourceName.startsWith(sourcePrefix)) {
+    resourceName = resourceName.substring(sourcePrefix.length);
+  } else if (event.project) {
+    resourceName = `projects/${event.project}`;
+  }
+  return {
+    eventId: event.id,
+    timestamp: event.time,
+    eventType:
+      {
+        [USER_CREATED_EVENT]: "providers/firebase.auth/eventTypes/user.create",
+        [USER_DELETED_EVENT]: "providers/firebase.auth/eventTypes/user.delete",
+      }[event.type as string] || event.type,
+    resource: {
+      service,
+      name: resourceName,
+    },
+    params: {},
+  };
+}
+
 /** @hidden */
 function makeAuthTrigger(
   eventType: string,
-  optsOrHandler: AuthOptions | ((event: AuthEvent<User>) => any | Promise<any>),
-  handler?: (event: AuthEvent<User>) => any | Promise<any>
+  optsOrHandler: AuthOptions | ((event: any) => any | Promise<any>),
+  handler?: (event: any) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>> {
   const { opts, handler: handlerFunc } = getOptsAndHandler(optsOrHandler, handler);
 
@@ -511,7 +538,11 @@ function makeAuthTrigger(
 
   const func = ((raw: CloudEvent<unknown>) => {
     const event = getAuthEvent(raw);
-    return wrappedHandler(event);
+    const compatEvent = addV1Compat(event, {
+      context: () => getV1AuthContext(event),
+      user: () => event.data,
+    });
+    return wrappedHandler(compatEvent);
   }) as CloudFunction<AuthEvent<User>>;
 
   func.run = handlerFunc;
@@ -560,7 +591,35 @@ const USER_CREATED_EVENT = "google.firebase.auth.user.v2.created";
  * @returns A Cloud Function that you can export.
  */
 export function onUserCreated(
+  handler: (event: AuthEvent<User> & V1Compat<"user", User>) => any | Promise<any>
+): CloudFunction<AuthEvent<User>>;
+/**
+ * Handles user creation events in Firebase Authentication.
+ *
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
+ *
+ * @beta
+ * @internal
+ *
+ * @param handler - Event handler which is run every time a new user is created.
+ * @returns A Cloud Function that you can export.
+ */
+export function onUserCreated(
   handler: (event: AuthEvent<User>) => any | Promise<any>
+): CloudFunction<AuthEvent<User>>;
+/**
+ * Handles user creation events in Firebase Authentication.
+ *
+ * @beta
+ * @internal
+ *
+ * @param opts - Object containing function options.
+ * @param handler - Event handler which is run every time a new user is created.
+ * @returns A Cloud Function that you can export.
+ */
+export function onUserCreated(
+  opts: AuthOptions,
+  handler: (event: AuthEvent<User> & V1Compat<"user", User>) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user creation events in Firebase Authentication.
@@ -577,14 +636,28 @@ export function onUserCreated(
   handler: (event: AuthEvent<User>) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>>;
 export function onUserCreated(
-  optsOrHandler: AuthOptions | ((event: AuthEvent<User>) => any | Promise<any>),
-  handler?: (event: AuthEvent<User>) => any | Promise<any>
+  optsOrHandler: AuthOptions | ((event: any) => any | Promise<any>),
+  handler?: (event: any) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>> {
   return makeAuthTrigger(USER_CREATED_EVENT, optsOrHandler, handler);
 }
 
 const USER_DELETED_EVENT = "google.firebase.auth.user.v2.deleted";
 
+/**
+ * Handles user deletion events in Firebase Authentication.
+ *
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
+ *
+ * @beta
+ * @internal
+ *
+ * @param handler - Event handler that is run every time a user is deleted.
+ * @returns A Cloud Function that you can export.
+ */
+export function onUserDeleted(
+  handler: (event: AuthEvent<User> & V1Compat<"user", User>) => any | Promise<any>
+): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user deletion events in Firebase Authentication.
  *
@@ -611,11 +684,25 @@ export function onUserDeleted(
  */
 export function onUserDeleted(
   opts: AuthOptions,
+  handler: (event: AuthEvent<User> & V1Compat<"user", User>) => any | Promise<any>
+): CloudFunction<AuthEvent<User>>;
+/**
+ * Handles user deletion events in Firebase Authentication.
+ *
+ * @beta
+ * @internal
+ *
+ * @param opts - Object containing function options.
+ * @param handler - Event handler that is run every time a user is deleted.
+ * @returns A Cloud Function that you can export.
+ */
+export function onUserDeleted(
+  opts: AuthOptions,
   handler: (event: AuthEvent<User>) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>>;
 export function onUserDeleted(
-  optsOrHandler: AuthOptions | ((event: AuthEvent<User>) => any | Promise<any>),
-  handler?: (event: AuthEvent<User>) => any | Promise<any>
+  optsOrHandler: AuthOptions | ((event: any) => any | Promise<any>),
+  handler?: (event: any) => any | Promise<any>
 ): CloudFunction<AuthEvent<User>> {
   return makeAuthTrigger(USER_DELETED_EVENT, optsOrHandler, handler);
 }

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -512,10 +512,11 @@ export function getV1AuthContext(event: AuthEvent<User>) {
     eventId: event.id,
     timestamp: event.time,
     eventType:
-      {
-        [USER_CREATED_EVENT]: "providers/firebase.auth/eventTypes/user.create",
-        [USER_DELETED_EVENT]: "providers/firebase.auth/eventTypes/user.delete",
-      }[event.type as string] || event.type,
+      event.type === USER_CREATED_EVENT
+        ? "providers/firebase.auth/eventTypes/user.create"
+        : event.type === USER_DELETED_EVENT
+        ? "providers/firebase.auth/eventTypes/user.delete"
+        : event.type,
     resource: {
       service: FIREBASE_AUTH_SERVICE,
       name: resourceName,

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -548,10 +548,12 @@ function makeAuthTrigger(
   }) as CloudFunction<AuthEvent<User>>;
 
   func.run = ((event: AuthEvent<User>) => {
-    const compatEvent = addV1Compat(event, {
-      context: () => getV1AuthContext(event),
-      user: () => event.data,
-    });
+    const compatEvent = event
+      ? addV1Compat(event, {
+          context: () => getV1AuthContext(event),
+          user: () => event.data,
+        })
+      : event;
     return handlerFunc(compatEvent);
   }) as any;
   const baseOptsEndpoint = options.optionsToEndpoint(options.getGlobalOptions());


### PR DESCRIPTION
relnote: none

### Description
Adds `V1Compat` destructuring support to 2nd-Gen Firebase Authentication triggers (`onUserCreated` and `onUserDeleted`), bringing Auth to full feature and type parity with `firestore`, `pubsub`, `storage`, `database`, and `remoteConfig`.

Key changes:
- **Lazy Getters via `addV1Compat`**: Attaches `user` (returning `event.data`) and `context` (returning `getV1AuthContext(event)`) via non-enumerable, memoized getters with zero performance/allocation overhead for standard v2 callers.
- **V1 Field Parity (`getV1AuthContext`)**: Maps legacy `EventContext` properties:
  - `eventType`: Translates v2 CloudEvent types to `"providers/firebase.auth/eventTypes/user.create"` and `"user.delete"`.
  - `resource`: Sets `service: "firebaseauth.googleapis.com"` and normalizes `name` by stripping `//identitytoolkit.googleapis.com/`.
  - `params: {}`, `eventId`, `timestamp`.
- **TypeScript Contravariance Overloads**: Declares overloads for both `(event: AuthEvent<User> & V1Compat<"user", User>)` and `(event: AuthEvent<User>)` to ensure user test suites passing vanilla POJO `CloudEvent` mocks to `.run()` compile without type friction.
- **Constants Extraction**: Centralizes top-level constants (`IDENTITY_TOOLKIT_SOURCE_PREFIX`, `FIREBASE_AUTH_SERVICE`, `USER_CREATED_EVENT`, `USER_DELETED_EVENT`).

### Scenarios Tested
- **Unit Tests (`spec/v2/providers/identity.spec.ts`)**:
  - Verified `v1-compatible getters` (`event.user` and all fields of `event.context`).
  - Verified destructuring assignment syntax: `onUserCreated(({ user, context }) => ...)`.
  - Verified backward compatibility for plain mock POJOs passed to `.run()`.
  - Ran full test suite: 988 passing tests (`npm test`).
- **Live GCP Deployment**:
  - Deployed `onUserCreated(({ user, context }) => ...)` to test project `varun-test-project-auth`.
  - Triggered passwordless email link sign-up flow and verified in Cloud Run logs that `user.uid`, `user.email`, `context.eventId`, `context.eventType`, and `context.resource` were captured and logged correctly.
