### PR TITLE
fix(params): remove internal WireParamSpec from public exports

### DIFF
--- a/src/params/index.ts
+++ b/src/params/index.ts
@@ -54,7 +54,6 @@ export type {
   BooleanParam,
   IntParam,
   ListParam,
-  WireParamSpec,
 } from "./types";
 
 export { Expression };

--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -428,7 +428,7 @@ export type ParamSpec<T extends string | number | boolean | string[]> = {
  * Representation of parameters for the stack over the wire.
  * @remarks
  * N.B: a WireParamSpec is just a ParamSpec with default expressions converted into a CEL literal
- * @alpha
+ * @internal
  */
 export type WireParamSpec<T extends string | number | boolean | string[]> = {
   name: string;


### PR DESCRIPTION
### Description
In PR #1955, `WireParamSpec` was imported into `src/params/index.ts` to type `globalManifest.params` during manifest registration, but was accidentally included in the public `export type { ... }` re-export block as well. Because `src/v2/index.ts` re-exports `params`, this caused API Extractor to treat `WireParamSpec` as a public API export and generate unwanted reference docs on DevSite (`#paramswireparamspec`).

This PR:
1. Removes `WireParamSpec` from the public `export type { ... }` block in `src/params/index.ts` (keeping the internal `import type`).
2. Updates the JSDoc tag on `WireParamSpec` in `src/params/types.ts` from `@alpha` to `@internal`.

`WireParamSpec` is an internal wire protocol schema between the SDK and the CLI during manifest extraction, not developer API.

### Scenarios Tested
- Built project: `npm run build` (0 errors)
- Ran unit tests: `npm test` (all 996 tests passing)
- Ran linter: `npm run lint:quiet` (0 errors)
- Ran docgen: `npm run docgen:v2` (verified `WireParamSpec` is cleanly omitted from generated docs)

relnotes: none
