### PR TITLE
fix(scripts): pass space-separated flags in cloudbuild.yaml

### DIFF
--- a/scripts/publish/cloudbuild.yaml
+++ b/scripts/publish/cloudbuild.yaml
@@ -52,8 +52,8 @@ steps:
           $([ "${_DRY_RUN}" = "false" ] && echo "--no-dry-run") \
           $([ "${_FORCE}" = "true" ] && echo "--force") \
           $([ -n "${_BRANCH}" ] && echo "--branch ${_BRANCH}") \
-          --org=${_REPOSITORY_ORG} \
-          --repository=${_REPOSITORY_NAME}
+          --org "${_REPOSITORY_ORG}" \
+          --repository "${_REPOSITORY_NAME}"
     secretEnv: ["GITHUB_TOKEN", "NPMRC_CONTENT"]
 
 options:


### PR DESCRIPTION
### Description
Fixes argument parsing failure in Cloud Build publishing pipeline where `--org` and `--repository` were passed with `=` syntax instead of space-separated flags expected by `scripts/publish.sh`.

### Scenarios tested
- `./scripts/publish.sh patch --prerelease`

### Release notes
relnote: none