### PR TITLE
feat: unify global manifest on globalThis for forward-compatible manifest extraction

### DIFF
--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -8,6 +8,7 @@ import {
   ManifestExtension,
   ManifestRequiredAPI,
   ManifestStack,
+  clearGlobalManifest,
 } from "../../src/runtime/manifest";
 import { clearParams } from "../../src/params";
 import { clearGlobalRequiredAPIs } from "../../src/common/api";
@@ -336,6 +337,7 @@ describe("loadStack", () => {
   let prev;
 
   beforeEach(() => {
+    clearGlobalManifest();
     // TODO: When __trigger annotation is removed and GCLOUD_PROJECT is not required at runtime, remove this.
     prev = process.env.GCLOUD_PROJECT;
     process.env.GCLOUD_PROJECT = "test-project";
@@ -343,6 +345,7 @@ describe("loadStack", () => {
 
   afterEach(() => {
     process.env.GCLOUD_PROJECT = prev;
+    clearGlobalManifest();
     clearGlobalRequiredAPIs();
     clearParams();
     clearDeclaredLifecycleHooks();
@@ -616,6 +619,28 @@ describe("loadStack", () => {
           },
         },
       });
+    });
+  });
+
+  describe("loadStack with forwards-compatible globalManifest properties", () => {
+    it("destructures arbitrary future wire properties into ManifestStack", async () => {
+      const globalManifestSymbol = Symbol.for("firebase-functions:manifest");
+      const globalSymbols = globalThis as unknown as Record<symbol, Record<string, unknown>>;
+      const manifest = globalSymbols[globalManifestSymbol];
+
+      manifest.requiredRoles = ["roles/storage.admin", "roles/aiplatform.user"];
+      manifest.futureFeatureConfig = { enabled: true, mode: "fast" };
+      manifest.customStackMetadata = "version-2";
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+      expect(stack.requiredRoles).to.deep.equal(["roles/storage.admin", "roles/aiplatform.user"]);
+      expect(stack.futureFeatureConfig).to.deep.equal({ enabled: true, mode: "fast" });
+      expect(stack.customStackMetadata).to.equal("version-2");
+
+      clearGlobalManifest();
+      expect(manifest.futureFeatureConfig).to.be.undefined;
+      expect(manifest.customStackMetadata).to.be.undefined;
+      expect(manifest.requiredRoles).to.be.undefined;
     });
   });
 });

--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -11,7 +11,6 @@ import {
   clearGlobalManifest,
 } from "../../src/runtime/manifest";
 import { clearParams } from "../../src/params";
-import { clearGlobalRequiredAPIs } from "../../src/common/api";
 import { afterFirstDeploy, afterRedeploy, clearDeclaredLifecycleHooks } from "../../src/lifecycle";
 import { MINIMAL_V1_ENDPOINT, MINIMAL_V2_ENDPOINT } from "../fixtures";
 import { MINIMAL_SCHEDULE_TRIGGER, MINIMIAL_TASK_QUEUE_TRIGGER } from "../v1/providers/fixtures";
@@ -346,7 +345,6 @@ describe("loadStack", () => {
   afterEach(() => {
     process.env.GCLOUD_PROJECT = prev;
     clearGlobalManifest();
-    clearGlobalRequiredAPIs();
     clearParams();
     clearDeclaredLifecycleHooks();
     // Purge the require cache for fixture modules so that when a file is loaded

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -20,9 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-import { ManifestRequiredAPI } from "../runtime/manifest";
-
-let globalRequiredAPIs: ManifestRequiredAPI[] = [];
+import { globalManifest, ManifestRequiredAPI } from "../runtime/manifest";
 
 export type GoogleCloudApi = `${string}.googleapis.com`;
 
@@ -35,19 +33,35 @@ export function requiresAPI(api: GoogleCloudApi, reason = ""): void {
   if (!api || typeof api !== "string" || !api.endsWith(".googleapis.com")) {
     throw new Error("requiresAPI: 'api' must be a non-empty string ending with '.googleapis.com'.");
   }
-  globalRequiredAPIs.push({ api, reason });
+  if (!Array.isArray(globalManifest.requiredAPIs)) {
+    globalManifest.requiredAPIs = [];
+  }
+  const list = globalManifest.requiredAPIs as ManifestRequiredAPI[];
+  const existing = list.find((item) => item.api === api);
+  if (existing) {
+    if (reason && !existing.reason.includes(reason)) {
+      existing.reason = existing.reason ? `${existing.reason} ${reason}` : reason;
+    }
+  } else {
+    list.push({ api, reason });
+  }
 }
 
 /**
  * @internal
  */
 export function getGlobalRequiredAPIs(): ManifestRequiredAPI[] {
-  return globalRequiredAPIs;
+  if (!Array.isArray(globalManifest.requiredAPIs)) {
+    return [];
+  }
+  return globalManifest.requiredAPIs as ManifestRequiredAPI[];
 }
 
 /**
  * @internal
  */
 export function clearGlobalRequiredAPIs(): void {
-  globalRequiredAPIs = [];
+  if (Array.isArray(globalManifest.requiredAPIs)) {
+    (globalManifest.requiredAPIs as ManifestRequiredAPI[]).length = 0;
+  }
 }

--- a/src/common/api.ts
+++ b/src/common/api.ts
@@ -61,7 +61,5 @@ export function getGlobalRequiredAPIs(): ManifestRequiredAPI[] {
  * @internal
  */
 export function clearGlobalRequiredAPIs(): void {
-  if (Array.isArray(globalManifest.requiredAPIs)) {
-    (globalManifest.requiredAPIs as ManifestRequiredAPI[]).length = 0;
-  }
+  delete globalManifest.requiredAPIs;
 }

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -43,14 +43,25 @@ export type LifecycleAction =
 
 import { globalManifest } from "../runtime/manifest";
 
-function getDeclaredHooks(): Record<string, LifecycleAction> {
+/**
+ * Gets or creates the mutable lifecycle hooks record directly on `globalManifest`.
+ * Used exclusively for write operations (e.g., registering a hook) so that
+ * `globalManifest.lifecycleHooks` is created lazily on demand.
+ */
+function getOrCreateDeclaredLifecycleHooks(): Record<string, LifecycleAction> {
   if (!globalManifest.lifecycleHooks || typeof globalManifest.lifecycleHooks !== "object") {
     globalManifest.lifecycleHooks = {};
   }
   return globalManifest.lifecycleHooks as Record<string, LifecycleAction>;
 }
 
-function getExistingDeclaredHooks(): Record<string, LifecycleAction> {
+/**
+ * Gets the existing lifecycle hooks record on `globalManifest` if defined,
+ * or returns a fallback empty object without mutating `globalManifest`.
+ * Used for read-only operations (e.g., property lookup, keys, descriptors)
+ * to avoid emitting an unwanted empty `lifecycleHooks: {}` into the manifest.
+ */
+function getExistingDeclaredLifecycleHooks(): Record<string, LifecycleAction> {
   if (!globalManifest.lifecycleHooks || typeof globalManifest.lifecycleHooks !== "object") {
     return {};
   }
@@ -73,32 +84,36 @@ export const declaredLifecycleHooks: Record<string, LifecycleAction> = new Proxy
   {
     get(_, prop) {
       if (typeof prop === "string") {
-        return getExistingDeclaredHooks()[prop];
+        return getExistingDeclaredLifecycleHooks()[prop];
       }
       return undefined;
     },
     set(_, prop, value) {
       if (typeof prop === "string") {
-        getDeclaredHooks()[prop] = value as LifecycleAction;
+        getOrCreateDeclaredLifecycleHooks()[prop] = value as LifecycleAction;
         return true;
       }
       return false;
     },
     deleteProperty(_, prop) {
-      if (typeof prop === "string") {
-        delete getExistingDeclaredHooks()[prop];
+      if (typeof prop === "string" && globalManifest.lifecycleHooks) {
+        const hooks = globalManifest.lifecycleHooks as Record<string, LifecycleAction>;
+        delete hooks[prop];
+        if (Object.keys(hooks).length === 0) {
+          delete globalManifest.lifecycleHooks;
+        }
         return true;
       }
       return false;
     },
     has(_, prop) {
-      return Reflect.has(getExistingDeclaredHooks(), prop);
+      return Reflect.has(getExistingDeclaredLifecycleHooks(), prop);
     },
     ownKeys() {
-      return Reflect.ownKeys(getExistingDeclaredHooks());
+      return Reflect.ownKeys(getExistingDeclaredLifecycleHooks());
     },
     getOwnPropertyDescriptor(_, prop) {
-      const hooks = getExistingDeclaredHooks();
+      const hooks = getExistingDeclaredLifecycleHooks();
       if (typeof prop === "string" && prop in hooks) {
         return {
           enumerable: true,
@@ -119,7 +134,7 @@ export const declaredLifecycleHooks: Record<string, LifecycleAction> = new Proxy
  * @param action The lifecycle action to execute.
  */
 export function afterFirstDeploy(action: LifecycleAction): void {
-  const hooks = getDeclaredHooks();
+  const hooks = getOrCreateDeclaredLifecycleHooks();
   if (hooks.afterFirstDeploy) {
     throw new Error("Only one afterFirstDeploy lifecycle hook is allowed per codebase.");
   }
@@ -133,7 +148,7 @@ export function afterFirstDeploy(action: LifecycleAction): void {
  * @param action The lifecycle action to execute.
  */
 export function afterRedeploy(action: LifecycleAction): void {
-  const hooks = getDeclaredHooks();
+  const hooks = getOrCreateDeclaredLifecycleHooks();
   if (hooks.afterRedeploy) {
     throw new Error("Only one afterRedeploy lifecycle hook is allowed per codebase.");
   }

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -41,32 +41,16 @@ export type LifecycleAction =
   | { call: CallAction; task?: never; http?: never }
   | { http: HttpAction; task?: never; call?: never };
 
-/**
- * Use a global singleton to manage the list of declared lifecycle hooks.
- *
- * This ensures that lifecycle hooks are shared between CJS and ESM builds,
- * avoiding the "dual-package hazard" where the src/bin/firebase-functions.ts (CJS) sees
- * an empty list while the user's code (ESM) populates a different list.
- */
-const majorVersion =
-  // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
-  typeof __FIREBASE_FUNCTIONS_MAJOR_VERSION__ !== "undefined"
-    ? // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
-      __FIREBASE_FUNCTIONS_MAJOR_VERSION__
-    : "0";
+import { globalManifest } from "../runtime/manifest";
 
-const GLOBAL_SYMBOL = Symbol.for(`firebase-functions:lifecycle:declaredHooks:v${majorVersion}`);
-const globalSymbols = globalThis as unknown as Record<symbol, Record<string, LifecycleAction>>;
-
-if (!globalSymbols[GLOBAL_SYMBOL]) {
-  globalSymbols[GLOBAL_SYMBOL] = {};
+function getDeclaredHooks(): Record<string, LifecycleAction> {
+  if (!globalManifest.lifecycleHooks || typeof globalManifest.lifecycleHooks !== "object") {
+    globalManifest.lifecycleHooks = {};
+  }
+  return globalManifest.lifecycleHooks as Record<string, LifecycleAction>;
 }
 
-/**
- * Singleton dictionary of declared lifecycle hooks.
- * @internal
- */
-export const declaredLifecycleHooks: Record<string, LifecycleAction> = globalSymbols[GLOBAL_SYMBOL];
+export const declaredLifecycleHooks: Record<string, LifecycleAction> = {};
 
 /**
  * Registers an action to be executed automatically post-deployment when resources in this codebase
@@ -75,9 +59,11 @@ export const declaredLifecycleHooks: Record<string, LifecycleAction> = globalSym
  * @param action The lifecycle action to execute.
  */
 export function afterFirstDeploy(action: LifecycleAction): void {
-  if (declaredLifecycleHooks.afterFirstDeploy) {
+  const hooks = getDeclaredHooks();
+  if (hooks.afterFirstDeploy) {
     throw new Error("Only one afterFirstDeploy lifecycle hook is allowed per codebase.");
   }
+  hooks.afterFirstDeploy = action;
   declaredLifecycleHooks.afterFirstDeploy = action;
 }
 
@@ -88,9 +74,11 @@ export function afterFirstDeploy(action: LifecycleAction): void {
  * @param action The lifecycle action to execute.
  */
 export function afterRedeploy(action: LifecycleAction): void {
-  if (declaredLifecycleHooks.afterRedeploy) {
+  const hooks = getDeclaredHooks();
+  if (hooks.afterRedeploy) {
     throw new Error("Only one afterRedeploy lifecycle hook is allowed per codebase.");
   }
+  hooks.afterRedeploy = action;
   declaredLifecycleHooks.afterRedeploy = action;
 }
 
@@ -102,4 +90,5 @@ export function clearDeclaredLifecycleHooks(): void {
   for (const key of Object.keys(declaredLifecycleHooks)) {
     delete declaredLifecycleHooks[key];
   }
+  delete globalManifest.lifecycleHooks;
 }

--- a/src/lifecycle/index.ts
+++ b/src/lifecycle/index.ts
@@ -50,7 +50,67 @@ function getDeclaredHooks(): Record<string, LifecycleAction> {
   return globalManifest.lifecycleHooks as Record<string, LifecycleAction>;
 }
 
-export const declaredLifecycleHooks: Record<string, LifecycleAction> = {};
+function getExistingDeclaredHooks(): Record<string, LifecycleAction> {
+  if (!globalManifest.lifecycleHooks || typeof globalManifest.lifecycleHooks !== "object") {
+    return {};
+  }
+  return globalManifest.lifecycleHooks as Record<string, LifecycleAction>;
+}
+
+/**
+ * Shared dictionary of declared lifecycle hooks.
+ *
+ * NOTE: A Proxy is necessary here because `lifecycleHooks` is only initialized
+ * on `globalManifest` when hooks are registered (to avoid emitting empty `{}`
+ * into the manifest). The Proxy dynamically delegates all property reads, writes,
+ * and key enumerations directly to `globalManifest.lifecycleHooks` on `globalThis`,
+ * ensuring dual-package hazard protection across ESM/CJS or duplicate module contexts.
+ *
+ * @internal
+ */
+export const declaredLifecycleHooks: Record<string, LifecycleAction> = new Proxy(
+  {},
+  {
+    get(_, prop) {
+      if (typeof prop === "string") {
+        return getExistingDeclaredHooks()[prop];
+      }
+      return undefined;
+    },
+    set(_, prop, value) {
+      if (typeof prop === "string") {
+        getDeclaredHooks()[prop] = value as LifecycleAction;
+        return true;
+      }
+      return false;
+    },
+    deleteProperty(_, prop) {
+      if (typeof prop === "string") {
+        delete getExistingDeclaredHooks()[prop];
+        return true;
+      }
+      return false;
+    },
+    has(_, prop) {
+      return Reflect.has(getExistingDeclaredHooks(), prop);
+    },
+    ownKeys() {
+      return Reflect.ownKeys(getExistingDeclaredHooks());
+    },
+    getOwnPropertyDescriptor(_, prop) {
+      const hooks = getExistingDeclaredHooks();
+      if (typeof prop === "string" && prop in hooks) {
+        return {
+          enumerable: true,
+          configurable: true,
+          writable: true,
+          value: hooks[prop],
+        };
+      }
+      return undefined;
+    },
+  }
+);
 
 /**
  * Registers an action to be executed automatically post-deployment when resources in this codebase
@@ -64,7 +124,6 @@ export function afterFirstDeploy(action: LifecycleAction): void {
     throw new Error("Only one afterFirstDeploy lifecycle hook is allowed per codebase.");
   }
   hooks.afterFirstDeploy = action;
-  declaredLifecycleHooks.afterFirstDeploy = action;
 }
 
 /**
@@ -79,7 +138,6 @@ export function afterRedeploy(action: LifecycleAction): void {
     throw new Error("Only one afterRedeploy lifecycle hook is allowed per codebase.");
   }
   hooks.afterRedeploy = action;
-  declaredLifecycleHooks.afterRedeploy = action;
 }
 
 /**
@@ -87,8 +145,5 @@ export function afterRedeploy(action: LifecycleAction): void {
  * @internal
  */
 export function clearDeclaredLifecycleHooks(): void {
-  for (const key of Object.keys(declaredLifecycleHooks)) {
-    delete declaredLifecycleHooks[key];
-  }
   delete globalManifest.lifecycleHooks;
 }

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -54,34 +54,18 @@ export type {
   BooleanParam,
   IntParam,
   ListParam,
+  WireParamSpec,
 } from "./types";
 
 export { Expression };
 export type { ParamOptions, SecretParamOptions };
 
+import { globalManifest } from "../runtime/manifest";
+import type { WireParamSpec } from "./types";
+
 type SecretOrExpr = Param<any> | SecretParam | JsonSecretParam<any>;
 
-/**
- * Use a global singleton to manage the list of declared parameters.
- *
- * This ensures that parameters are shared between CJS and ESM builds,
- * avoiding the "dual-package hazard" where the src/bin/firebase-functions.ts (CJS) sees
- * an empty list while the user's code (ESM) populates a different list.
- */
-const majorVersion =
-  // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
-  typeof __FIREBASE_FUNCTIONS_MAJOR_VERSION__ !== "undefined"
-    ? // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
-      __FIREBASE_FUNCTIONS_MAJOR_VERSION__
-    : "0";
-const GLOBAL_SYMBOL = Symbol.for(`firebase-functions:params:declaredParams:v${majorVersion}`);
-const globalSymbols = globalThis as unknown as Record<symbol, SecretOrExpr[]>;
-
-if (!globalSymbols[GLOBAL_SYMBOL]) {
-  globalSymbols[GLOBAL_SYMBOL] = [];
-}
-
-export const declaredParams: SecretOrExpr[] = globalSymbols[GLOBAL_SYMBOL];
+export const declaredParams: SecretOrExpr[] = [];
 
 /**
  * Use a helper to manage the list such that parameters are uniquely
@@ -95,6 +79,17 @@ function registerParam(param: SecretOrExpr) {
     }
   }
   declaredParams.push(param);
+
+  if (!Array.isArray(globalManifest.params)) {
+    globalManifest.params = [];
+  }
+  const manifestParams = globalManifest.params as WireParamSpec<any>[];
+  for (let i = 0; i < manifestParams.length; i++) {
+    if (manifestParams[i].name === param.name) {
+      manifestParams.splice(i, 1);
+    }
+  }
+  manifestParams.push(param.toSpec());
 }
 
 /**
@@ -102,7 +97,8 @@ function registerParam(param: SecretOrExpr) {
  * @internal
  */
 export function clearParams() {
-  declaredParams.splice(0, declaredParams.length);
+  declaredParams.length = 0;
+  delete globalManifest.params;
 }
 
 /**

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -65,7 +65,16 @@ import type { WireParamSpec } from "./types";
 
 type SecretOrExpr = Param<any> | SecretParam | JsonSecretParam<any>;
 
-export const declaredParams: SecretOrExpr[] = [];
+const GLOBAL_PARAMS_SYMBOL = Symbol.for("firebase-functions:params:declaredParams");
+const globalSymbols = globalThis as unknown as Record<symbol, SecretOrExpr[]>;
+if (!globalSymbols[GLOBAL_PARAMS_SYMBOL]) {
+  globalSymbols[GLOBAL_PARAMS_SYMBOL] = [];
+}
+
+/**
+ * Shared list of declared parameters backed by globalThis across module contexts.
+ */
+export const declaredParams: SecretOrExpr[] = globalSymbols[GLOBAL_PARAMS_SYMBOL];
 
 /**
  * Use a helper to manage the list such that parameters are uniquely

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -197,6 +197,9 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
     requiresAPI(req.api as GoogleCloudApi, req.reason);
   }
 
+  // The v1alpha1 stack manifest specification expects `extensions: {}` and `requiredAPIs: []`
+  // to always be present on ManifestStack (even if empty), whereas other optional fields
+  // (e.g., params, requiredRoles, lifecycleHooks) are only included when declared.
   const existingExtensions =
     globalManifest.extensions && typeof globalManifest.extensions === "object"
       ? (globalManifest.extensions as Record<string, ManifestExtension>)

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -23,16 +23,13 @@ import * as path from "path";
 import * as url from "url";
 
 import {
+  globalManifest,
   ManifestEndpoint,
   ManifestExtension,
   ManifestRequiredAPI,
   ManifestStack,
 } from "./manifest";
-
-import * as params from "../params";
-import { declaredRoles } from "../security/roles";
-import { getGlobalRequiredAPIs, clearGlobalRequiredAPIs } from "../common/api";
-import { declaredLifecycleHooks, clearDeclaredLifecycleHooks } from "../lifecycle";
+import { requiresAPI, GoogleCloudApi } from "../common/api";
 
 /**
  * Dynamically load import function to prevent TypeScript from
@@ -195,25 +192,29 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
   const mod = await loadModule(functionsDir);
 
   extractStack(mod, endpoints, requiredAPIs, extensions);
-  requiredAPIs.push(...getGlobalRequiredAPIs());
-  clearGlobalRequiredAPIs();
+
+  for (const req of requiredAPIs) {
+    requiresAPI(req.api as GoogleCloudApi, req.reason);
+  }
+
+  const existingExtensions =
+    globalManifest.extensions && typeof globalManifest.extensions === "object"
+      ? (globalManifest.extensions as Record<string, ManifestExtension>)
+      : {};
+  globalManifest.extensions = {
+    ...extensions,
+    ...existingExtensions,
+  };
+
+  if (!globalManifest.requiredAPIs) {
+    globalManifest.requiredAPIs = [];
+  }
 
   const stack: ManifestStack = {
-    endpoints,
     specVersion: "v1alpha1",
-    requiredAPIs: mergeRequiredAPIs(requiredAPIs),
-    extensions,
+    endpoints,
+    ...globalManifest,
   };
-  if (params.declaredParams.length > 0) {
-    stack.params = params.declaredParams.map((p) => p.toSpec());
-  }
-  if (declaredRoles.size > 0) {
-    stack.requiredRoles = Array.from(declaredRoles);
-  }
 
-  if (Object.keys(declaredLifecycleHooks).length > 0) {
-    stack.lifecycleHooks = { ...declaredLifecycleHooks };
-  }
-  clearDeclaredLifecycleHooks();
   return stack;
 }

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -194,12 +194,7 @@ export const globalManifest: Record<string, unknown> = globalSymbols[GLOBAL_MANI
  */
 export function clearGlobalManifest(): void {
   for (const key of Object.keys(globalManifest)) {
-    const val = globalManifest[key];
-    if (val instanceof Set) {
-      val.clear();
-    } else {
-      delete globalManifest[key];
-    }
+    delete globalManifest[key];
   }
 }
 

--- a/src/runtime/manifest.ts
+++ b/src/runtime/manifest.ts
@@ -21,8 +21,7 @@
 // SOFTWARE.
 
 import { RESET_VALUE, ResettableKeys, ResetValue } from "../common/options";
-import { Expression } from "../params";
-import { WireParamSpec, SecretParam } from "../params/types";
+import { Expression, WireParamSpec, SecretParam } from "../params/types";
 
 /**
  * A definition of an extension as appears in the Manifest.
@@ -166,11 +165,42 @@ export interface ManifestLifecycleAction {
 export interface ManifestStack {
   specVersion: "v1alpha1";
   params?: WireParamSpec<any>[];
-  requiredAPIs: ManifestRequiredAPI[];
+  requiredAPIs?: ManifestRequiredAPI[];
   endpoints: Record<string, ManifestEndpoint>;
   extensions?: Record<string, ManifestExtension>;
   requiredRoles?: string[];
   lifecycleHooks?: Record<string, ManifestLifecycleAction>;
+  [key: string]: unknown;
+}
+
+const GLOBAL_MANIFEST_SYMBOL = Symbol.for("firebase-functions:manifest");
+const globalSymbols = globalThis as unknown as Record<symbol, Record<string, unknown>>;
+
+if (!globalSymbols[GLOBAL_MANIFEST_SYMBOL]) {
+  globalSymbols[GLOBAL_MANIFEST_SYMBOL] = {};
+}
+
+/**
+ * Shared global manifest object on globalThis.
+ * Contains all global stack/manifest declarations (requiredRoles, requiredAPIs, params, lifecycleHooks, etc.)
+ * so that they can be directly destructured into the final ManifestStack.
+ * @internal
+ */
+export const globalManifest: Record<string, unknown> = globalSymbols[GLOBAL_MANIFEST_SYMBOL];
+
+/**
+ * Clears all entries from the shared global manifest.
+ * @internal
+ */
+export function clearGlobalManifest(): void {
+  for (const key of Object.keys(globalManifest)) {
+    const val = globalManifest[key];
+    if (val instanceof Set) {
+      val.clear();
+    } else {
+      delete globalManifest[key];
+    }
+  }
 }
 
 /**

--- a/src/security/roles.ts
+++ b/src/security/roles.ts
@@ -22,9 +22,11 @@
 
 import { globalManifest } from "../runtime/manifest";
 
-function getDeclaredRolesList(): string[] {
+const EMPTY_ROLES: readonly string[] = Object.freeze([]);
+
+function getDeclaredRolesList(): readonly string[] {
   if (!Array.isArray(globalManifest.requiredRoles)) {
-    return [];
+    return EMPTY_ROLES;
   }
   return globalManifest.requiredRoles as string[];
 }

--- a/src/security/roles.ts
+++ b/src/security/roles.ts
@@ -20,17 +20,53 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+import { globalManifest } from "../runtime/manifest";
+
+function getDeclaredRolesList(): string[] {
+  if (!Array.isArray(globalManifest.requiredRoles)) {
+    return [];
+  }
+  return globalManifest.requiredRoles as string[];
+}
+
 /**
  * Global set of declared IAM roles required by this codebase.
- * Accumulated in-memory during manifest generation.
+ * Accumulated in-memory in globalManifest on globalThis during manifest generation.
  */
-export const declaredRoles = new Set<string>();
+export const declaredRoles = {
+  get size(): number {
+    return getDeclaredRolesList().length;
+  },
+  add(role: string): void {
+    registerRole(role);
+  },
+  has(role: string): boolean {
+    return getDeclaredRolesList().includes(role);
+  },
+  clear(): void {
+    delete globalManifest.requiredRoles;
+  },
+  [Symbol.iterator](): IterableIterator<string> {
+    return getDeclaredRolesList()[Symbol.iterator]();
+  },
+  forEach(callback: (value: string, value2: string, set: typeof declaredRoles) => void): void {
+    for (const role of getDeclaredRolesList()) {
+      callback(role, role, declaredRoles);
+    }
+  },
+};
 
 /**
  * Registers a role to be required by this codebase.
- * Automatically deduplicates using the Set.
+ * Automatically deduplicates roles in globalManifest.requiredRoles.
  * @internal
  */
-export function registerRole(role: string) {
-  declaredRoles.add(role);
+export function registerRole(role: string): void {
+  if (!Array.isArray(globalManifest.requiredRoles)) {
+    globalManifest.requiredRoles = [];
+  }
+  const roles = globalManifest.requiredRoles as string[];
+  if (!roles.includes(role)) {
+    roles.push(role);
+  }
 }

--- a/src/security/roles.ts
+++ b/src/security/roles.ts
@@ -31,7 +31,12 @@ function getDeclaredRolesList(): string[] {
 
 /**
  * Global set of declared IAM roles required by this codebase.
- * Accumulated in-memory in globalManifest on globalThis during manifest generation.
+ *
+ * NOTE: This cannot be a native `Set` because `globalManifest.requiredRoles`
+ * is stored directly as a wire-ready `string[]` on `globalThis` so that
+ * any manifest loader (even older harness versions) can simply spread
+ * `...globalManifest` without needing role-specific Set-to-Array conversion.
+ * `declaredRoles` implements the full `Set` interface for backwards compatibility.
  */
 export const declaredRoles = {
   get size(): number {
@@ -40,11 +45,34 @@ export const declaredRoles = {
   add(role: string): void {
     registerRole(role);
   },
+  delete(role: string): boolean {
+    if (!Array.isArray(globalManifest.requiredRoles)) {
+      return false;
+    }
+    const roles = globalManifest.requiredRoles as string[];
+    const idx = roles.indexOf(role);
+    if (idx !== -1) {
+      roles.splice(idx, 1);
+      return true;
+    }
+    return false;
+  },
   has(role: string): boolean {
     return getDeclaredRolesList().includes(role);
   },
   clear(): void {
     delete globalManifest.requiredRoles;
+  },
+  keys(): IterableIterator<string> {
+    return getDeclaredRolesList()[Symbol.iterator]();
+  },
+  values(): IterableIterator<string> {
+    return getDeclaredRolesList()[Symbol.iterator]();
+  },
+  *entries(): IterableIterator<[string, string]> {
+    for (const role of getDeclaredRolesList()) {
+      yield [role, role];
+    }
   },
   [Symbol.iterator](): IterableIterator<string> {
     return getDeclaredRolesList()[Symbol.iterator]();

--- a/src/v2/options.ts
+++ b/src/v2/options.ts
@@ -309,17 +309,22 @@ export interface GlobalOptions {
   preserveExternalChanges?: boolean;
 }
 
-let globalOptions: GlobalOptions | undefined;
+const GLOBAL_OPTIONS_SYMBOL = Symbol.for("firebase-functions:v2:globalOptions");
+const globalOptionSymbols = globalThis as unknown as Record<symbol, { value?: GlobalOptions }>;
+
+if (!globalOptionSymbols[GLOBAL_OPTIONS_SYMBOL]) {
+  globalOptionSymbols[GLOBAL_OPTIONS_SYMBOL] = {};
+}
 
 /**
  * Sets default options for all functions written using the 2nd gen SDK.
  * @param options Options to set as default
  */
 export function setGlobalOptions(options: GlobalOptions) {
-  if (globalOptions) {
+  if (globalOptionSymbols[GLOBAL_OPTIONS_SYMBOL].value) {
     logger.warn("Calling setGlobalOptions twice leads to undefined behavior");
   }
-  globalOptions = options;
+  globalOptionSymbols[GLOBAL_OPTIONS_SYMBOL].value = options;
 }
 
 /**
@@ -328,7 +333,15 @@ export function setGlobalOptions(options: GlobalOptions) {
  * @internal
  */
 export function getGlobalOptions(): GlobalOptions {
-  return globalOptions || {};
+  return globalOptionSymbols[GLOBAL_OPTIONS_SYMBOL].value || {};
+}
+
+/**
+ * Reset global options for testing.
+ * @internal
+ */
+export function clearGlobalOptions(): void {
+  delete globalOptionSymbols[GLOBAL_OPTIONS_SYMBOL].value;
 }
 
 /**


### PR DESCRIPTION
### Description
Backs all manifest-level declarations (params, requiredRoles, lifecycleHooks, requiredAPIs, extensions, and any arbitrary future manifest fields) by a shared globalManifest object on globalThis (Symbol.for("firebase-functions:manifest")).

This ensures that:
1. Duplicate or nested node_modules installations of firebase-functions (e.g. within function kits or dependencies) write directly to the shared global manifest.
2. loadStack() in src/runtime/loader.ts is completely agnostic as to what features and options exist in globalManifest, simply spreading ...globalManifest alongside endpoints and specVersion.
3. setGlobalOptions and getGlobalOptions share state across module boundaries using Symbol.for("firebase-functions:v2:globalOptions").

### Scenarios Tested
- Ran unit tests across full test suite: npm test (all 976 tests passing).
- Added test in spec/runtime/loader.spec.ts verifying arbitrary future properties on globalManifest are preserved in ManifestStack and properly cleared.
- Ran linter: npm run lint:ts -- --quiet (0 errors).
- Built project: npm run build.

### Sample Commands
npm test

relnote: Unify global manifest on globalThis for forward-compatible manifest extraction across duplicate module installations