### PR TITLE
fix(params): retain @alpha tag on WireParamSpec to prevent stripped dts export

### DIFF
--- a/src/params/types.ts
+++ b/src/params/types.ts
@@ -428,7 +428,7 @@ export type ParamSpec<T extends string | number | boolean | string[]> = {
  * Representation of parameters for the stack over the wire.
  * @remarks
  * N.B: a WireParamSpec is just a ParamSpec with default expressions converted into a CEL literal
- * @internal
+ * @alpha
  */
 export type WireParamSpec<T extends string | number | boolean | string[]> = {
   name: string;


### PR DESCRIPTION

### Description
In PR #1960, `WireParamSpec` was tagged as `@internal` to indicate that it is an internal wire protocol schema rather than public user API. However, `tsconfig.release.json` has `stripInternal: true`, which completely removes declarations tagged `@internal` from the emitted `lib/params/types.d.ts`.

Because `src/runtime/manifest.ts` is not marked `@internal`, its emitted declaration file `lib/runtime/manifest.d.ts` still imports `WireParamSpec` directly from `../params/types`. Stripping `WireParamSpec` creates a broken dangling import in the published `.d.ts` bundle, causing downstream consumers (such as extension function kits or user projects without `skipLibCheck: true`) to fail compilation with:
```
node_modules/firebase-functions/lib/runtime/manifest.d.ts:2:22 - error TS2724: '"../params/types"' has no exported member named 'WireParamSpec'. Did you mean 'ParamSpec'?
```

This PR changes `WireParamSpec` in `src/params/types.ts` from `@internal` back to `@alpha`:
- `WireParamSpec` remains unexported from `src/params/index.ts`, so it is still cleanly omitted from public documentation (`docgen:v2`) and public module autocompletion.
- Marking it `@alpha` instead of `@internal` ensures `tsc` emits the type into `lib/params/types.d.ts`, resolving the broken import in `manifest.d.ts`.

### Scenarios Tested
- **Package Build:** Ran `npm run build` (0 errors; verified `export type WireParamSpec` is present in `lib/params/types.d.ts`).
- **Unit Tests:** Ran `npm test` (all 996 tests passing).
- **Linter:** Ran `npm run lint:quiet` (0 errors).
- **Docgen:** Ran `npm run docgen:v2` (verified `WireParamSpec` is absent from generated reference docs in `docgen/v2/markdown/`).
- **Downstream Verification:** Built and packed tarball locally, installed it into `@firebase-function-kits/storage-resize-images`, and verified `npm run build` (`tsc`) compiles cleanly with 0 errors (and confirmed it reproduces the TS2724 error when reverted).

### Release Notes
relnote: none
