### PR TITLE
Auth v2 public release

### DIFF
--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -377,49 +377,49 @@ export function getOpts(blockingOptions: BlockingOptions): InternalOptions {
 }
 
 /**
- * The user data payload for an Auth Event. this is the standard "UserRecord"
- * from the firebase Admin SDK.
- * @internal
+ * The user data payload for an Auth Event. This is the standard "UserRecord"
+ * from the Firebase Admin SDK.
+ * @public
  */
 export type User = AdminUserRecord;
 
 /**
- * The event object passed to the handler funcation for Firebase Authentication
+ * The event object passed to the handler function for Firebase Authentication
  * events.
- * @internal
+ * @public
  */
 export interface AuthEvent<T> extends CloudEvent<T> {
   /** The project identifier */
   project?: string;
 
-  /** The ID of the Identity Platform Tenant Associated with the event. If Applicable */
+  /** The ID of the Identity Platform Tenant associated with the event, if applicable. */
   tenantId?: string;
 }
 
 /**
- * Options for configuring a Firebase Authentication Trigger
- * @internal
+ * Options for configuring a Firebase Authentication Trigger.
+ * @public
  */
 export interface AuthOptions extends options.EventHandlerOptions {
   /**
-   * The Id of the Identity Platform tenant to scope the function to.
-   * If not set, the function triggers on users across all tenants
+   * The ID of the Identity Platform tenant to scope the function to.
+   * If not set, the function triggers on users across all tenants.
    * Set to `IS_NOT_TENANT` to only trigger on users in the default
-   * project(no tenant).
+   * project (no tenant).
    */
   tenantId?: string | Expression<string> | typeof RESET_VALUE;
 }
 
 /**
- * constant to represent the absence of tenant ID.
- * @internal
+ * Constant to represent the absence of tenant ID.
+ * @public
  */
 export const IS_NOT_TENANT = RESET_VALUE;
 
 /**
  * Event handler type for Authentication triggers that supports both standard `AuthEvent`
  * and V1 compatibility destructuring (`{ user, context }`).
- * @internal
+ * @public
  */
 export type AuthEventHandler = (
   event: AuthEvent<User> & V1Compat<"user", User>
@@ -605,9 +605,6 @@ function makeAuthTrigger(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
  *
- * @beta
- * @internal
- *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
  */
@@ -619,9 +616,6 @@ export function onUserCreated(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
  *
- * @beta
- * @internal
- *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
  */
@@ -630,9 +624,6 @@ export function onUserCreated(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user creation events in Firebase Authentication.
- *
- * @beta
- * @internal
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -644,9 +635,6 @@ export function onUserCreated(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user creation events in Firebase Authentication.
- *
- * @beta
- * @internal
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -668,9 +656,6 @@ export function onUserCreated(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
  *
- * @beta
- * @internal
- *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
  */
@@ -682,9 +667,6 @@ export function onUserDeleted(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
  *
- * @beta
- * @internal
- *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
  */
@@ -693,9 +675,6 @@ export function onUserDeleted(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user deletion events in Firebase Authentication.
- *
- * @beta
- * @internal
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.
@@ -707,9 +686,6 @@ export function onUserDeleted(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user deletion events in Firebase Authentication.
- *
- * @beta
- * @internal
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -62,7 +62,7 @@ interface InternalOptions {
 }
 
 /**
- * All function options plus idToken, accessToken, and refreshToken.
+ * All function options plus `idToken`, `accessToken`, and `refreshToken`.
  */
 export interface BlockingOptions {
   /** Pass the ID Token credential to the function. */
@@ -75,7 +75,7 @@ export interface BlockingOptions {
   refreshToken?: boolean;
 
   /**
-   * If true, do not deploy or emulate this function.
+   * If `true`, do not deploy or emulate this function.
    */
   omit?: boolean | Expression<boolean>;
 
@@ -121,7 +121,7 @@ export interface BlockingOptions {
    *
    * @remarks
    * Can only be applied to functions running on Cloud Functions v2.
-   * A value of null restores the default concurrency (80 when CPU >= 1, 1 otherwise).
+   * A value of `null` restores the default concurrency (80 when `cpu` >= 1, 1 otherwise).
    * Concurrency cannot be set to any value other than 1 if `cpu` is less than 1.
    * The maximum value for concurrency is 1,000.
    */
@@ -135,7 +135,7 @@ export interface BlockingOptions {
    * This is different from the defaults when using the gcloud utility and is different from
    * the fixed amount assigned in Google Cloud Functions generation 1.
    * To revert to the CPU amounts used in gcloud or in Cloud Functions generation 1, set this
-   * to the value "gcf_gen1"
+   * to the value `"gcf_gen1"`.
    */
   cpu?: number | "gcf_gen1";
 
@@ -254,7 +254,7 @@ export function beforeEmailSent(
 
 /**
  * Handles an event that is triggered before an email is sent to a user.
- * @param optsOrHandler- Either an object containing function options, or an event handler that is run before an email is sent to a user.
+ * @param optsOrHandler - Either an object containing function options, or an event handler that is run before an email is sent to a user.
  * @param handler - Event handler that is run before an email is sent to a user.
  */
 export function beforeEmailSent(
@@ -377,7 +377,7 @@ export function getOpts(blockingOptions: BlockingOptions): InternalOptions {
 }
 
 /**
- * The user data payload for an Auth Event. This is the standard "UserRecord"
+ * The user data payload for a Firebase Authentication event. This is the standard `UserRecord`
  * from the Firebase Admin SDK.
  * @public
  */
@@ -389,15 +389,15 @@ export type User = AdminUserRecord;
  * @public
  */
 export interface AuthEvent<T> extends CloudEvent<T> {
-  /** The project identifier */
+  /** The project identifier. */
   project?: string;
 
-  /** The ID of the Identity Platform Tenant associated with the event, if applicable. */
+  /** The ID of the Identity Platform tenant associated with the event, if applicable. */
   tenantId?: string;
 }
 
 /**
- * Options for configuring a Firebase Authentication Trigger.
+ * Options for configuring a Firebase Authentication trigger.
  * @public
  */
 export interface AuthOptions extends options.EventHandlerOptions {
@@ -411,14 +411,14 @@ export interface AuthOptions extends options.EventHandlerOptions {
 }
 
 /**
- * Constant to represent the absence of tenant ID.
+ * Constant to represent the absence of a tenant ID.
  * @public
  */
 export const IS_NOT_TENANT = RESET_VALUE;
 
 /**
- * Event handler type for Authentication triggers that supports both standard `AuthEvent`
- * and V1 compatibility destructuring (`{ user, context }`).
+ * Event handler type for Firebase Authentication triggers that supports both standard `AuthEvent`
+ * and 1st gen compatibility destructuring (`{ user, context }`).
  * @public
  */
 export type AuthEventHandler = (
@@ -603,7 +603,7 @@ function makeAuthTrigger(
 /**
  * Handles user creation events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
@@ -614,7 +614,7 @@ export function onUserCreated(
 /**
  * Handles user creation events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
@@ -624,6 +624,8 @@ export function onUserCreated(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user creation events in Firebase Authentication.
+ *
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -635,6 +637,8 @@ export function onUserCreated(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user creation events in Firebase Authentication.
+ *
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -654,7 +658,7 @@ export function onUserCreated(
 /**
  * Handles user deletion events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
@@ -665,7 +669,7 @@ export function onUserDeleted(
 /**
  * Handles user deletion events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in options.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
@@ -675,6 +679,8 @@ export function onUserDeleted(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user deletion events in Firebase Authentication.
+ *
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.
@@ -686,6 +692,8 @@ export function onUserDeleted(
 ): CloudFunction<AuthEvent<User>>;
 /**
  * Handles user deletion events in Firebase Authentication.
+ *
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -407,7 +407,7 @@ export interface AuthOptions extends options.EventHandlerOptions {
    * Set to `IS_NOT_TENANT` to only trigger on users in the default
    * project (no tenant).
    */
-  tenantId?: string | Expression<string> | typeof RESET_VALUE;
+  tenantId?: string | Expression<string> | typeof IS_NOT_TENANT;
 }
 
 /**
@@ -603,7 +603,7 @@ function makeAuthTrigger(
 /**
  * Handles user creation events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
@@ -614,7 +614,7 @@ export function onUserCreated(
 /**
  * Handles user creation events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
@@ -625,7 +625,7 @@ export function onUserCreated(
 /**
  * Handles user creation events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -638,7 +638,7 @@ export function onUserCreated(
 /**
  * Handles user creation events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -658,7 +658,7 @@ export function onUserCreated(
 /**
  * Handles user deletion events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
@@ -669,7 +669,7 @@ export function onUserDeleted(
 /**
  * Handles user deletion events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
@@ -680,7 +680,7 @@ export function onUserDeleted(
 /**
  * Handles user deletion events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.
@@ -693,7 +693,7 @@ export function onUserDeleted(
 /**
  * Handles user deletion events in Firebase Authentication.
  *
- * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `options`.
+ * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.

--- a/src/v2/providers/identity.ts
+++ b/src/v2/providers/identity.ts
@@ -379,14 +379,14 @@ export function getOpts(blockingOptions: BlockingOptions): InternalOptions {
 /**
  * The user data payload for a Firebase Authentication event. This is the standard `UserRecord`
  * from the Firebase Admin SDK.
- * @public
+ * @beta
  */
 export type User = AdminUserRecord;
 
 /**
  * The event object passed to the handler function for Firebase Authentication
  * events.
- * @public
+ * @beta
  */
 export interface AuthEvent<T> extends CloudEvent<T> {
   /** The project identifier. */
@@ -398,7 +398,7 @@ export interface AuthEvent<T> extends CloudEvent<T> {
 
 /**
  * Options for configuring a Firebase Authentication trigger.
- * @public
+ * @beta
  */
 export interface AuthOptions extends options.EventHandlerOptions {
   /**
@@ -412,14 +412,14 @@ export interface AuthOptions extends options.EventHandlerOptions {
 
 /**
  * Constant to represent the absence of a tenant ID.
- * @public
+ * @beta
  */
 export const IS_NOT_TENANT = RESET_VALUE;
 
 /**
  * Event handler type for Firebase Authentication triggers that supports both standard `AuthEvent`
  * and 1st gen compatibility destructuring (`{ user, context }`).
- * @public
+ * @beta
  */
 export type AuthEventHandler = (
   event: AuthEvent<User> & V1Compat<"user", User>
@@ -605,6 +605,8 @@ function makeAuthTrigger(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
+ * @beta
+ *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
  */
@@ -616,6 +618,8 @@ export function onUserCreated(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
+ * @beta
+ *
  * @param handler - Event handler which is run every time a new user is created.
  * @returns A Cloud Function that you can export.
  */
@@ -626,6 +630,8 @@ export function onUserCreated(
  * Handles user creation events in Firebase Authentication.
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
+ *
+ * @beta
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -639,6 +645,8 @@ export function onUserCreated(
  * Handles user creation events in Firebase Authentication.
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
+ *
+ * @beta
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler which is run every time a new user is created.
@@ -660,6 +668,8 @@ export function onUserCreated(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
+ * @beta
+ *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
  */
@@ -671,6 +681,8 @@ export function onUserDeleted(
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
  *
+ * @beta
+ *
  * @param handler - Event handler that is run every time a user is deleted.
  * @returns A Cloud Function that you can export.
  */
@@ -681,6 +693,8 @@ export function onUserDeleted(
  * Handles user deletion events in Firebase Authentication.
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
+ *
+ * @beta
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.
@@ -694,6 +708,8 @@ export function onUserDeleted(
  * Handles user deletion events in Firebase Authentication.
  *
  * To filter for users not associated with a tenant, use the `IS_NOT_TENANT` constant in `opts`.
+ *
+ * @beta
  *
  * @param opts - Object containing function options.
  * @param handler - Event handler that is run every time a user is deleted.


### PR DESCRIPTION
### Description
With Firebase Authentication 2nd gen event triggers now generally available from the backend for all projects (no allowlisting required), this PR promotes the 2nd gen Auth event triggers and related types to the public API:
- **Public Release**: Removes `@beta` and `@internal` tags from `onUserCreated` and `onUserDeleted`.
- **Public API Documentation**: Updates supporting types and constants (`User`, `AuthEvent`, `AuthOptions`, `IS_NOT_TENANT`, `AuthEventHandler`) to `@public` so they are properly documented and indexed in the public reference docs.
- **JSDoc Style Consistency**: Wraps literals, parameter names, and type identifiers (`UserRecord`, `options`, `idToken`, `null`, `true`, `IS_NOT_TENANT`, etc.) in backticks across all `src/v2/providers/identity.ts` docstrings in accordance with repository standards.
### Code sample
```typescript
import { onUserCreated, onUserDeleted, IS_NOT_TENANT } from "firebase-functions/v2/identity";
// Trigger on users in the default project (no tenant)
export const handleNewUser = onUserCreated(
  { tenantId: IS_NOT_TENANT },
  (event) => {
    // Standard 2nd gen CloudEvent data
    console.log(`Created user: ${event.data.uid}, email: ${event.data.email}`);
  }
);
// Supports 1st gen compat destructuring:
export const handleDeletedUser = onUserDeleted((event) => {
  const { user, context } = event;
  console.log(`Deleted user ${user.uid} from ${context.resource.name}`);
});
```


### Scenarios Tested:
**Unit tests:** Ran full test suite via npm test (all 993 tests passing).
**Linter:** Ran npm run lint:ts -- --quiet (0 errors).
**Doc generation:** Ran npm run docgen:v2:extract and npm run docgen:v2:gen to verify reference tables and markdown generate cleanly.
**Live deployment verification:** Deployed onUserCreated and onUserDeleted to an un-allowlisted project using Eventarc and Cloud Run. Verified that user creation and deletion events triggered the functions and accurately populated both standard CloudEvent fields and 1st gen destructuring ({ user, context }).

### Release notes
relnote: Promoted 2nd gen Firebase Authentication triggers (onUserCreated and onUserDeleted) to general availability.
