### PR TITLE
docs(ai): explicitly declare tools and toolConfig on Vertex GenerateC…

### DIFF
--- a/src/v2/providers/ai/types/gemini/v1beta/index.ts
+++ b/src/v2/providers/ai/types/gemini/v1beta/index.ts
@@ -384,10 +384,14 @@ export declare interface GenerateContentCandidate {
 export declare interface GenerateContentRequest extends BaseParams {
   /** Array of conversation turns (Content) that make up the prompt. */
   contents: Content[];
-  /** Optional tools that the model may use to generate content. */
+  /** Optional tools (such as function declarations) the model can interact with to assist in generating a response. */
   tools?: Tool[];
   /** Optional tool configuration. */
   toolConfig?: ToolConfig;
+  /** Optional safety settings. */
+  safetySettings?: SafetySetting[];
+  /** Optional generation configuration. */
+  generationConfig?: GenerationConfig;
   /** Optional system instructions for the model. */
   systemInstruction?: string | Part | Content;
   /**

--- a/src/v2/providers/ai/types/vertex/v1beta1/index.ts
+++ b/src/v2/providers/ai/types/vertex/v1beta1/index.ts
@@ -105,6 +105,14 @@ export interface Schema {
 export declare interface GenerateContentRequest extends BaseModelParams {
   /** Array of `Content`. */
   contents: Content[];
+  /** Optional tools (such as function declarations) the model can interact with to assist in generating a response. */
+  tools?: Tool[];
+  /** Optional tool configuration. */
+  toolConfig?: ToolConfig;
+  /** Optional safety settings. */
+  safetySettings?: SafetySetting[];
+  /** Optional generation configuration. */
+  generationConfig?: GenerationConfig;
   /**
    * Optional. The user provided system instructions for the model.
    * Note: only text should be used in parts of `Content`.
@@ -124,7 +132,7 @@ export declare interface BaseModelParams {
   safetySettings?: SafetySetting[];
   /** Optional.  {@link GenerationConfig}. */
   generationConfig?: GenerationConfig;
-  /** Optional. Array of {@link Tool}. */
+  /** Optional tools (such as function declarations) the model can interact with to assist in generating a response. */
   tools?: Tool[];
   /** Optional. This config is shared for all tools provided in the request. */
   toolConfig?: ToolConfig;


### PR DESCRIPTION
### Description
Explicitly declares `tools` and `toolConfig` properties directly on `VertexV1Beta1GenerateContentRequest` (in `src/v2/providers/ai/types/vertex/v1beta1/index.ts`), matching `GeminiV1BetaGenerateContentRequest`.
#### Background:
`api-extractor` and `api-documenter` only generate property tables for properties declared directly on the exported interface AST; they do not inline properties inherited from unexported base interfaces like `BaseModelParams`. Declaring `tools` and `toolConfig` directly on the interface ensures they are documented on the DevSite 2nd Gen API reference page for `VertexV1Beta1GenerateContentRequest`.
### Scenarios Tested
- `npm run format` & `npm run lint` (0 errors)
- `npm test` (all 988 unit tests passing)
- `npm run docgen:v2`: Verified `tools` and `toolConfig` property rows and detail sections are generated in `docgen/v2/markdown/firebase-functions.ai.vertexv1beta1generatecontentrequest.md`.
### Release Notes
relnote: none