### PR TITLE
fix(params): restore backwards compatibility for declared params with pre-#1955 SDK versions

### DIFF
--- a/spec/runtime/loader.spec.ts
+++ b/spec/runtime/loader.spec.ts
@@ -10,6 +10,7 @@ import {
   ManifestStack,
   clearGlobalManifest,
 } from "../../src/runtime/manifest";
+import * as params from "../../src/params";
 import { clearParams } from "../../src/params";
 import { afterFirstDeploy, afterRedeploy, clearDeclaredLifecycleHooks } from "../../src/lifecycle";
 import { MINIMAL_V1_ENDPOINT, MINIMAL_V2_ENDPOINT } from "../fixtures";
@@ -347,6 +348,17 @@ describe("loadStack", () => {
     clearGlobalManifest();
     clearParams();
     clearDeclaredLifecycleHooks();
+    // Clear any synthetic legacy version symbols (e.g. :v6, :v7) mock-injected onto globalThis
+    // by compatibility tests so they do not pollute subsequent tests in the shared Node process.
+    for (const sym of Object.getOwnPropertySymbols(globalThis)) {
+      const desc = sym.description || sym.toString();
+      if (desc.includes("firebase-functions:params:declaredParams:v")) {
+        const arr = (globalThis as unknown as Record<symbol, unknown>)[sym];
+        if (Array.isArray(arr)) {
+          arr.length = 0;
+        }
+      }
+    }
     // Purge the require cache for fixture modules so that when a file is loaded
     // a second time via absolute path, it re-executes and successfully runs its global side-effects.
     for (const key of Object.keys(require.cache)) {
@@ -639,6 +651,80 @@ describe("loadStack", () => {
       expect(manifest.futureFeatureConfig).to.be.undefined;
       expect(manifest.customStackMetadata).to.be.undefined;
       expect(manifest.requiredRoles).to.be.undefined;
+    });
+  });
+
+  describe("loadStack with backwards-compatible legacy params", () => {
+    it("ingests params declared on legacy versioned symbols into ManifestStack", async () => {
+      const legacySymbol = Symbol.for("firebase-functions:params:declaredParams:v6");
+      const globalSymbols = globalThis as unknown as Record<symbol, any[]>;
+      if (!globalSymbols[legacySymbol]) {
+        globalSymbols[legacySymbol] = [];
+      }
+
+      globalSymbols[legacySymbol].push(new StringParam("LEGACY_API_KEY", { default: "secret123" }));
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+      expect(stack.params).to.deep.include({
+        name: "LEGACY_API_KEY",
+        type: "string",
+        default: "secret123",
+      });
+    });
+
+    it("mirrors params registered by new code to legacy versioned symbol", async () => {
+      const legacySymbol = Symbol.for("firebase-functions:params:declaredParams:v0");
+      const globalSymbols = globalThis as unknown as Record<symbol, any[]>;
+
+      params.defineInt("NEW_PARAM_MIRRORED", { default: 42 });
+
+      expect(globalSymbols[legacySymbol]).to.be.an("array");
+      expect(globalSymbols[legacySymbol].some((p) => p.name === "NEW_PARAM_MIRRORED")).to.be.true;
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+      expect(stack.params).to.deep.include({
+        name: "NEW_PARAM_MIRRORED",
+        type: "int",
+        default: 42,
+      });
+
+      clearParams();
+      clearGlobalManifest();
+      expect(globalSymbols[legacySymbol]).to.have.lengthOf(0);
+    });
+
+    it("never creates duplicate params in manifest when present on both global manifest and legacy symbols", async () => {
+      // 1. Declare param via new API (populates globalManifest.params and mirrors to GLOBAL_SYMBOL)
+      params.defineString("SHARED_PARAM_NAME", { default: "from_new_sdk" });
+
+      // 2. Also simulate an older nested module registering the same param name on legacy :v7 symbol
+      const legacyV7Symbol = Symbol.for("firebase-functions:params:declaredParams:v7");
+      const globalSymbols = globalThis as unknown as Record<symbol, any[]>;
+      if (!globalSymbols[legacyV7Symbol]) {
+        globalSymbols[legacyV7Symbol] = [];
+      }
+      globalSymbols[legacyV7Symbol].push(
+        new StringParam("SHARED_PARAM_NAME", { default: "from_old_sdk" })
+      );
+      // And a unique legacy param
+      globalSymbols[legacyV7Symbol].push(
+        new StringParam("UNIQUE_OLD_PARAM", { default: "old_val" })
+      );
+
+      const stack = await loader.loadStack("./spec/fixtures/sources/commonjs");
+
+      // Verify that SHARED_PARAM_NAME appears exactly once
+      const matches = (stack.params || []).filter((p) => p.name === "SHARED_PARAM_NAME");
+      expect(matches).to.have.lengthOf(1);
+      // Should preserve the version registered first (from new SDK in globalManifest)
+      expect(matches[0].default).to.equal("from_new_sdk");
+
+      // Verify UNIQUE_OLD_PARAM was also ingested
+      const oldMatches = (stack.params || []).filter((p) => p.name === "UNIQUE_OLD_PARAM");
+      expect(oldMatches).to.have.lengthOf(1);
+
+      // Total params should be exactly 2
+      expect(stack.params).to.have.lengthOf(2);
     });
   });
 });

--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -66,9 +66,29 @@ import type { WireParamSpec } from "./types";
 type SecretOrExpr = Param<any> | SecretParam | JsonSecretParam<any>;
 
 const GLOBAL_PARAMS_SYMBOL = Symbol.for("firebase-functions:params:declaredParams");
+
+/**
+ * Use a global singleton to manage the list of declared parameters.
+ *
+ * This ensures that parameters are shared between CJS and ESM builds,
+ * avoiding the "dual-package hazard" where the src/bin/firebase-functions.ts (CJS) sees
+ * an empty list while the user's code (ESM) populates a different list.
+ */
+const majorVersion =
+  // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
+  typeof __FIREBASE_FUNCTIONS_MAJOR_VERSION__ !== "undefined"
+    ? // @ts-expect-error __FIREBASE_FUNCTIONS_MAJOR_VERSION__ is injected at build time
+      __FIREBASE_FUNCTIONS_MAJOR_VERSION__
+    : "0";
+
+const GLOBAL_SYMBOL = Symbol.for(`firebase-functions:params:declaredParams:v${majorVersion}`);
+
 const globalSymbols = globalThis as unknown as Record<symbol, SecretOrExpr[]>;
 if (!globalSymbols[GLOBAL_PARAMS_SYMBOL]) {
   globalSymbols[GLOBAL_PARAMS_SYMBOL] = [];
+}
+if (!globalSymbols[GLOBAL_SYMBOL]) {
+  globalSymbols[GLOBAL_SYMBOL] = [];
 }
 
 /**
@@ -89,6 +109,14 @@ function registerParam(param: SecretOrExpr) {
   }
   declaredParams.push(param);
 
+  const legacyList = globalSymbols[GLOBAL_SYMBOL];
+  for (let i = 0; i < legacyList.length; i++) {
+    if (legacyList[i].name === param.name) {
+      legacyList.splice(i, 1);
+    }
+  }
+  legacyList.push(param);
+
   if (!Array.isArray(globalManifest.params)) {
     globalManifest.params = [];
   }
@@ -107,6 +135,9 @@ function registerParam(param: SecretOrExpr) {
  */
 export function clearParams() {
   declaredParams.length = 0;
+  if (globalSymbols[GLOBAL_SYMBOL]) {
+    globalSymbols[GLOBAL_SYMBOL].length = 0;
+  }
   delete globalManifest.params;
 }
 

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -216,21 +216,22 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
 
   // Ingest parameters declared on legacy versioned symbols (e.g. by older SDK modules in nested packages)
   // that were not already declared via the shared global manifest, preventing duplicates.
-  for (const sym of Object.getOwnPropertySymbols(globalThis)) {
-    const desc = sym.description || sym.toString();
-    if (desc.includes("firebase-functions:params:declaredParams:v")) {
-      const legacyParams = (globalThis as unknown as Record<symbol, unknown>)[sym];
-      if (Array.isArray(legacyParams) && legacyParams.length > 0) {
-        for (const p of legacyParams) {
-          if (typeof p?.toSpec === "function") {
-            const spec = p.toSpec();
-            if (!Array.isArray(globalManifest.params)) {
-              globalManifest.params = [];
-            }
-            const manifestParams = globalManifest.params as WireParamSpec<any>[];
-            if (!manifestParams.some((m) => m.name === spec.name)) {
-              manifestParams.push(spec);
-            }
+  const legacySymbols = Object.getOwnPropertySymbols(globalThis).filter((sym) =>
+    (sym.description || sym.toString()).includes("firebase-functions:params:declaredParams:v")
+  );
+
+  for (const sym of legacySymbols) {
+    const legacyParams = (globalThis as unknown as Record<symbol, unknown>)[sym];
+    if (Array.isArray(legacyParams)) {
+      for (const p of legacyParams) {
+        if (typeof p?.toSpec === "function") {
+          const spec = p.toSpec();
+          if (!Array.isArray(globalManifest.params)) {
+            globalManifest.params = [];
+          }
+          const manifestParams = globalManifest.params as WireParamSpec<any>[];
+          if (!manifestParams.some((m) => m.name === spec.name)) {
+            manifestParams.push(spec);
           }
         }
       }

--- a/src/runtime/loader.ts
+++ b/src/runtime/loader.ts
@@ -30,6 +30,7 @@ import {
   ManifestStack,
 } from "./manifest";
 import { requiresAPI, GoogleCloudApi } from "../common/api";
+import type { WireParamSpec } from "../params/types";
 
 /**
  * Dynamically load import function to prevent TypeScript from
@@ -211,6 +212,29 @@ export async function loadStack(functionsDir: string): Promise<ManifestStack> {
 
   if (!globalManifest.requiredAPIs) {
     globalManifest.requiredAPIs = [];
+  }
+
+  // Ingest parameters declared on legacy versioned symbols (e.g. by older SDK modules in nested packages)
+  // that were not already declared via the shared global manifest, preventing duplicates.
+  for (const sym of Object.getOwnPropertySymbols(globalThis)) {
+    const desc = sym.description || sym.toString();
+    if (desc.includes("firebase-functions:params:declaredParams:v")) {
+      const legacyParams = (globalThis as unknown as Record<symbol, unknown>)[sym];
+      if (Array.isArray(legacyParams) && legacyParams.length > 0) {
+        for (const p of legacyParams) {
+          if (typeof p?.toSpec === "function") {
+            const spec = p.toSpec();
+            if (!Array.isArray(globalManifest.params)) {
+              globalManifest.params = [];
+            }
+            const manifestParams = globalManifest.params as WireParamSpec<any>[];
+            if (!manifestParams.some((m) => m.name === spec.name)) {
+              manifestParams.push(spec);
+            }
+          }
+        }
+      }
+    }
   }
 
   const stack: ManifestStack = {


### PR DESCRIPTION
### Description
PR #1955 unified manifest extraction by storing all declared parameters on a shared `globalManifest` object (`Symbol.for("firebase-functions:manifest")`). While this provides a forward-compatible manifest for future releases, it broke compatibility when mixing newer SDK versions with older ones (v7.3.2 and earlier) that still rely on legacy versioned symbol arrays (`Symbol.for("firebase-functions:params:declaredParams:v${majorVersion}")`).

This change restores two-way backwards compatibility between new and older versions:

1. **New Nested Modules in Older Apps (e.g., nested v7.4+ dependency in a v7.3 root app)**:
   When `registerParam()` runs in the new SDK, it continues writing to `globalManifest.params` (per PR #1955) while also mirroring the parameters to the legacy versioned symbol array so older root loaders can discover them.

2. **Older Nested Modules in Newer Apps (e.g., nested v7.3 dependency in a v7.4+ root app)**:
   When `loader.ts` builds the deployment manifest, it reads from `globalManifest.params` and also inspects legacy versioned symbols to pull in any parameters declared by older nested packages, automatically deduplicating any shared entries.

### Scenarios Tested
- **Unit Tests**: Full test suite passing (`npm test`, 996 / 996 tests passing), including deduplication tests when parameters exist on both `globalManifest` and legacy symbols.
- **Production Deployments on GCP (`ajp-testing`)**:
  - Tested **v7.4+ Root with v7.3.2 Nested Dependency**: Successfully extracted manifest, deployed functions, and resolved runtime parameter values via Cloud Run.
  - Tested **v7.3.2 Root with v7.4+ Nested Dependency**: Successfully extracted manifest, deployed functions, and resolved runtime parameter values via Cloud Run.

### Release notes
relnote: Restore backwards compatibility for declared parameters when mixing SDK versions in nested dependencies
